### PR TITLE
Pad right when 0s are stripped from an oid.

### DIFF
--- a/snmp_exporter/collector.py
+++ b/snmp_exporter/collector.py
@@ -33,6 +33,12 @@ def oid_to_tuple(oid):
   """Convert an OID to a tuple of numbers"""
   return tuple([int(x) for x in oid.split('.')])
 
+def pad_oid(oid, size):
+    """If oid is short, pad right with 0s."""
+    result = list(oid)
+    while len(result) < size:
+      result.append(0)
+    return result
 
 def parse_indexes(suboid, index_config, lookup_config, oids):
   """Return labels for an oid based on config and table entry."""
@@ -40,12 +46,12 @@ def parse_indexes(suboid, index_config, lookup_config, oids):
   label_oids = {}
   for index in index_config:
     if index['type'] == 'Integer32':
-      sub = suboid[0:1]
+      sub = pad_oid(suboid[0:1], 1)
       label_oids[index['labelname']] = sub
       labels[index['labelname']] = '.'.join((str(s) for s in sub))
       suboid = suboid[1:]
     elif index['type'] == 'PhysAddress48':
-      sub = suboid[0:6]
+      sub = pad_oid(suboid[0:6], 6)
       label_oids[index['labelname']] = sub
       labels[index['labelname']] = ':'.join((str(s) for s in sub))
       suboid = suboid[6:]

--- a/tests/collector.py
+++ b/tests/collector.py
@@ -1,21 +1,21 @@
 import unittest
 
 from snmp_exporter.collector import parse_indexes
-from pysnmp.proto.rfc1902 import Counter32, ObjectName, OctetString
 
 class TestCollector(unittest.TestCase):
 
-  def setUp(self):
-    self.oids = {ObjectName('1.2.3.4'): OctetString('eth0')}
 
   def test_parse_indexes(self):
-    self.assertEqual({}, parse_indexes((), [], [], self.oids))
+    oids = {(1, 2, 3, 4): 'eth0'}
+    self.assertEqual({}, parse_indexes((), [], [], oids))
     self.assertEqual({'l': '4'}, 
-        parse_indexes((4,), [{'labelname': 'l', 'type': 'Integer32'}], [], self.oids))
+        parse_indexes((4,), [{'labelname': 'l', 'type': 'Integer32'}], [], oids))
     self.assertEqual({'l': 'eth0'}, 
         parse_indexes((4,), [{'labelname': 'l', 'type': 'Integer32'}], 
-                      [{'labels': ['l'], 'labelname': 'l', 'oid': '1.2.3'}], self.oids))
+                      [{'labels': ['l'], 'labelname': 'l', 'oid': '1.2.3'}], oids))
     self.assertEqual({'a': '3', 'b': '4', 'l': 'eth0'}, 
         parse_indexes((3, 4,), [{'labelname': 'a', 'type': 'Integer32'}, {'labelname': 'b', 'type': 'Integer32'}], 
-                      [{'labels': ['a', 'b'], 'labelname': 'l', 'oid': '1.2'}], self.oids))
+                      [{'labels': ['a', 'b'], 'labelname': 'l', 'oid': '1.2'}], oids))
+    self.assertEqual({'l': '0'},
+        parse_indexes((), [{'labelname': 'l', 'type': 'Integer32'}], [], {}))
 


### PR DESCRIPTION
Fix tests to work with netsnmp.