### PR TITLE
Replace libsnmp with libnetsnmp, add /usr/local prefix

### DIFF
--- a/generator/net_snmp.go
+++ b/generator/net_snmp.go
@@ -1,7 +1,8 @@
 package main
 
 /*
-#cgo LDFLAGS: -lnetsnmp
+#cgo LDFLAGS: -lnetsnmp -L/usr/local/lib
+#cgo CFLAGS: -I/usr/local/include
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/mib_api.h>
 #include <unistd.h>


### PR DESCRIPTION
According to the issue I've opened yesterday, these are two simple changes that replace -lsnmp with -lnetsnmp and add -L/usr/local/lib to the cgo ldflags and also -I/usr/local/include to the cgo cflags. These changes do not appear to break builds in Linux, but at the same time make building on FreeBSD possible without patching the code.