### PR TITLE
Update by request

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,13 +109,14 @@ func updateConfiguration(w http.ResponseWriter, r *http.Request) {
 }
 
 func (sc *SafeConfig) reloadConfig(configFile string) (err error) {
-	sc.Lock()
-	sc.C, err = config.LoadFile(configFile)
-	sc.Unlock()
+	conf, err := config.LoadFile(configFile)
 	if err != nil {
 		log.Errorf("Error parsing config file: %s", err)
 		return err
 	}
+	sc.Lock()
+	sc.C = conf
+	sc.Unlock()
 	log.Infoln("Loaded config file")
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -41,7 +41,7 @@ var (
 			Help: "Errors in requests to the SNMP exporter",
 		},
 	)
-	updateOnDemand = flag.Bool("config.update-on-demand", false, "Configuration will be updated only on demand in case true.")
+	updateOnDemand = flag.Bool("config.update-on-demand", false, "Configuration will be updated only on demand if specified.")
 	cfg            *config.Config
 	err            error
 )

--- a/main.go
+++ b/main.go
@@ -99,8 +99,7 @@ func updateConfiguration(w http.ResponseWriter, r *http.Request) {
 	case "POST":
 		rc := make(chan error)
 		reloadCh <- rc
-		var err error
-		if err = <-rc; err != nil {
+		if err := <-rc; err != nil {
 			http.Error(w, fmt.Sprintf("failed to reload config: %s", err), http.StatusInternalServerError)
 		}
 	default:

--- a/main.go
+++ b/main.go
@@ -52,7 +52,6 @@ var (
 	sc = &SafeConfig{
 		C: &config.Config{},
 	}
-	err      error
 	reloadCh chan chan error
 )
 
@@ -100,6 +99,7 @@ func updateConfiguration(w http.ResponseWriter, r *http.Request) {
 	case "POST":
 		rc := make(chan error)
 		reloadCh <- rc
+		var err error
 		if err = <-rc; err != nil {
 			http.Error(w, fmt.Sprintf("failed to reload config: %s", err), http.StatusInternalServerError)
 		}
@@ -132,6 +132,7 @@ func main() {
 	log.Infoln("Build context", version.BuildContext())
 
 	// Bail early if the config is bad.
+	var err error
 	sc.C, err = config.LoadFile(*configFile)
 	if err != nil {
 		log.Fatalf("Error parsing config file: %s", err)


### PR DESCRIPTION
Hello @brian-brazil,

I think this change may be useful for complex configuration and for big amount of targets per one exporter.

The on demand update will be enabled only in case -config.update-on-demand specified, if not specified it works as before.