### PR TITLE
Bit more robustness for legacy systems

### DIFF
--- a/snmp_exporter/collector.py
+++ b/snmp_exporter/collector.py
@@ -22,13 +22,21 @@ def walk_oid(session, oid):
         return
 
       for v in vl:
-        last_oid = v.tag[1:] + '.' + v.iid
-        if not (last_oid + '.').startswith(oid + '.'):
+        if v.iid == None or v.iid == '':
           return
+
+        next_oid = v.tag[1:] + '.' + v.iid
+        if not (next_oid + '.').startswith(oid + '.'):
+          return
+        if next_oid == last_oid:
+          return
+
+        last_oid = next_oid
         if v.iid == '0':
           yield v.tag[1:], v.val
         else:
-          yield last_oid, v.val
+          yield next_oid, v.val
+
 
 def oid_to_tuple(oid):
   """Convert an OID to a tuple of numbers"""


### PR DESCRIPTION
Some devices (e.g. Emerson PSU) do not seem to support getbulk. We have introduced a configuration option "bulkget", which allows to switch to simple getnext. 

This is also introducing more robust termination criteria for the walk. If the same oid reappears, the walk is terminated. This might also fix the hanging request as described in #8. 
Also if the iid is None or empty, which would lead to an invalid oid (terminated by .), the walk is terminated.

/cc @totallyunknown 