### PR TITLE
Updated link for Synology mib files

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -98,7 +98,7 @@ Put the extracted mibs in a location NetSNMP can read them from. `$HOME/.snmp/mi
 * Arista Networks: https://www.arista.com/assets/data/docs/MIBS/ARISTA-ENTITY-SENSOR-MIB.txt
                    https://www.arista.com/assets/data/docs/MIBS/ARISTA-SW-IP-FORWARDING-MIB.txt
                    https://www.arista.com/assets/data/docs/MIBS/ARISTA-SMI-MIB.txt
-* Synology: http://dedl.synology.com/download/Document/MIBGuide/Synology_MIB_File.zip
+* Synology: https://global.download.synology.com/download/Document/MIBGuide/Synology_MIB_File.zip
 * UCD-SNMP-MIB (Net-SNMP): http://www.net-snmp.org/docs/mibs/UCD-SNMP-MIB.txt
 
 https://github.com/librenms/librenms/tree/master/mibs can also be a good source of MIBs.


### PR DESCRIPTION
Old link was 404'ing. New link taken from [here](https://global.download.synology.com/download/Document/MIBGuide/Synology_DiskStation_MIB_Guide.pdf).