### PR TITLE
Use struct for auth, not pointer

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -36,7 +36,7 @@ var (
 		MaxRepetitions: 25,
 		Retries:        3,
 		Timeout:        time.Second * 20,
-		Auth:           &DefaultAuth,
+		Auth:           DefaultAuth,
 	}
 	DefaultModule = Module{
 		WalkParams: DefaultWalkParams,
@@ -54,7 +54,7 @@ type WalkParams struct {
 	MaxRepetitions uint8         `yaml:"max_repetitions,omitempty"`
 	Retries        int           `yaml:"retries,omitempty"`
 	Timeout        time.Duration `yaml:"timeout,omitempty"`
-	Auth           *Auth         `yaml:"auth,omitempty"`
+	Auth           Auth          `yaml:"auth,omitempty"`
 
 	XXX map[string]interface{} `yaml:",inline"`
 }


### PR DESCRIPTION
This avoids sharing the auth across modules.

Fixes #220 
@Conorbro 