### PR TITLE
Add -version argument to the CLI

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
+	"os"
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -16,7 +17,8 @@ import (
 )
 
 var (
-	configFile = flag.String(
+	showVersion = flag.Bool("version", false, "Print version information.")
+	configFile  = flag.String(
 		"config.file", "snmp.yml",
 		"Path to configuration file.",
 	)
@@ -88,6 +90,11 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 func main() {
 	flag.Parse()
+
+	if *showVersion {
+		fmt.Fprintln(os.Stdout, version.Print("node_exporter"))
+		os.Exit(0)
+	}
 
 	log.Infoln("Starting snmp exporter", version.Info())
 	log.Infoln("Build context", version.BuildContext())

--- a/main.go
+++ b/main.go
@@ -92,7 +92,7 @@ func main() {
 	flag.Parse()
 
 	if *showVersion {
-		fmt.Fprintln(os.Stdout, version.Print("node_exporter"))
+		fmt.Fprintln(os.Stdout, version.Print("snmp_exporter"))
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Add *--version* argument like other tools (prometheus, node_exporter, ...)

```bash
$ ./snmp_exporter --help
Usage of ./snmp_exporter:
  -config.file string
    	Path to configuration file. (default "snmp.yml")
  -log.format value
    	Set the log target and format. Example: "logger:syslog?appname=bob&local=7" or "logger:stdout?json=true" (default "logger:stderr")
  -log.level value
    	Only log messages with the given severity or above. Valid levels: [debug, info, warn, error, fatal] (default "info")
  -version
    	Print version information.
  -web.listen-address string
    	Address to listen on for web interface and telemetry. (default ":9116")

$ ./snmp_exporter --version
node_exporter, version 0.1.0 (branch: master, revision: 0490194fbda24c99f58a742dbceb53913786fb3b)
  build user:       nlamirault@nlamirault
  build date:       20170113-09:06:35
  go version:       go1.6
```


Signed-off-by: Nicolas Lamirault <nicolas.lamirault@gmail.com>