### PR TITLE
Fix infinite loop for endOfMibView SNMP response

### DIFF
--- a/snmp_exporter/collector.py
+++ b/snmp_exporter/collector.py
@@ -14,16 +14,13 @@ def walk_oids(host, port, oids, community):
       yield v
 
 def walk_oid(session, oid):
+    prev_oid = None
     last_oid = oid
-    while True:
+    while prev_oid != last_oid:
+      prev_oid = last_oid
       # getbulk starts from the last oid we saw.
       vl = netsnmp.VarList(netsnmp.Varbind('.' + last_oid))
-      result = session.getbulk(0, 25, vl)
-      # result check: when querying an OID that the target
-      # device does not support, some HP switches prematurely
-      # send endOfMibView instead of noSuchObject. This causes
-      # getbulk to return ('',).
-      if not result or (len(result) == 1 and not result[0]):
+      if not session.getbulk(0, 25, vl):
         return
 
       for v in vl:

--- a/snmp_exporter/collector.py
+++ b/snmp_exporter/collector.py
@@ -18,7 +18,8 @@ def walk_oid(session, oid):
     while True:
       # getbulk starts from the last oid we saw.
       vl = netsnmp.VarList(netsnmp.Varbind('.' + last_oid))
-      if not session.getbulk(0, 25, vl):
+      result = session.getbulk(0, 25, vl)
+      if not result or (len(result) == 1 and not result[0]):
         return
 
       for v in vl:

--- a/snmp_exporter/collector.py
+++ b/snmp_exporter/collector.py
@@ -19,6 +19,8 @@ def walk_oid(session, oid):
       # getbulk starts from the last oid we saw.
       vl = netsnmp.VarList(netsnmp.Varbind('.' + last_oid))
       result = session.getbulk(0, 25, vl)
+      # result check: when querying an OID that the target
+      # device does not support, getbulk returns ('',)
       if not result or (len(result) == 1 and not result[0]):
         return
 

--- a/snmp_exporter/collector.py
+++ b/snmp_exporter/collector.py
@@ -20,7 +20,9 @@ def walk_oid(session, oid):
       vl = netsnmp.VarList(netsnmp.Varbind('.' + last_oid))
       result = session.getbulk(0, 25, vl)
       # result check: when querying an OID that the target
-      # device does not support, getbulk returns ('',)
+      # device does not support, some HP switches prematurely
+      # send endOfMibView instead of noSuchObject. This causes
+      # getbulk to return ('',).
       if not result or (len(result) == 1 and not result[0]):
         return
 


### PR DESCRIPTION
Hi,

when querying an OID that the target device does not support, netsnmp's getbulk seems to return a tuple that only contains an empty string -- i.e., `('',)`. This caused SNMP Exporter to go into an infinite loop.

I extended the result check to cope with this situation.

Cheers,
Svedrin.
