### PR TITLE
Allows snmp retries, timeout, and maxrepititions to be specified in the snmp.yml file.

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -39,9 +39,9 @@ func oidToList(oid string) []int {
 func ScrapeTarget(target string, config *config.Module) ([]gosnmp.SnmpPDU, error) {
 	// Set the options.
 	snmp := gosnmp.GoSNMP{}
-	snmp.Retries = 3
-	snmp.MaxRepetitions = 25
-	snmp.Timeout = time.Second * 60
+	snmp.Retries = config.Retries
+	snmp.MaxRepetitions = config.MaxRepititions
+	snmp.Timeout = time.Second * config.Timeout
 
 	snmp.Target = target
 	snmp.Port = 161

--- a/collector.go
+++ b/collector.go
@@ -39,9 +39,9 @@ func oidToList(oid string) []int {
 func ScrapeTarget(target string, config *config.Module) ([]gosnmp.SnmpPDU, error) {
 	// Set the options.
 	snmp := gosnmp.GoSNMP{}
-	snmp.Retries = config.Retries
 	snmp.MaxRepetitions = config.MaxRepititions
-	snmp.Timeout = time.Second * config.Timeout
+	snmp.Retries = config.Retries
+	snmp.Timeout = config.Timeout * time.Duration(snmp.Retries)
 
 	snmp.Target = target
 	snmp.Port = 161

--- a/collector.go
+++ b/collector.go
@@ -40,6 +40,7 @@ func ScrapeTarget(target string, config *config.Module) ([]gosnmp.SnmpPDU, error
 	// Set the options.
 	snmp := gosnmp.GoSNMP{}
 	snmp.MaxRepetitions = config.MaxRepititions
+	// user specifies timeout of each retry attempt but GoSNMP expects total timeout for all attemtps
 	snmp.Retries = config.Retries
 	snmp.Timeout = config.Timeout * time.Duration(snmp.Retries)
 

--- a/collector.go
+++ b/collector.go
@@ -40,7 +40,7 @@ func ScrapeTarget(target string, config *config.Module) ([]gosnmp.SnmpPDU, error
 	// Set the options.
 	snmp := gosnmp.GoSNMP{}
 	snmp.MaxRepetitions = config.MaxRepititions
-	// user specifies timeout of each retry attempt but GoSNMP expects total timeout for all attemtps
+	// User specifies timeout of each retry attempt but GoSNMP expects total timeout for all attemtps.
 	snmp.Retries = config.Retries
 	snmp.Timeout = config.Timeout * time.Duration(snmp.Retries)
 

--- a/config/config.go
+++ b/config/config.go
@@ -26,9 +26,9 @@ func LoadFile(filename string) (*Config, error) {
 var (
 	DefaultModule = Module{
 		Version:        2,
-		Retries:        3,
 		MaxRepititions: 25,
-		Timeout:        60,
+		Retries:        3,
+		Timeout:        time.Second,
 	}
 	DefaultAuth = Auth{
 		Community:     "public",
@@ -47,8 +47,8 @@ type Module struct {
 	Metrics []*Metric `yaml:"metrics"`
 
 	Version        int           `yaml:"version,omitempty"`
-	Retries        int           `yaml:"retries,omitempty"`
 	MaxRepititions uint8         `yaml:"max_repititions,omitempty"`
+	Retries        int           `yaml:"retries,omitempty"`
 	Timeout        time.Duration `yaml:"timeout,omitempty"`
 	Auth           *Auth         `yaml:"auth,omitempty"`
 

--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,7 @@ var (
 		Version:        2,
 		MaxRepititions: 25,
 		Retries:        3,
-		Timeout:        time.Second,
+		Timeout:        time.Second * 20,
 	}
 	DefaultAuth = Auth{
 		Community:     "public",

--- a/config/config.go
+++ b/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"strings"
+	"time"
 
 	"github.com/soniah/gosnmp"
 	"gopkg.in/yaml.v2"
@@ -24,7 +25,10 @@ func LoadFile(filename string) (*Config, error) {
 
 var (
 	DefaultModule = Module{
-		Version: 2,
+		Version:        2,
+		Retries:        3,
+		MaxRepititions: 25,
+		Timeout:        60,
 	}
 	DefaultAuth = Auth{
 		Community:     "public",
@@ -42,8 +46,11 @@ type Module struct {
 	Walk    []string  `yaml:"walk"`
 	Metrics []*Metric `yaml:"metrics"`
 
-	Version int   `yaml:"version,omitempty"`
-	Auth    *Auth `yaml:"auth,omitempty"`
+	Version        int           `yaml:"version,omitempty"`
+	Retries        int           `yaml:"retries,omitempty"`
+	MaxRepititions uint8         `yaml:"max_repititions,omitempty"`
+	Timeout        time.Duration `yaml:"timeout,omitempty"`
+	Auth           *Auth         `yaml:"auth,omitempty"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/generator/config.go
+++ b/generator/config.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/prometheus/snmp_exporter/config"
+	"time"
 )
 
 // The generator config.
@@ -27,8 +28,11 @@ type ModuleConfig struct {
 	Lookups []*Lookup `yaml:"lookups"`
 
 	// This need to be kepy in sync with the generated config.
-	Version int          `yaml:"version,omitempty"`
-	Auth    *config.Auth `yaml:"auth,omitempty"`
+	Version        int           `yaml:"version,omitempty"`
+	Retries        int           `yaml:"retries,omitempty"`
+	MaxRepititions uint8         `yaml:"max_repititions,omitempty"`
+	Timeout        time.Duration `yaml:"timeout,omitempty"`
+	Auth           *config.Auth  `yaml:"auth,omitempty"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }

--- a/generator/config.go
+++ b/generator/config.go
@@ -1,8 +1,9 @@
 package main
 
 import (
-	"github.com/prometheus/snmp_exporter/config"
 	"time"
+
+	"github.com/prometheus/snmp_exporter/config"
 )
 
 // The generator config.
@@ -29,8 +30,8 @@ type ModuleConfig struct {
 
 	// This need to be kepy in sync with the generated config.
 	Version        int           `yaml:"version,omitempty"`
-	Retries        int           `yaml:"retries,omitempty"`
 	MaxRepititions uint8         `yaml:"max_repititions,omitempty"`
+	Retries        int           `yaml:"retries,omitempty"`
 	Timeout        time.Duration `yaml:"timeout,omitempty"`
 	Auth           *config.Auth  `yaml:"auth,omitempty"`
 

--- a/generator/main.go
+++ b/generator/main.go
@@ -29,8 +29,8 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node) {
 		log.Infof("Generating config for module %s", name)
 		outputConfig[name] = generateConfigModule(m, nodes, nameToNode)
 		outputConfig[name].Version = m.Version
-		outputConfig[name].Retries = m.Retries
 		outputConfig[name].MaxRepititions = m.MaxRepititions
+		outputConfig[name].Retries = m.Retries
 		outputConfig[name].Timeout = m.Timeout
 		outputConfig[name].Auth = m.Auth
 		log.Infof("Generated %d metrics for module %s", len(outputConfig[name].Metrics), name)

--- a/generator/main.go
+++ b/generator/main.go
@@ -29,6 +29,9 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node) {
 		log.Infof("Generating config for module %s", name)
 		outputConfig[name] = generateConfigModule(m, nodes, nameToNode)
 		outputConfig[name].Version = m.Version
+		outputConfig[name].Retries = m.Retries
+		outputConfig[name].MaxRepititions = m.MaxRepititions
+		outputConfig[name].Timeout = m.Timeout
 		outputConfig[name].Auth = m.Auth
 		log.Infof("Generated %d metrics for module %s", len(outputConfig[name].Metrics), name)
 	}


### PR DESCRIPTION
@matthiasr This relates to Issues #17 and #80 as well as adding an option that was not specified by those tickets since it was related and simple (retries).

Basically just adds retries, max_repititions, and timeout options to the snmp.yml file. These are defined per config.Module so that it can be changed for different device types.

An example snmp.yml file would look like the following:
```yaml
default:
  version: 2
  max_repititions: 25
  timeout: 60
  retries: 3
  walk:
    - 1.3.6.1.2.1.1.3
...
```

The default values for when these are omitted are the same as currently in master. The timeout value is in seconds. So in the example above it would timeout after 60 seconds. I ran a brief test on Windows but will likely be using this on a Linux machine shortly (as I understand it should not matter).

My specific needs relate to timeout because I have a device or two that takes a little longer to respond.

If any adjustments are needed let me know. So far I have just dabbled with Go code so I may have made some mistakes. Also, I did not see unit tests for the configuration and don't really have time to add them right now. If you would like some before accepting this let me know. I will need you to provide some guidance on how to make sure it will integrate with your CI server (links are fine). I've not done unit tests for Go before, my experience is mostly with Python & .NET. 