### PR TITLE
Switch to netsnmp for fetching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,10 @@ for use by the Prometheus monitoring system.
 ## Installation
 
 ```Shell
+apt-get install libsnmp-python  # On older distros.
+apt-get install python-netsnmp  # On newer distros.
 pip install snmp_exporter
 ```
-
-You may need to also install the `python-dev` package on Debian/Ubuntu systems,
-as some dependencies require it.
 
 ## Usage
 

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup
 
 setup(
     name = "snmp_exporter",
-    version = "0.0.3",
+    version = "0.0.4",
     author = "Brian Brazil",
     author_email = "brian.brazil@robustperception.io",
-    description = ("Python client for the Prometheus monitoring system."),
+    description = ("SNMP exporter for the Prometheus monitoring system."),
     long_description = ("See https://github.com/prometheus/snmp_exporter/blob/master/README.md for documentation."),
     license = "Apache Software License 2.0",
     keywords = "prometheus exporter network monitoring snmp",
@@ -14,7 +14,8 @@ setup(
     scripts = ["scripts/snmp_exporter"],
     packages=['snmp_exporter'],
     test_suite="tests",
-    install_requires=["prometheus_client>=0.0.11", "pyyaml", "pysnmp>=4.2.5"],
+    # Also needs python-netsnmp per http://www.net-snmp.org/wiki/index.php/Python_Bindings
+    install_requires=["prometheus_client>=0.0.11", "pyyaml"],
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Information Technology",

--- a/snmp_exporter/http.py
+++ b/snmp_exporter/http.py
@@ -1,3 +1,4 @@
+import traceback
 import urlparse
 from BaseHTTPServer import BaseHTTPRequestHandler
 from BaseHTTPServer import HTTPServer
@@ -29,11 +30,16 @@ class SnmpExporterHandler(BaseHTTPRequestHandler):
         return
       with open(self._config_path) as f:
         config = yaml.safe_load(f)
-      output = collect_snmp(config, params['address'][0])
-      self.send_response(200)
-      self.send_header('Content-Type', CONTENT_TYPE_LATEST)
-      self.end_headers()
-      self.wfile.write(output)
+      try:
+        output = collect_snmp(config, params['address'][0])
+        self.send_response(200)
+        self.send_header('Content-Type', CONTENT_TYPE_LATEST)
+        self.end_headers()
+        self.wfile.write(output)
+      except:
+        self.send_response(500)
+        self.end_headers()
+        self.wfile.write(traceback.format_exc())
     elif url.path == '/':
       self.send_response(200)
       self.end_headers()


### PR DESCRIPTION
This is at least 4x as fast, though requires the user
to install the python bindings for netsnmp.

Improve how exceptions are exposed.

@SuperQ @RichiH 