### PR TITLE
Reduce MaxRepetitions to 25.

### DIFF
--- a/snmp_exporter/collector.py
+++ b/snmp_exporter/collector.py
@@ -17,7 +17,7 @@ def walk_oid(session, oid):
     while True:
       # getbulk starts from the last oid we saw.
       vl = netsnmp.VarList(netsnmp.Varbind('.' + last_oid))
-      if not session.getbulk(0, 100, vl):
+      if not session.getbulk(0, 25, vl):
         return
 
       for v in vl:


### PR DESCRIPTION
There's a bug on my GS1920-48 where a value greater than 55
will silently skip results, and with even higher values start
returning results out of order. Drop to a smaller value.

This issue is also apparent with snmpbulkget.