### PR TITLE
community and version can be passed by get param

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/prometheus/common/version"
 
 	"github.com/prometheus/snmp_exporter/config"
+	"strconv"
 )
 
 var (
@@ -75,6 +76,18 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	log.Debugf("Scraping target '%s' with module '%s'", target, moduleName)
+
+	snmpVersion := r.URL.Query().Get("version")
+	if v, err := strconv.Atoi(snmpVersion); snmpVersion != "" && err != nil {
+		log.Debugf("Overriding version. Old version: '%d' new version: '%d'", module.Version, v)
+		module.Version = v
+	}
+
+	community := r.URL.Query().Get("community")
+	if community != "" {
+		log.Debugf("Overriding community. Old community: '%s' new community: '%s'", module.Auth.Community, community)
+		module.Auth.Community = community
+	}
 
 	start := time.Now()
 	registry := prometheus.NewRegistry()


### PR DESCRIPTION
Hi @brian-brazil, 
this patch allows Prometheus to pass a custom version and community per request, which makes it more flexible, due to overriding the values from the config. I'm not sure if this is breaking the base concept of this tool but maybe it's usefully for others, too.
It's just makes sense for snmp v1/2.
Best Regards,
Philip