### PR TITLE
Feature to add labels (based on static oid), description and type to metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 dist/
 *.pyc
 *.egg-info
+.idea

--- a/README.md
+++ b/README.md
@@ -67,3 +67,19 @@ This is to allow for customisation of what's done during the scrape as many
 special cases are expected.  The varying levels of SNMP MIB-parsing support
 across different langauges also means that a single language may not be
 practical.
+
+## Metric Labels
+
+It's possible to add extra labels to the metrics. For example `sysName or
+`sysLocation` are pretty useful.
+
+```YAML
+  metrics:
+    - name: sysUpTime
+      oid: 1.3.6.1.2.1.1.3
+      labels:
+       - labelname: sysName
+         oid: 1.3.6.1.2.1.1.5
+       - labelname: sysLocation
+         oid: 1.3.6.1.2.1.1.6
+```

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ special cases are expected.  The varying levels of SNMP MIB-parsing support
 across different langauges also means that a single language may not be
 practical.
 
-## Metric Labels
+## Metric Label, Description and Type
 
 It's possible to add extra labels to the metrics. For example `sysName or
 `sysLocation` are pretty useful.
@@ -76,6 +76,8 @@ It's possible to add extra labels to the metrics. For example `sysName or
 ```YAML
   metrics:
     - name: sysUpTime
+      description: description: The time (in hundredths of a second) since the network management portion of the system was last re-initialized.
+      type: counter
       oid: 1.3.6.1.2.1.1.3
       labels:
        - labelname: sysName
@@ -83,3 +85,6 @@ It's possible to add extra labels to the metrics. For example `sysName or
        - labelname: sysLocation
          oid: 1.3.6.1.2.1.1.6
 ```
+
+With `description` you can set a useful help text. `type` is either counter or gauge. See
+<http://prometheus.io/docs/concepts/metric_types/>

--- a/snmp.yml
+++ b/snmp.yml
@@ -11,6 +11,8 @@ default:
   metrics:
     - name: sysUpTime
       oid: 1.3.6.1.2.1.1.3
+      description: The time (in hundredths of a second) since the network management portion of the system was last re-initialized.
+      type: counter
       labels:
        - labelname: sysName
          oid: 1.3.6.1.2.1.1.5

--- a/snmp.yml
+++ b/snmp.yml
@@ -2,12 +2,20 @@
 # Default module: interface stats and uptime.
 default:
   walk:
-    - 1.3.6.1.2.1.1.3
+    # system
+    - 1.3.6.1.2.1.1
+    # ifTable
     - 1.3.6.1.2.1.2
+    # ifXTable
     - 1.3.6.1.2.1.31.1.1
   metrics:
     - name: sysUpTime
       oid: 1.3.6.1.2.1.1.3
+      labels:
+       - labelname: sysName
+         oid: 1.3.6.1.2.1.1.5
+       - labelname: sysLocation
+         oid: 1.3.6.1.2.1.1.6
     - name: ifNumber
       oid: 1.3.6.1.2.1.2.1
     - name: ifMtu

--- a/snmp_exporter/collector.py
+++ b/snmp_exporter/collector.py
@@ -87,7 +87,12 @@ def collect_snmp(config, host, port=161):
   start = time.time()
   metrics = {}
   for metric in config['metrics']:
-    metrics[metric['name']] = Metric(metric['name'], 'SNMP OID {0}'.format(metric['oid']), 'untyped')
+    if 'type' in metric:
+      type = metric['type']
+    else:
+      type = "untyped"
+
+    metrics[metric['name']] = Metric(metric['name'], metric['description'] + ' (OID {0})'.format(metric['oid']), type)
 
   values = walk_oids(host, port, config['walk'], config.get('community', 'public'))
   oids = {}

--- a/snmp_exporter/collector.py
+++ b/snmp_exporter/collector.py
@@ -92,7 +92,12 @@ def collect_snmp(config, host, port=161):
     else:
       type = "untyped"
 
-    metrics[metric['name']] = Metric(metric['name'], metric['description'] + ' (OID {0})'.format(metric['oid']), type)
+    if 'description' in metric:
+      description = metric['description']
+    else:
+      description = "Not available."
+
+    metrics[metric['name']] = Metric(metric['name'], description + ' (OID {0})'.format(metric['oid']), type)
 
   values = walk_oids(host, port, config['walk'], config.get('community', 'public'))
   oids = {}

--- a/snmp_exporter/collector.py
+++ b/snmp_exporter/collector.py
@@ -71,6 +71,15 @@ def parse_indexes(suboid, index_config, lookup_config, oids):
 
   return labels
 
+def add_labels(label_config, oids):
+  """Return a static label"""
+  labels = {}
+  for label in label_config:
+    value = oids.get(oid_to_tuple(label['oid']))
+    if value is not None:
+      labels[label['labelname']] = str(value)
+
+  return labels
 
 def collect_snmp(config, host, port=161):
   """Scrape a host and return prometheus text format for it"""
@@ -113,7 +122,10 @@ def collect_snmp(config, host, port=161):
         prefix = oid_to_tuple(metric['oid'])
         value = float(value)
         indexes = oid[len(prefix):]
-        labels = parse_indexes(indexes, metric.get('indexes', {}), metric.get('lookups', {}), oids)
+        index_labels = parse_indexes(indexes, metric.get('indexes', {}), metric.get('lookups', {}), oids)
+        single_labels = add_labels(metric.get('labels', {}), oids)
+        labels = dict(single_labels)
+        labels.update(index_labels)
         metrics[metric['name']].add_sample(metric['name'], value=value, labels=labels)
         break
 


### PR DESCRIPTION
We need the ability to add metric tag based on a oid. For example we want to tag all metrics with the sysName and sysLocation. I've updated the sysUpTime  example in `snmp.yml`.