### PR TITLE
Handle missing label lookups

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -312,6 +312,8 @@ func indexesToLabels(indexOids []int, metric *config.Metric, oidToPdu map[string
 		}
 		if pdu, ok := oidToPdu[oid]; ok {
 			labels[lookup.Labelname] = pduValueAsString(&pdu)
+		} else {
+			labels[lookup.Labelname] = ""
 		}
 	}
 

--- a/collector_test.go
+++ b/collector_test.go
@@ -155,7 +155,7 @@ func TestIndexesToLabels(t *testing.T) {
 				Lookups: []*config.Lookup{{Labels: []string{"l"}, Labelname: "l", Oid: "1.2.3"}},
 			},
 			oidToPdu: map[string]gosnmp.SnmpPDU{},
-			result:   map[string]string{"l": "4"},
+			result:   map[string]string{"l": ""},
 		},
 		{
 			oid:      []int{},


### PR DESCRIPTION
When performing lookups across different tables there are cases where
data in the lookup table doesn't match the data in the metric table.

This makes `indexesToLabels()` always return the requested label sets.
Currently you end up with scrape errors due to Prometheus client
miss-matched label sets in metric families.