### PR TITLE
Added a dockerfile to simplify building and generating snmp configs

### DIFF
--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -1,20 +1,22 @@
-FROM golang:1.9.2
+FROM golang:latest
 
-# snmp-mibs-downloader is in the multiverse
-RUN echo "deb http://http.us.debian.org/debian stretch non-free" >> /etc/apt/sources.list
+RUN apt-get update && apt-get install -y libsnmp-dev
 
-RUN apt-get update && apt-get install -y \
-  build-essential \
-  libsnmp-dev \
-  snmp-mibs-downloader
-
+# Pull published snmp_exporter dependency so that we have access to
+# shared code in the snmp_exporter project
 RUN go get github.com/prometheus/snmp_exporter/generator
+
+WORKDIR /go/src/github.com/prometheus/snmp_exporter/generator/
+
+# Copy local generator directory so we can develop locally and test
+COPY . .
+RUN go get -v . && go install
 
 # Move the default generator file to the expected location
 RUN cp /go/src/github.com/prometheus/snmp_exporter/generator/generator.yml /opt/
-RUN cd /go/src/github.com/prometheus/snmp_exporter/generator && go install
 
 WORKDIR "/opt"
 
-# Run in a shell - redirect stdout to /dev/null and spit out the resulting config
-CMD /go/bin/generator generate > /dev/null 2>&1 && cat /opt/snmp.yml
+ENTRYPOINT ["/go/bin/generator"]
+
+CMD ["generate"]

--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -2,15 +2,10 @@ FROM golang:latest
 
 RUN apt-get update && apt-get install -y libsnmp-dev
 
-# Pull published snmp_exporter dependency so that we have access to
-# shared code in the snmp_exporter project
 RUN go get github.com/prometheus/snmp_exporter/generator
-
-WORKDIR /go/src/github.com/prometheus/snmp_exporter/generator/
-
-# Copy local generator directory so we can develop locally and test
-COPY . .
-RUN go get -v . && go install
+RUN cd /go/src/github.com/prometheus/snmp_exporter/generator \
+    go get -v . && \
+    go install
 
 # Move the default generator file to the expected location
 RUN cp /go/src/github.com/prometheus/snmp_exporter/generator/generator.yml /opt/

--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -1,0 +1,20 @@
+FROM golang:1.9.2
+
+# snmp-mibs-downloader is in the multiverse
+RUN echo "deb http://http.us.debian.org/debian stretch non-free" >> /etc/apt/sources.list
+
+RUN apt-get update && apt-get install -y \
+  build-essential \
+  libsnmp-dev \
+  snmp-mibs-downloader
+
+RUN go get github.com/prometheus/snmp_exporter/generator
+
+# Move the default generator file to the expected location
+RUN cp /go/src/github.com/prometheus/snmp_exporter/generator/generator.yml /opt/
+RUN cd /go/src/github.com/prometheus/snmp_exporter/generator && go install
+
+WORKDIR "/opt"
+
+# Run in a shell - redirect stdout to /dev/null and spit out the resulting config
+CMD /go/bin/generator generate > /dev/null 2>&1 && cat /opt/snmp.yml

--- a/generator/README.md
+++ b/generator/README.md
@@ -31,7 +31,7 @@ If you would like to run the generator in docker to generate your `snmp.yml` con
 ```
 docker build -t snmp-generator .
 docker run -ti \
-  -v $PWD/mibs:/root/.snmp/mibs \
+  -v $$HOME/.snmp/mibs:/root/.snmp/mibs \
   -v $PWD/generator.yml:/opt/generator.yml:ro \
   -v $PWD/out/:/opt/ \
   snmp-generator generate

--- a/generator/README.md
+++ b/generator/README.md
@@ -29,15 +29,7 @@ Additional command are available for debugging, use the `help` command to see th
 If you would like to run the generator in docker to generate your `snmp.yml` config run the following commands.
 
 ```
-# Build the image
 docker build -t snmp-generator .
-
-# The following command will:
-# - Mount the directory containing your MIB files to /root/.snmp/mibs \
-# - Mount your generator.yml to working directory \
-# - Mount a directory for the resulting config file \
-# - Run the generator with output directory defined (inside the container) \
-
 docker run -ti \
   -v $PWD/mibs:/root/.snmp/mibs \
   -v $PWD/generator.yml:/opt/generator.yml:ro \

--- a/generator/README.md
+++ b/generator/README.md
@@ -33,8 +33,8 @@ docker build -t snmp-generator .
 docker run -ti \
   -v $PWD/mibs:/root/.snmp/mibs \
   -v $PWD/generator.yml:/opt/generator.yml:ro \
-  -v $PWD/out/:/opt/build \
-  snmp-generator generate -o /opt/build
+  -v $PWD/out/:/opt/ \
+  snmp-generator generate
 ```
 
 ## File Format

--- a/generator/README.md
+++ b/generator/README.md
@@ -31,7 +31,7 @@ If you would like to run the generator in docker to generate your `snmp.yml` con
 ```
 docker build -t snmp-generator .
 docker run -ti \
-  -v $$HOME/.snmp/mibs:/root/.snmp/mibs \
+  -v $HOME/.snmp/mibs:/root/.snmp/mibs \
   -v $PWD/generator.yml:/opt/generator.yml:ro \
   -v $PWD/out/:/opt/ \
   snmp-generator generate

--- a/generator/README.md
+++ b/generator/README.md
@@ -32,13 +32,17 @@ If you would like to run the generator in docker to generate your `snmp.yml` con
 # Build the image
 docker build -t snmp-generator .
 
-# Mount the directory containing your MIB files to
-# /root/.snmp/mibs and your generator.yml to /opt/generator.yml inside
-# the running container, run the generator and write the resulting
-# snmp.yml to stdout (which is then written to ./snmp.yml on your
-# host machine with "> snmp.yml")
+# The following command will:
+# - Mount the directory containing your MIB files to /root/.snmp/mibs \
+# - Mount your generator.yml to working directory \
+# - Mount a directory for the resulting config file \
+# - Run the generator with output directory defined (inside the container) \
 
-docker run -ti -v path/to/mibs:/root/.snmp/mibs -v path/to/generator.yml:/opt/generator.yml:ro snmp-generator > snmp.yml
+docker run -ti \
+  -v $PWD/mibs:/root/.snmp/mibs \
+  -v $PWD/generator.yml:/opt/generator.yml:ro \
+  -v $PWD/out/:/opt/build \
+  snmp-generator generate -o /opt/build
 ```
 
 ## File Format

--- a/generator/README.md
+++ b/generator/README.md
@@ -24,6 +24,23 @@ The generator reads in from `generator.yml` and writes to `snmp.yml`.
 
 Additional command are available for debugging, use the `help` command to see them.
 
+## Docker Users
+
+If you would like to run the generator in docker to generate your `snmp.yml` config run the following commands.
+
+```
+# Build the image
+docker build -t snmp-generator .
+
+# Mount the directory containing your MIB files to
+# /root/.snmp/mibs and your generator.yml to /opt/generator.yml inside
+# the running container, run the generator and write the resulting
+# snmp.yml to stdout (which is then written to ./snmp.yml on your
+# host machine with "> snmp.yml")
+
+docker run -ti -v path/to/mibs:/root/.snmp/mibs -v path/to/generator.yml:/opt/generator.yml:ro snmp-generator > snmp.yml
+```
+
 ## File Format
 
 `generator.yml` provides a list of modules. The simplest module is just a name

--- a/generator/main.go
+++ b/generator/main.go
@@ -16,21 +16,21 @@ import (
 
 // Generate a snmp_exporter config and write it out.
 func generateConfig(nodes *Node, nameToNode map[string]*Node) {
-	if *outputDir == "" {
+	if *outputPath == "" {
 		currentDir, err := os.Getwd()
 		if err != nil {
 			log.Fatal(err)
 		}
 		log.Infof("No output directory specified writing to %s", currentDir)
-		outputDir = &currentDir
+		outputPath = &currentDir
 	}
 
-	outputDir, err := filepath.Abs(*outputDir)
+	outputPath, err := filepath.Abs(*outputPath)
 	if err != nil {
 		log.Fatal("Unable to determine absolute path for output")
 	}
 
-	outputPath := fmt.Sprintf("%s/snmp.yml", outputDir)
+	filePath := fmt.Sprintf("%s/snmp.yml", outputPath)
 
 	content, err := ioutil.ReadFile("generator.yml")
 	if err != nil {
@@ -63,7 +63,7 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node) {
 		log.Fatalf("Error parsing generated config: %s", err)
 	}
 
-	f, err := os.Create(outputPath)
+	f, err := os.Create(filePath)
 	if err != nil {
 		log.Fatalf("Error opening output file: %s", err)
 	}
@@ -71,12 +71,12 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node) {
 	if err != nil {
 		log.Fatalf("Error writing to output file: %s", err)
 	}
-	log.Infof("Config written to %s", outputPath)
+	log.Infof("Config written to %s", filePath)
 }
 
 var (
 	generateCommand    = kingpin.Command("generate", "Generate snmp.yml from generator.yml")
-	outputDir          = generateCommand.Flag("output-dir", "Directory to write resulting config file").Short('o').String()
+	outputPath         = generateCommand.Flag("output-path", "Path to to write resulting config file").Short('o').String()
 	parseErrorsCommand = kingpin.Command("parse_errors", "Debug: Print the parse errors output by NetSNMP")
 	dumpCommand        = kingpin.Command("dump", "Debug: Dump the parsed and prepared MIBs")
 )

--- a/generator/main.go
+++ b/generator/main.go
@@ -16,21 +16,10 @@ import (
 
 // Generate a snmp_exporter config and write it out.
 func generateConfig(nodes *Node, nameToNode map[string]*Node) {
-	if *outputPath == "" {
-		currentDir, err := os.Getwd()
-		if err != nil {
-			log.Fatal(err)
-		}
-		log.Infof("No output directory specified writing to %s", currentDir)
-		outputPath = &currentDir
-	}
-
 	outputPath, err := filepath.Abs(*outputPath)
 	if err != nil {
 		log.Fatal("Unable to determine absolute path for output")
 	}
-
-	filePath := fmt.Sprintf("%s/snmp.yml", outputPath)
 
 	content, err := ioutil.ReadFile("generator.yml")
 	if err != nil {
@@ -63,7 +52,7 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node) {
 		log.Fatalf("Error parsing generated config: %s", err)
 	}
 
-	f, err := os.Create(filePath)
+	f, err := os.Create(outputPath)
 	if err != nil {
 		log.Fatalf("Error opening output file: %s", err)
 	}
@@ -71,12 +60,12 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node) {
 	if err != nil {
 		log.Fatalf("Error writing to output file: %s", err)
 	}
-	log.Infof("Config written to %s", filePath)
+	log.Infof("Config written to %s", outputPath)
 }
 
 var (
 	generateCommand    = kingpin.Command("generate", "Generate snmp.yml from generator.yml")
-	outputPath         = generateCommand.Flag("output-path", "Path to to write resulting config file").Short('o').String()
+	outputPath         = generateCommand.Flag("output-path", "Path to to write resulting config file").Default("snmp.yml").Short('o').String()
 	parseErrorsCommand = kingpin.Command("parse_errors", "Debug: Print the parse errors output by NetSNMP")
 	dumpCommand        = kingpin.Command("dump", "Debug: Dump the parsed and prepared MIBs")
 )

--- a/generator/main.go
+++ b/generator/main.go
@@ -15,6 +15,7 @@ import (
 
 // Generate a snmp_exporter config and write it out.
 func generateConfig(nodes *Node, nameToNode map[string]*Node) {
+	outputPath := fmt.Sprintf("%s/snmp.yml", *outputDir)
 	content, err := ioutil.ReadFile("generator.yml")
 	if err != nil {
 		log.Fatalf("Error reading yml config: %s", err)
@@ -46,7 +47,7 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node) {
 		log.Fatalf("Error parsing generated config: %s", err)
 	}
 
-	f, err := os.Create("snmp.yml")
+	f, err := os.Create(outputPath)
 	if err != nil {
 		log.Fatalf("Error opening output file: %s", err)
 	}
@@ -54,13 +55,14 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node) {
 	if err != nil {
 		log.Fatalf("Error writing to output file: %s", err)
 	}
-	log.Infof("Config written to snmp.yml")
+	log.Infof("Config written to %s", outputPath)
 }
 
 var (
 	generateCommand    = kingpin.Command("generate", "Generate snmp.yml from generator.yml")
 	parseErrorsCommand = kingpin.Command("parse_errors", "Debug: Print the parse errors output by NetSNMP")
 	dumpCommand        = kingpin.Command("dump", "Debug: Dump the parsed and prepared MIBs")
+	outputDir          = kingpin.Flag("output-dir", "Directory to write resulting config file").Default("/opt").Short('o').String()
 )
 
 func main() {


### PR DESCRIPTION
This PR adds a dockerfile which simplifies building the generator, reading MIB files (mounted in the running container), and generating the resulting snmp.yml.
