### PR TITLE
Handle SnmpPDUs with a value of type uint64

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -226,8 +226,6 @@ func pduValueAsString(pdu *gosnmp.SnmpPDU, typ string) string {
 		return strconv.Itoa(pdu.Value.(int))
 	case uint:
 		return strconv.FormatUint(uint64(pdu.Value.(uint)), 10)
-	case int64:
-		return strconv.FormatInt(pdu.Value.(int64), 10)
 	case uint64:
 		return strconv.FormatUint(pdu.Value.(uint64), 10)
 	case string:

--- a/collector.go
+++ b/collector.go
@@ -228,6 +228,8 @@ func pduValueAsString(pdu *gosnmp.SnmpPDU, typ string) string {
 		return strconv.FormatUint(uint64(pdu.Value.(uint)), 10)
 	case int64:
 		return strconv.FormatInt(pdu.Value.(int64), 10)
+	case uint64:
+		return strconv.FormatUint(pdu.Value.(uint64), 10)
 	case string:
 		if pdu.Type == gosnmp.ObjectIdentifier {
 			// Trim leading period.

--- a/collector_test.go
+++ b/collector_test.go
@@ -84,10 +84,6 @@ func TestPduValueAsString(t *testing.T) {
 			result: "1",
 		},
 		{
-			pdu:    &gosnmp.SnmpPDU{Value: int64(-1000000000000)},
-			result: "-1000000000000",
-		},
-		{
 			pdu:    &gosnmp.SnmpPDU{Value: ".1.2.3.4", Type: gosnmp.ObjectIdentifier},
 			result: "1.2.3.4",
 		},

--- a/collector_test.go
+++ b/collector_test.go
@@ -80,6 +80,10 @@ func TestPduValueAsString(t *testing.T) {
 			result: "1",
 		},
 		{
+			pdu:    &gosnmp.SnmpPDU{Value: uint64(1)},
+			result: "1",
+		},
+		{
 			pdu:    &gosnmp.SnmpPDU{Value: int64(-1000000000000)},
 			result: "-1000000000000",
 		},


### PR DESCRIPTION
We encountered the following log message when trying to use Prometheus SNMP Exporter against a Cisco firewall:

    INFO[0014] Got PDU with unexpected type: Name: .1.3.6.1.4.1.9.9.392.1.3.21.1.35.8.107.114.105.115.116.105.97.110.9940993 Value: '%!s(uint64=522077)', Go Type: uint64 SNMP Type: %!s(gosnmp.Asn1BER=70)   source="collector.go:257"

This pull request fixes that by adding support for uint64.

Ping: @brian-brazil

Closes: https://github.com/prometheus/snmp_exporter/issues/187