### PR TITLE
Fixed IP address in label(lookups)

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -244,6 +244,12 @@ func pduValueAsString(pdu *gosnmp.SnmpPDU, typ string) string {
 				parts[i] = fmt.Sprintf("%02X", o)
 			}
 			return strings.Join(parts, ":")
+		case "IpAddress":
+			parts := make([]string, 4)
+				for i, o := range pdu.Value.([]byte) {
+					parts[i] = strconv.Itoa(int(o))
+				}
+			return strings.Join(parts, ".")
 		default: // Assume OctetString.
 			if len(pdu.Value.([]byte)) == 0 {
 				return ""


### PR DESCRIPTION
Earliler it converts IP Address (Hex format "AC 1F 10 31" ) to  Hex string ("0xAC1F1031")

**SNMP Exporter output:**
`rttMonLatestJitterOperOWAvgDS{rttMonCtrlAdminIndex="13",rttMonEchoAdminSourceAddress="0xAC1F1031",rttMonEchoAdminTargetAddress="0x36BB915D"} 0
`

Now in SNMP.yml file mention the label type as "IpAddress" and the hex value of IP will be connverted to actual IP address 

**snmp.yaml**
```
  - name: rttMonLatestJitterOperOWAvgDS
    oid: 1.3.6.1.4.1.9.9.42.1.5.2.1.50
    type: gauge
    indexes:
    - labelname: rttMonCtrlAdminIndex
      type: Integer
    lookups:
    - labels:
      - rttMonCtrlAdminIndex
      labelname: rttMonEchoAdminSourceAddress
      oid: 1.3.6.1.4.1.9.9.42.1.2.2.1.6
      type: IpAddress
```

**SNMP Exporter output:**
**Fixed to:**
`rttMonLatestJitterOperOWAvgDS{rttMonCtrlAdminIndex="13",rttMonEchoAdminSourceAddress="172.31.16.49",rttMonEchoAdminTargetAddress="54.187.145.93"} 0
`