### PR TITLE
Add DisplayString type

### DIFF
--- a/snmp_exporter/collector.py
+++ b/snmp_exporter/collector.py
@@ -61,7 +61,11 @@ def parse_indexes(suboid, index_config, lookup_config, oids):
       content = pad_oid(suboid[1:length+1], length)
       label_oids[index['labelname']] = [length] + content
       labels[index['labelname']] = ''.join((chr(s) for s in content))
-      suboid = suboid[length+1:]
+      suboid = suboid[length+1:]+
+    elif index['type'] == 'DisplayString':
+      sub = suboid
+      label_oids[index['labelname']] = sub
+      labels[index['labelname']] = '.'.join((str(s) for s in sub))
   for lookup in lookup_config:
     index_oid = itertools.chain(*[label_oids[l] for l in lookup['labels']])
     full_oid = oid_to_tuple(lookup['oid']) + tuple(index_oid)


### PR DESCRIPTION

Hi!

I ran into a problem where my MIB has defined an object as
```
poolName OBJECT-TYPE
   SYNTAX DisplayString (SIZE (0..255))
   MAX-ACCESS read-only
   STATUS current
   DESCRIPTION
      "The name of the pool."
   ::= { poolEntry 1 }
```

This is my config
```---
# Default module: interface stats and uptime.
default:
  walk:
    - 1.3.6.1.4.1.7146.1.2.3.2
  metrics:
    - name: poolBytesIn
      oid: 1.3.6.1.4.1.7146.1.2.3.2.1.22
      indexes:
      - labelname: poolName
        type: Integer32
      lookups:
      - labels: [poolName]
        labelname: poolName
        oid: 1.3.6.1.4.1.7146.1.2.3.2.1.1
```

but if I define the index with an Integer32 results come up with some chopped OID as labels
```
poolBytesIn{poolName="20"} 51365792.0
poolBytesIn{poolName="11"} 46169766.0
```

So now I've added a `DisplayString` type and things look better. 
```
poolBytesIn{poolName="eint cockpit-stg"} 51365792.0
poolBytesIn{poolName="web sitemaps-s3"} 46169766.0
```

Which makes me wonder how does in the example this works (AFAIK ifDescr is also of DisplayString type):
```
indexes:
        - labelname: ifDescr
          type: Integer32
```

