### PR TITLE
add InetAddress capabilities

### DIFF
--- a/snmp_exporter/collector.py
+++ b/snmp_exporter/collector.py
@@ -62,6 +62,20 @@ def parse_indexes(suboid, index_config, lookup_config, oids):
       label_oids[index['labelname']] = [length] + content
       labels[index['labelname']] = ''.join((chr(s) for s in content))
       suboid = suboid[length+1:]
+    # InetAddress is always formed by [InetAddressType][InetAddressXX] 
+    elif index['type'] == 'InetAddress':
+      address_type = suboid[0]
+      octets = suboid[1:2][0]
+      address = suboid[2: 2 + octets]
+      label_oids[index['labelname']] = suboid[0: 2 + octets] 
+      # ipv4
+      if address_type == 1:
+        labels[index['labelname']] = '.'.join(str(s) for s in address)
+      # ipv6
+      elif address_type == 2:
+        labels[index['labelname']] = ':'.join(("{0:02X}".format(s) for s in address))   
+      suboid = suboid[2 + octets :]
+
   for lookup in lookup_config:
     index_oid = itertools.chain(*[label_oids[l] for l in lookup['labels']])
     full_oid = oid_to_tuple(lookup['oid']) + tuple(index_oid)

--- a/tests/collector.py
+++ b/tests/collector.py
@@ -6,15 +6,18 @@ class TestCollector(unittest.TestCase):
 
 
   def test_parse_indexes(self):
-    oids = {(1, 2, 3, 4): 'eth0', (1, 3, 65, 32, 255): "octet"}
+    oids = {(1, 2, 3, 4): 'eth0', (1, 3, 65, 32, 255): 'octet',
+            (1, 1, 4, 10, 181, 1, 30): 'ipv4',
+            (1, 2, 16, 42, 6, 29, 128, 0, 1, 0, 3, 0, 0, 0, 0, 0, 1, 1, 52):
+            'ipv6'}
     self.assertEqual({}, parse_indexes((), [], [], oids))
-    self.assertEqual({'l': '4'}, 
+    self.assertEqual({'l': '4'},
         parse_indexes((4,), [{'labelname': 'l', 'type': 'Integer32'}], [], oids))
-    self.assertEqual({'l': 'eth0'}, 
-        parse_indexes((4,), [{'labelname': 'l', 'type': 'Integer32'}], 
+    self.assertEqual({'l': 'eth0'},
+        parse_indexes((4,), [{'labelname': 'l', 'type': 'Integer32'}],
                       [{'labels': ['l'], 'labelname': 'l', 'oid': '1.2.3'}], oids))
-    self.assertEqual({'a': '3', 'b': '4', 'l': 'eth0'}, 
-        parse_indexes((3, 4,), [{'labelname': 'a', 'type': 'Integer32'}, {'labelname': 'b', 'type': 'Integer32'}], 
+    self.assertEqual({'a': '3', 'b': '4', 'l': 'eth0'},
+        parse_indexes((3, 4,), [{'labelname': 'a', 'type': 'Integer32'}, {'labelname': 'b', 'type': 'Integer32'}],
                       [{'labels': ['a', 'b'], 'labelname': 'l', 'oid': '1.2'}], oids))
     self.assertEqual({'l': '0'},
         parse_indexes((), [{'labelname': 'l', 'type': 'Integer32'}], [], {}))
@@ -24,3 +27,15 @@ class TestCollector(unittest.TestCase):
     self.assertEqual({'l': 'octet'},
         parse_indexes((3, 65, 32, 255), [{'labelname': 'l', 'type': 'OctetString'}],
                       [{'labels': ['l'], 'labelname': 'l', 'oid': '1'}], oids))
+    self.assertEqual({'l': 'ipv4'},
+        parse_indexes((1, 4, 10, 181, 1, 30), [{'labelname': 'l', 'type': 'InetAddress'}],
+                      [{'labels': ['l'], 'labelname': 'l', 'oid': '1'}], oids))
+    self.assertEqual({'l': '192.168.2.2'},
+        parse_indexes((1, 4, 192, 168, 2, 2), [{'labelname': 'l', 'type': 'InetAddress'}],
+                      [], oids))
+    self.assertEqual({'l': 'ipv6'},
+        parse_indexes((2, 16, 42, 6, 29, 128, 0, 1, 0, 3, 0, 0, 0, 0, 0, 1, 1, 52), [{'labelname': 'l', 'type': 'InetAddress'}],
+                      [{'labels': ['l'], 'labelname': 'l', 'oid': '1'}], oids))
+    self.assertEqual({'l': '2A:06:1D:80:00:01:00:03:00:00:00:00:00:01:01:34'},
+        parse_indexes((2, 16, 42, 6, 29, 128, 0, 1, 0, 3, 0, 0, 0, 0, 0, 1, 1, 52), [{'labelname': 'l', 'type': 'InetAddress'}],
+                      [], oids))


### PR DESCRIPTION

Hello! Recently I need this feature (a table containing both ipv4 and ipv6 addresses indexes) so I thought I would share it. This pull request would allow for OIDs which require `InetAddressType` and `InetAddress` decoding as table indexes.

as RFC4001 states:

>  When a generic Internet address is used as an index, both the
   InetAddressType and InetAddress objects MUST be used.  The
   InetAddressType object MUST be listed before the InetAddress object
   in the INDEX clause.

using `InetAddress` as type in the yaml file would read both indexes and decode the address according to its type. Currently only ipv4 and ipv6 supported.

