### PR TITLE
Update generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ dependencies-stamp
 /.tarballs
 .deps
 *.tar.gz
+
+generator/generator

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -10,7 +10,8 @@ modules:
     walk: [sysUpTime, interfaces, ifXTable]
     lookups:
       - old_index: ifIndex
-        new_index: ifName
+        # Use OID to avoid conflict with Netscaler NS-ROOT-MIB.
+        new_index: 1.3.6.1.2.1.31.1.1.1.1 # ifName
 # If only ifIndex is unique.
   default_ifindex:
     walk: [sysUpTime, interfaces, ifXTable]
@@ -177,7 +178,8 @@ modules:
       - old_index: serviceInfoIndex
         new_index: serviceName
       - old_index: ifIndex
-        new_index: ifName
+        # Use OID to avoid conflict with Netscaler NS-ROOT-MIB.
+        new_index: 1.3.6.1.2.1.31.1.1.1.1 # ifName
       - old_index: diskIndex
         new_index: diskID
       - old_index: raidIndex

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -195,14 +195,14 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 					}
 					indexNode := nameToNode[lookup.NewIndex]
 					// Avoid leaving the old labelname around.
-					index.Labelname = lookup.NewIndex
+					index.Labelname = indexNode.Label
 					typ, ok := metricType(indexNode.Type)
 					if !ok {
 						log.Fatalf("Unknown index type %s for %s", indexNode.Type, lookup.NewIndex)
 					}
 					metric.Lookups = append(metric.Lookups, &config.Lookup{
-						Labels:    []string{lookup.NewIndex},
-						Labelname: lookup.NewIndex,
+						Labels:    []string{indexNode.Label},
+						Labelname: indexNode.Label,
 						Type:      typ,
 						Oid:       indexNode.Oid,
 					})

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -543,6 +543,52 @@ func TestGenerateConfigModule(t *testing.T) {
 				},
 			},
 		},
+		// Lookup via OID.
+		{
+			node: &Node{Oid: "1", Label: "root",
+				Children: []*Node{
+					{Oid: "1.1", Label: "octet",
+						Children: []*Node{
+							{Oid: "1.1.1", Label: "octetEntry", Indexes: []string{"octetIndex"},
+								Children: []*Node{
+									{Oid: "1.1.1.1", Access: "ACCESS_READONLY", Label: "octetIndex", Type: "INTEGER"},
+									{Oid: "1.1.1.2", Access: "ACCESS_READONLY", Label: "octetDesc", Type: "OCTETSTR"},
+									{Oid: "1.1.1.3", Access: "ACCESS_READONLY", Label: "octetFoo", Type: "INTEGER"}}}}}}},
+			cfg: &ModuleConfig{
+				Walk: []string{"octetFoo"},
+				Lookups: []*Lookup{
+					{
+						OldIndex: "octetIndex",
+						NewIndex: "1.1.1.2",
+					},
+				},
+			},
+			out: &config.Module{
+				// Walk is expanded to include the lookup OID.
+				Walk: []string{"1.1.1.2", "1.1.1.3"},
+				Metrics: []*config.Metric{
+					{
+						Name: "octetFoo",
+						Oid:  "1.1.1.3",
+						Type: "gauge",
+						Indexes: []*config.Index{
+							{
+								Labelname: "octetDesc",
+								Type:      "gauge",
+							},
+						},
+						Lookups: []*config.Lookup{
+							{
+								Labels:    []string{"octetDesc"},
+								Labelname: "octetDesc",
+								Type:      "OctetString",
+								Oid:       "1.1.1.2",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 	for i, c := range cases {
 		// Indexes and lookups always end up initilized.

--- a/snmp.yml
+++ b/snmp.yml
@@ -1208,12 +1208,6 @@ arista_sw:
     indexes:
     - labelname: ifIndex
       type: gauge
-  - name: aristaSwFwdIpStatsIPVersion
-    oid: 1.3.6.1.4.1.30065.3.1.1.1.1.1
-    type: gauge
-    indexes:
-    - labelname: aristaSwFwdIpStatsIPVersion
-      type: gauge
   - name: aristaSwFwdIpStatsInReceives
     oid: 1.3.6.1.4.1.30065.3.1.1.1.1.3
     type: counter
@@ -4789,14 +4783,6 @@ servertech_sentry3:
   - name: sysUpTime
     oid: 1.3.6.1.2.1.1.3
     type: gauge
-  - name: infeedIndex
-    oid: 1.3.6.1.4.1.1718.3.2.2.1.1
-    type: gauge
-    indexes:
-    - labelname: towerIndex
-      type: gauge
-    - labelname: infeedIndex
-      type: gauge
   - name: infeedID
     oid: 1.3.6.1.4.1.1718.3.2.2.1.2
     type: DisplayString
@@ -4988,16 +4974,6 @@ servertech_sentry3:
     - labelname: towerIndex
       type: gauge
     - labelname: infeedIndex
-      type: gauge
-  - name: outletIndex
-    oid: 1.3.6.1.4.1.1718.3.2.3.1.1
-    type: gauge
-    indexes:
-    - labelname: towerIndex
-      type: gauge
-    - labelname: infeedIndex
-      type: gauge
-    - labelname: outletIndex
       type: gauge
   - name: outletID
     oid: 1.3.6.1.4.1.1718.3.2.3.1.2
@@ -5889,18 +5865,6 @@ synology:
   - name: upgradeAvailable
     oid: 1.3.6.1.4.1.6574.1.5.4
     type: gauge
-  - name: storageIOIndex
-    oid: 1.3.6.1.4.1.6574.101.1.1.1
-    type: gauge
-    indexes:
-    - labelname: storageIODevice
-      type: gauge
-    lookups:
-    - labels:
-      - storageIODevice
-      labelname: storageIODevice
-      oid: 1.3.6.1.4.1.6574.101.1.1.2
-      type: DisplayString
   - name: storageIODevice
     oid: 1.3.6.1.4.1.6574.101.1.1.2
     type: DisplayString
@@ -6032,18 +5996,6 @@ synology:
       - storageIODevice
       labelname: storageIODevice
       oid: 1.3.6.1.4.1.6574.101.1.1.2
-      type: DisplayString
-  - name: spaceIOIndex
-    oid: 1.3.6.1.4.1.6574.102.1.1.1
-    type: gauge
-    indexes:
-    - labelname: spaceIODevice
-      type: gauge
-    lookups:
-    - labels:
-      - spaceIODevice
-      labelname: spaceIODevice
-      oid: 1.3.6.1.4.1.6574.102.1.1.2
       type: DisplayString
   - name: spaceIODevice
     oid: 1.3.6.1.4.1.6574.102.1.1.2
@@ -6177,12 +6129,6 @@ synology:
       labelname: spaceIODevice
       oid: 1.3.6.1.4.1.6574.102.1.1.2
       type: DisplayString
-  - name: iSCSILUNInfoIndex
-    oid: 1.3.6.1.4.1.6574.104.1.1.1
-    type: gauge
-    indexes:
-    - labelname: iSCSILUNInfoIndex
-      type: gauge
   - name: iSCSILUNUUID
     oid: 1.3.6.1.4.1.6574.104.1.1.2
     type: OctetString
@@ -6279,18 +6225,6 @@ synology:
     indexes:
     - labelname: iSCSILUNInfoIndex
       type: gauge
-  - name: diskIndex
-    oid: 1.3.6.1.4.1.6574.2.1.1.1
-    type: gauge
-    indexes:
-    - labelname: diskID
-      type: gauge
-    lookups:
-    - labels:
-      - diskID
-      labelname: diskID
-      oid: 1.3.6.1.4.1.6574.2.1.1.2
-      type: OctetString
   - name: diskID
     oid: 1.3.6.1.4.1.6574.2.1.1.2
     type: OctetString
@@ -6350,18 +6284,6 @@ synology:
       - diskID
       labelname: diskID
       oid: 1.3.6.1.4.1.6574.2.1.1.2
-      type: OctetString
-  - name: raidIndex
-    oid: 1.3.6.1.4.1.6574.3.1.1.1
-    type: gauge
-    indexes:
-    - labelname: raidName
-      type: gauge
-    lookups:
-    - labels:
-      - raidName
-      labelname: raidName
-      oid: 1.3.6.1.4.1.6574.3.1.1.2
       type: OctetString
   - name: raidName
     oid: 1.3.6.1.4.1.6574.3.1.1.2
@@ -6591,12 +6513,6 @@ synology:
   - name: upsServerVersion
     oid: 1.3.6.1.4.1.6574.4.8.2
     type: DisplayString
-  - name: diskSMARTInfoIndex
-    oid: 1.3.6.1.4.1.6574.5.1.1.1
-    type: gauge
-    indexes:
-    - labelname: diskSMARTInfoIndex
-      type: gauge
   - name: diskSMARTInfoDevName
     oid: 1.3.6.1.4.1.6574.5.1.1.2
     type: OctetString
@@ -6645,18 +6561,6 @@ synology:
     indexes:
     - labelname: diskSMARTInfoIndex
       type: gauge
-  - name: serviceInfoIndex
-    oid: 1.3.6.1.4.1.6574.6.1.1.1
-    type: gauge
-    indexes:
-    - labelname: serviceName
-      type: gauge
-    lookups:
-    - labels:
-      - serviceName
-      labelname: serviceName
-      oid: 1.3.6.1.4.1.6574.6.1.1.2
-      type: OctetString
   - name: serviceName
     oid: 1.3.6.1.4.1.6574.6.1.1.2
     type: OctetString


### PR DESCRIPTION
Use lookup node's index label in the generator:
* Instead of using the literal name from the generator's config, use the
  Label from the MIB index.  This allows OIDs to be used in the
  `new_index` field in the generator.yml.

Use an explicit OID for ifName lookups.
* This avoids the ifName conflict caused by the Citrix netscaler NS-ROOT-MIB module.

Update snmp.yml  
* This updates with the latest generator code, removes non-accessible
  metrics from being used.

Misc:
* Ignore the generator binary from the git repo.