### PR TITLE
vendor: update gosnmp

### DIFF
--- a/vendor/github.com/soniah/gosnmp/marshal.go
+++ b/vendor/github.com/soniah/gosnmp/marshal.go
@@ -571,6 +571,9 @@ func marshalVarbind(pdu *SnmpPDU) ([]byte, error) {
 // -- Unmarshalling Logic ------------------------------------------------------
 
 func (x *GoSNMP) unmarshalHeader(packet []byte, response *SnmpPacket) (int, error) {
+	if len(packet) < 2 {
+		return 0, fmt.Errorf("Cannot unmarshal empty packet")
+	}
 	if response == nil {
 		return 0, fmt.Errorf("Cannot unmarshal response into nil packet reference")
 	}

--- a/vendor/github.com/soniah/gosnmp/v3.go
+++ b/vendor/github.com/soniah/gosnmp/v3.go
@@ -345,6 +345,10 @@ func (x *GoSNMP) unmarshalV3Header(packet []byte,
 	_, cursorTmp = parseLength(packet[cursor:])
 	cursor += cursorTmp
 
+	if response.SecurityParameters == nil {
+		return 0, fmt.Errorf("Unable to parse V3 packet - unknown security model")
+	}
+
 	cursor, err = response.SecurityParameters.unmarshal(response.MsgFlags, packet, cursor)
 	if err != nil {
 		return 0, err

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -68,9 +68,10 @@
 			"revisionTime": "2015-10-29T15:50:50-04:00"
 		},
 		{
+			"checksumSHA1": "L7+d0vCZcj7GoFMswzyWBPDr2iY=",
 			"path": "github.com/soniah/gosnmp",
-			"revision": "db6b5e552bd4a54e1692046a03b4dd8682cdcd6f",
-			"revisionTime": "2016-09-11T02:16:57-08:00"
+			"revision": "5ad50dc75ab389f8a1c9f8a67d3a1cd85f67ed15",
+			"revisionTime": "2017-01-04T02:24:20Z"
 		},
 		{
 			"path": "golang.org/x/sys/unix",
@@ -97,5 +98,6 @@
 			"revision": "a83829b6f1293c91addabc89d0571c246397bbf4",
 			"revisionTime": "2016-03-01T17:40:22-03:00"
 		}
-	]
+	],
+	"rootPath": "github.com/prometheus/snmp_exporter"
 }


### PR DESCRIPTION
Notably to pickup https://github.com/soniah/gosnmp/pull/92

This was necessary to get the exporter to work against a tripplite PDU.

Without it, the scrape requests timeout, and I observed `.1.3.6.1.4.1.850.10.1.2.7.4.0=[inetaddr len!=4]` when I tcpdumped snmp traffic due to the value of the ipaddress being wrong (snmpwalk prints it as 'IpAddress: 2.0.0.0').