### PR TITLE
Improve relabel config documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ scrape_configs:
       - source_labels: [__param_target]
         target_label: instance
       - target_label: __address__
-        replacement: 127.0.0.1:9116  # SNMP exporter.
+        replacement: 127.0.0.1:9116  # The SNMP exporter's real hostname:port.
 ```
 
 This setup allows Prometheus to provide scheduling and service discovery, as


### PR DESCRIPTION
Improve the clarity of how to use the relabel config to adjust the
SNMP exporter target.

Closes: https://github.com/prometheus/snmp_exporter/issues/260