### PR TITLE
Add SNMPv1 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,42 @@ Visit http://localhost:9116/metrics?address=1.2.3.4 where 1.2.3.4 is the IP of t
 SNMP device to get metrics from. You can also specify a `module` parameter, to
 choose which module to use from the config file.
 
+
+## Auththentication
+
+The default configuration is to use SNMPv2 with the community `public`.  This can be changed in the yaml config.  NOTE: Version 2 implies SNMP version 2c.
+
+Example:
+```YAML
+default:
+  version: 2
+  auth:
+    community: SomeCommunityString
+  walk:
+    - ...
+  metrics:
+    - ...
+```
+
+For SNMPv3, the authentication requires different parameters.  The `auth_proto` defaults to `MD5` and the `priv_proto` defaults to `DES`.  The `security_level` defaults to `noAuthNoPriv`.
+
+Example:
+```YAML
+default:
+  version: 3
+  auth:
+    username: SomeUser
+    password: TotallySecret
+    auth_proto: SHA
+    priv_proto: AES
+    security_level: SomethingReadOnly
+    priv_password: SomeOtherSecret
+  walk:
+    - ...
+  metrics:
+    - ...
+```
+
 ## Prometheus Configuration
 
 The snmp exporter needs to be passed the address as a parameter, this can be

--- a/README.md
+++ b/README.md
@@ -29,7 +29,15 @@ choose which module to use from the config file.
 
 ## Auththentication
 
+###SNMPv2
+
 The default configuration is to use SNMPv2 with the community `public`.  This can be changed in the yaml config.  NOTE: Version 2 implies SNMP version 2c.
+
+####Authentication parameters
+
+Name | Description
+--------|------------
+community | Community string defined on the device
 
 Example:
 ```YAML
@@ -43,7 +51,47 @@ default:
     - ...
 ```
 
-For SNMPv3, the authentication requires different parameters.  The `auth_proto` defaults to `MD5` and the `priv_proto` defaults to `DES`.  The `security_level` defaults to `noAuthNoPriv`.
+###SNMPv1
+
+For SNMPv1, the authentication also requires a community string which will default to 'public'.
+
+####Authentication parameters
+
+Name | Description
+--------|-----------
+community | Community string defined on the device
+
+Example:
+````YAML
+default:
+  version: 1
+  auth:
+    community: SomeCommunityString
+  walk:
+    - ...
+  metrics:
+    - ...
+````
+
+##SNMPv3
+
+For SNMPv3, the authentication requires different parameters.  The `auth_protocol` defaults to `MD5` and the `priv_protocol` defaults to `DES`.  The `security_level` defaults to `noAuthNoPriv`.
+
+####Authentication parameters
+
+Name | Description | required
+--------|--------------|--------------
+username | A string representing the name of the user | yes
+password |  If messages sent on behalf of this user can be authenticated, the (private) authentication key for use with the authentication protocol. Defined as authKey in RFC3414 | if security_level = authNoPriv or authPriv
+auth_protocol | An indication of whether messages sent on behalf of this user can be authenticated, and if so, the type of authentication protocol which is used. 2 protocols are defined in RFC3414: MD5 (HMAC-MD5-96) and SHA (HMAC-SHA-96) | if security_level = authNoPriv or authPriv
+priv_protocol | An indication of whether messages sent on behalf of this user can be protected from disclosure, and if so, the type of privacy protocol which is used. Only one protocol is defined in RFC3414: DES (CBC-DES Symmetric Encryption Protocol) | if security_level = authPriv
+security_level | The Level of Security from which the User-based Security module determines if the message needs to be protected from disclosure and if the message needs to be authenticated. | yes (see security settings under table)
+priv_password | If messages sent on behalf of this user can be en/decrypted, the (private) privacy key for use with the privacy protocol. Defined as privKey in RFC3414 | if security_level = authPriv 
+
+Security_level has 3 settings:
+* noAuthnoPriv: no authentication or privacy
+* authNoPriv: user authentication, without privacy
+* authPriv: user authentication and privacy
 
 Example:
 ```YAML
@@ -52,8 +100,8 @@ default:
   auth:
     username: SomeUser
     password: TotallySecret
-    auth_proto: SHA
-    priv_proto: AES
+    auth_protocol: SHA
+    priv_protocol: AES
     security_level: SomethingReadOnly
     priv_password: SomeOtherSecret
   walk:


### PR DESCRIPTION
Original software only supports SNMPv2, while some older hardware need SNMPv1. Main problem lays within the use of getBulk, which was only introduced in SNMPv2.
By adding an additional parameter we can check the version and act accordingly.