### PR TITLE
Fixing a spelling error introduced in snmp_options pull request.

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -39,7 +39,7 @@ func oidToList(oid string) []int {
 func ScrapeTarget(target string, config *config.Module) ([]gosnmp.SnmpPDU, error) {
 	// Set the options.
 	snmp := gosnmp.GoSNMP{}
-	snmp.MaxRepetitions = config.MaxRepititions
+	snmp.MaxRepetitions = config.MaxRepetitions
 	// User specifies timeout of each retry attempt but GoSNMP expects total timeout for all attemtps.
 	snmp.Retries = config.Retries
 	snmp.Timeout = config.Timeout * time.Duration(snmp.Retries)

--- a/config/config.go
+++ b/config/config.go
@@ -26,7 +26,7 @@ func LoadFile(filename string) (*Config, error) {
 var (
 	DefaultModule = Module{
 		Version:        2,
-		MaxRepititions: 25,
+		MaxRepetitions: 25,
 		Retries:        3,
 		Timeout:        time.Second * 20,
 	}
@@ -47,7 +47,7 @@ type Module struct {
 	Metrics []*Metric `yaml:"metrics"`
 
 	Version        int           `yaml:"version,omitempty"`
-	MaxRepititions uint8         `yaml:"max_repititions,omitempty"`
+	MaxRepetitions uint8         `yaml:"max_repetitions,omitempty"`
 	Retries        int           `yaml:"retries,omitempty"`
 	Timeout        time.Duration `yaml:"timeout,omitempty"`
 	Auth           *Auth         `yaml:"auth,omitempty"`

--- a/generator/config.go
+++ b/generator/config.go
@@ -30,7 +30,7 @@ type ModuleConfig struct {
 
 	// This need to be kepy in sync with the generated config.
 	Version        int           `yaml:"version,omitempty"`
-	MaxRepititions uint8         `yaml:"max_repititions,omitempty"`
+	MaxRepetitions uint8         `yaml:"max_repetitions,omitempty"`
 	Retries        int           `yaml:"retries,omitempty"`
 	Timeout        time.Duration `yaml:"timeout,omitempty"`
 	Auth           *config.Auth  `yaml:"auth,omitempty"`

--- a/generator/main.go
+++ b/generator/main.go
@@ -29,7 +29,7 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node) {
 		log.Infof("Generating config for module %s", name)
 		outputConfig[name] = generateConfigModule(m, nodes, nameToNode)
 		outputConfig[name].Version = m.Version
-		outputConfig[name].MaxRepititions = m.MaxRepititions
+		outputConfig[name].MaxRepetitions = m.MaxRepetitions
 		outputConfig[name].Retries = m.Retries
 		outputConfig[name].Timeout = m.Timeout
 		outputConfig[name].Auth = m.Auth


### PR DESCRIPTION
I discovered that I introduced a spelling error when I made my last pull request. This causes consistency issues both in the snmp_exporter and with the underlying go library used for making the connections and transferring data.

I believe that this request fixes all of those misspellings. `MaxRepititions` is now consistently `MaxRepetitions`.