### PR TITLE
update gosnmp and add support for opaque float/double

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -200,6 +200,8 @@ func pduToSamples(indexOids []int, pdu *gosnmp.SnmpPDU, metric *config.Metric, o
 		t = prometheus.CounterValue
 	case "gauge":
 		t = prometheus.GaugeValue
+	case "Float", "Double":
+		t = prometheus.GaugeValue
 	default:
 		// It's some form of string.
 		t = prometheus.GaugeValue
@@ -267,6 +269,10 @@ func pduValueAsString(pdu *gosnmp.SnmpPDU, typ string) string {
 		return strconv.FormatUint(uint64(pdu.Value.(uint)), 10)
 	case uint64:
 		return strconv.FormatUint(pdu.Value.(uint64), 10)
+	case float32:
+		return strconv.FormatFloat(float64(pdu.Value.(float32)), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(pdu.Value.(float64), 'f', -1, 64)
 	case string:
 		if pdu.Type == gosnmp.ObjectIdentifier {
 			// Trim leading period.

--- a/collector.go
+++ b/collector.go
@@ -172,6 +172,10 @@ func getPduValue(pdu *gosnmp.SnmpPDU) float64 {
 	switch pdu.Type {
 	case gosnmp.Counter64:
 		return float64(gosnmp.ToBigInt(pdu.Value).Uint64())
+	case gosnmp.OpaqueFloat:
+		return float64(pdu.Value.(float32))
+	case gosnmp.OpaqueDouble:
+		return pdu.Value.(float64)
 	default:
 		return float64(gosnmp.ToBigInt(pdu.Value).Int64())
 	}

--- a/collector_test.go
+++ b/collector_test.go
@@ -403,6 +403,14 @@ func TestPduValueAsString(t *testing.T) {
 			pdu:    &gosnmp.SnmpPDU{Value: nil},
 			result: "",
 		},
+		{
+			pdu:    &gosnmp.SnmpPDU{Value: float32(10.1), Type: gosnmp.OpaqueFloat},
+			result: "10.1",
+		},
+		{
+			pdu:    &gosnmp.SnmpPDU{Value: 10.1, Type: gosnmp.OpaqueDouble},
+			result: "10.1",
+		},
 	}
 	for _, c := range cases {
 		got := pduValueAsString(c.pdu, c.typ)

--- a/collector_test.go
+++ b/collector_test.go
@@ -228,6 +228,38 @@ func TestPduToSample(t *testing.T) {
 			oidToPdu:        make(map[string]gosnmp.SnmpPDU),
 			expectedMetrics: map[string]string{`label:<name:"test_metric" value:"-2" > gauge:<value:1 > `: `Desc{fqName: "test_metric", help: "Help string", constLabels: {}, variableLabels: [test_metric]}`},
 		},
+		{
+			pdu: &gosnmp.SnmpPDU{
+				Name:  "1.1.1.1.1",
+				Type:  gosnmp.OpaqueFloat,
+				Value: float32(3.0),
+			},
+			indexOids: []int{},
+			metric: &config.Metric{
+				Name: "test_metric",
+				Oid:  "1.1.1.1.1",
+				Type: "gauge",
+				Help: "Help string",
+			},
+			oidToPdu:        make(map[string]gosnmp.SnmpPDU),
+			expectedMetrics: map[string]string{"gauge:<value:3 > ": `Desc{fqName: "test_metric", help: "Help string", constLabels: {}, variableLabels: []}`},
+		},
+		{
+			pdu: &gosnmp.SnmpPDU{
+				Name:  "1.1.1.1.1",
+				Type:  gosnmp.OpaqueDouble,
+				Value: float64(3.0),
+			},
+			indexOids: []int{},
+			metric: &config.Metric{
+				Name: "test_metric",
+				Oid:  "1.1.1.1.1",
+				Type: "gauge",
+				Help: "Help string",
+			},
+			oidToPdu:        make(map[string]gosnmp.SnmpPDU),
+			expectedMetrics: map[string]string{"gauge:<value:3 > ": `Desc{fqName: "test_metric", help: "Help string", constLabels: {}, variableLabels: []}`},
+		},
 	}
 
 	for i, c := range cases {

--- a/generator/FORMAT.md
+++ b/generator/FORMAT.md
@@ -21,6 +21,8 @@ module_name:
      #   OctetString: A bit string, rendered as 0xff34.
      #   DisplayString: An ASCII or UTF-8 string.
      #   PhysAddress48: A 48 bit MAC address, rendered as 00:01:02:03:04:ff.
+     #   Float: A 32 bit floating-point value with type gauge.
+     #   Double: A 64 bit floating-point value with type gauge.
      # Non-numeric types are represented as a gauge with value 1, and the rendered value
      # as a label value on that gauge.
 

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -95,12 +95,10 @@ func prepareTree(nodes *Node) map[string]*Node {
 		}
 	})
 
-	// Promote Opaque Float/Double textual convention to type
+	// Promote Opaque Float/Double textual convention to type.
 	walkNode(nodes, func(n *Node) {
-		if n.Type == "OPAQUE" {
-			if n.TextualConvention == "Float" || n.TextualConvention == "Double" {
-				n.Type = n.TextualConvention
-			}
+		if n.TextualConvention == "Float" || n.TextualConvention == "Double" {
+			n.Type = n.TextualConvention
 		}
 	})
 
@@ -120,12 +118,8 @@ func metricType(t string) (string, bool) {
 	case "NETADDR":
 		// TODO: Not sure about this one.
 		return "InetAddress", true
-	case "PhysAddress48", "DisplayString":
+	case "PhysAddress48", "DisplayString", "Float", "Double":
 		return t, true
-	case "Float":
-		return "Float", true
-	case "Double":
-		return "Double", true
 	default:
 		// Unsupported type.
 		return "", false

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -95,12 +95,24 @@ func prepareTree(nodes *Node) map[string]*Node {
 		}
 	})
 
+	// Promote Opaque Float/Double textual convention to type
+	walkNode(nodes, func(n *Node) {
+		if n.Type == "OPAQUE" {
+			if strings.EqualFold(n.TextualConvention, "float") {
+				n.Type = "FLOAT"
+			} else if strings.EqualFold(n.TextualConvention, "double") {
+				n.Type = "DOUBLE"
+			}
+		}
+	})
+
 	return nameToNode
 }
 
 func metricType(t string) (string, bool) {
 	switch t {
-	case "INTEGER", "GAUGE", "TIMETICKS", "UINTEGER", "UNSIGNED32", "INTEGER32":
+	case "INTEGER", "GAUGE", "TIMETICKS", "UINTEGER", "UNSIGNED32", "INTEGER32",
+		"FLOAT", "DOUBLE":
 		return "gauge", true
 	case "COUNTER", "COUNTER64":
 		return "counter", true

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -98,10 +98,8 @@ func prepareTree(nodes *Node) map[string]*Node {
 	// Promote Opaque Float/Double textual convention to type
 	walkNode(nodes, func(n *Node) {
 		if n.Type == "OPAQUE" {
-			if strings.EqualFold(n.TextualConvention, "float") {
-				n.Type = "FLOAT"
-			} else if strings.EqualFold(n.TextualConvention, "double") {
-				n.Type = "DOUBLE"
+			if n.TextualConvention == "Float" || n.TextualConvention == "Double" {
+				n.Type = n.TextualConvention
 			}
 		}
 	})
@@ -111,8 +109,7 @@ func prepareTree(nodes *Node) map[string]*Node {
 
 func metricType(t string) (string, bool) {
 	switch t {
-	case "INTEGER", "GAUGE", "TIMETICKS", "UINTEGER", "UNSIGNED32", "INTEGER32",
-		"FLOAT", "DOUBLE":
+	case "INTEGER", "GAUGE", "TIMETICKS", "UINTEGER", "UNSIGNED32", "INTEGER32":
 		return "gauge", true
 	case "COUNTER", "COUNTER64":
 		return "counter", true
@@ -125,6 +122,10 @@ func metricType(t string) (string, bool) {
 		return "InetAddress", true
 	case "PhysAddress48", "DisplayString":
 		return t, true
+	case "Float":
+		return "Float", true
+	case "Double":
+		return "Double", true
 	default:
 		// Unsupported type.
 		return "", false

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -95,11 +95,11 @@ func TestTreePrepare(t *testing.T) {
 		// Opaques converted.
 		{
 			in:  &Node{Oid: "1", Type: "OPAQUE", TextualConvention: "Float"},
-			out: &Node{Oid: "1", Type: "FLOAT", TextualConvention: "Float"},
+			out: &Node{Oid: "1", Type: "Float", TextualConvention: "Float"},
 		},
 		{
 			in:  &Node{Oid: "1", Type: "OPAQUE", TextualConvention: "Double"},
-			out: &Node{Oid: "1", Type: "DOUBLE", TextualConvention: "Double"},
+			out: &Node{Oid: "1", Type: "Double", TextualConvention: "Double"},
 		},
 	}
 	for i, c := range cases {
@@ -251,6 +251,8 @@ func TestGenerateConfigModule(t *testing.T) {
 					{Oid: "1.26", Access: "ACCESS_READONLY", Label: "MODCOMP", Type: "MODCOMP"},
 					{Oid: "1.27", Access: "ACCESS_READONLY", Label: "OBJIDENTITY", Type: "OBJIDENTITY"},
 					{Oid: "1.100", Access: "ACCESS_READONLY", Label: "MacAddress", Type: "OCTETSTR", Hint: "1x:"},
+					{Oid: "1.200", Access: "ACCESS_READONLY", Label: "Float", Type: "OPAQUE", TextualConvention: "Float"},
+					{Oid: "1.201", Access: "ACCESS_READONLY", Label: "Double", Type: "OPAQUE", TextualConvention: "Double"},
 				}},
 			cfg: &ModuleConfig{
 				Walk: []string{"root", "1.3"},
@@ -335,6 +337,18 @@ func TestGenerateConfigModule(t *testing.T) {
 						Oid:  "1.100",
 						Type: "PhysAddress48",
 						Help: " - 1.100",
+					},
+					{
+						Name: "Float",
+						Oid:  "1.200",
+						Type: "Float",
+						Help: " - 1.200",
+					},
+					{
+						Name: "Double",
+						Oid:  "1.201",
+						Type: "Double",
+						Help: " - 1.201",
 					},
 				},
 			},
@@ -787,42 +801,6 @@ func TestGenerateConfigModule(t *testing.T) {
 								Oid:       "1.1.1.2",
 							},
 						},
-					},
-				},
-			},
-		},
-		// Opaque Float becomes gauge
-		{
-			node: &Node{Oid: "1", Access: "ACCESS_READONLY", Type: "OPAQUE", TextualConvention: "Float", Label: "root"},
-			cfg: &ModuleConfig{
-				Walk: []string{"root"},
-			},
-			out: &config.Module{
-				Walk: []string{"1"},
-				Metrics: []*config.Metric{
-					{
-						Name: "root",
-						Oid:  "1",
-						Type: "gauge",
-						Help: " - 1",
-					},
-				},
-			},
-		},
-		// Opaque Double becomes gauge
-		{
-			node: &Node{Oid: "1", Access: "ACCESS_READONLY", Type: "OPAQUE", TextualConvention: "Double", Label: "root"},
-			cfg: &ModuleConfig{
-				Walk: []string{"root"},
-			},
-			out: &config.Module{
-				Walk: []string{"1"},
-				Metrics: []*config.Metric{
-					{
-						Name: "root",
-						Oid:  "1",
-						Type: "gauge",
-						Help: " - 1",
 					},
 				},
 			},

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -92,6 +92,15 @@ func TestTreePrepare(t *testing.T) {
 			in:  &Node{Oid: "1", Label: "utf8", Hint: "255t"},
 			out: &Node{Oid: "1", Label: "utf8", Hint: "255t", Type: "DisplayString"},
 		},
+		// Opaques converted.
+		{
+			in:  &Node{Oid: "1", Type: "OPAQUE", TextualConvention: "Float"},
+			out: &Node{Oid: "1", Type: "FLOAT", TextualConvention: "Float"},
+		},
+		{
+			in:  &Node{Oid: "1", Type: "OPAQUE", TextualConvention: "Double"},
+			out: &Node{Oid: "1", Type: "DOUBLE", TextualConvention: "Double"},
+		},
 	}
 	for i, c := range cases {
 		// Indexes always end up initilized.
@@ -778,6 +787,42 @@ func TestGenerateConfigModule(t *testing.T) {
 								Oid:       "1.1.1.2",
 							},
 						},
+					},
+				},
+			},
+		},
+		// Opaque Float becomes gauge
+		{
+			node: &Node{Oid: "1", Access: "ACCESS_READONLY", Type: "OPAQUE", TextualConvention: "Float", Label: "root"},
+			cfg: &ModuleConfig{
+				Walk: []string{"root"},
+			},
+			out: &config.Module{
+				Walk: []string{"1"},
+				Metrics: []*config.Metric{
+					{
+						Name: "root",
+						Oid:  "1",
+						Type: "gauge",
+						Help: " - 1",
+					},
+				},
+			},
+		},
+		// Opaque Double becomes gauge
+		{
+			node: &Node{Oid: "1", Access: "ACCESS_READONLY", Type: "OPAQUE", TextualConvention: "Double", Label: "root"},
+			cfg: &ModuleConfig{
+				Walk: []string{"root"},
+			},
+			out: &config.Module{
+				Walk: []string{"1"},
+				Metrics: []*config.Metric{
+					{
+						Name: "root",
+						Oid:  "1",
+						Type: "gauge",
+						Help: " - 1",
 					},
 				},
 			},

--- a/vendor/github.com/soniah/gosnmp/AUTHORS.md
+++ b/vendor/github.com/soniah/gosnmp/AUTHORS.md
@@ -2,6 +2,7 @@
 
 * Jon Auer (@jda)
 * Chris Dance (@codedance)
+* Michał Derkacz (michal@Lnet.pl)
 * Jacob Dubinsky (@jdubinsky)
 * Eduardo Ferro (@eferro)
 * Mattias Folke (@msfe)
@@ -12,6 +13,7 @@
 * Marcin Jurczuk (@mrspock)
 * Andreas Louca (@alouca)
 * Toni Moreno (@toni-moreno)
+* Patryk Najda (@patrox)
 * Nathan Owens (@virtuallynathan)
 * Whitham Reeve (@wdreeveii)
 * Benjamin Thomas (@benjamin-thomas)

--- a/vendor/github.com/soniah/gosnmp/LICENSE
+++ b/vendor/github.com/soniah/gosnmp/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2012 Andreas Louca and Jon Auer, 2013 Sonia Hamilton. All
+Copyright 2012 Andreas Louca, 2012-2108 Sonia Hamilton. All
 rights reserved.  Use of this source code is governed by a BSD-style
 license that can be found in the LICENSE file.
 

--- a/vendor/github.com/soniah/gosnmp/README.md
+++ b/vendor/github.com/soniah/gosnmp/README.md
@@ -11,12 +11,10 @@ IPv6, using __SNMPv2c__ or __SNMPv3__.
 About
 -----
 
-**soniah/gosnmp** is based on **alouca/gosnmp** - many thanks to Andreas
-Louca for starting the project, other contributors (AUTHORS.md) and
-these project collaborators:
+**soniah/gosnmp** was originally based on **alouca/gosnmp**, but has been
+completely rewritten. Many thanks to Andreas Louca, other contributors
+(AUTHORS.md) and these project collaborators:
 
-* Chris Dance ([@codedance](https://github.com/codedance/))
-* Nathan Owens ([@virtuallynathan](https://github.com/virtuallynathan/))
 * Whitham Reeve ([@wdreeveii](https://github.com/wdreeveii/))
 
 Sonia Hamilton, sonia@snowfrog.net, http://www.snowfrog.net.
@@ -31,17 +29,17 @@ GoSNMP has the following SNMP functions:
 * **GetBulk**
 * **Walk** - retrieves a subtree of values using GETNEXT.
 * **BulkWalk** - retrieves a subtree of values using GETBULK.
-* **Set** - supports Integers and OctetStrings
-* **SendTrap** - send TRAPs
-* **Listen** - act as an NMS for receiving TRAPs
+* **Set** - supports Integers and OctetStrings.
+* **SendTrap** - send SNMP TRAPs.
+* **Listen** - act as an NMS for receiving TRAPs.
 
 GoSNMP has the following **helper** functions:
 
 * **ToBigInt** - treat returned values as `*big.Int`
 * **Partition** - facilitates dividing up large slices of OIDs
 
-**soniah/gosnmp** has diverged _significantly_ from **alouca/gosnmp**.
-Your code will require modification in these (and other) locations:
+**soniah/gosnmp** has completely diverged from **alouca/gosnmp**, your code
+will require modification in these (and other) locations:
 
 * the **Get** function has a different method signature
 * the **NewGoSNMP** function has been removed, use **Connect** instead
@@ -163,6 +161,7 @@ The following BER types have been implemented:
 * 0x41 Counter32
 * 0x42 Gauge32
 * 0x43 TimeTicks
+* 0x44 Opaque (Float & Double)
 * 0x46 Counter64
 * 0x47 Uinteger32
 * 0x80 NoSuchObject
@@ -176,7 +175,6 @@ time or haven't been able to find example devices to query:
 * 0x01 Boolean
 * 0x03 BitString
 * 0x07 ObjectDescription
-* 0x44 Opaque
 * 0x45 NsapAddress
 
 Packet Captures
@@ -256,5 +254,5 @@ conditions as the Go language. The rest of the code is under a BSD license.
 
 See the LICENSE file for more details.
 
-The remaining code is Copyright 2012-2016 the GoSNMP Authors - see
+The remaining code is Copyright 2012-2018 the GoSNMP Authors - see
 AUTHORS.md for a list of authors.

--- a/vendor/github.com/soniah/gosnmp/generic_e2e_test.go
+++ b/vendor/github.com/soniah/gosnmp/generic_e2e_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 The GoSNMP Authors. All rights reserved.  Use of this
+// Copyright 2012-2018 The GoSNMP Authors. All rights reserved.  Use of this
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
@@ -8,6 +8,8 @@
 //
 // Ensure "gosnmp-test-host" is defined in your hosts file, and points to your
 // generic test system.
+
+// +build all end2end
 
 package gosnmp
 

--- a/vendor/github.com/soniah/gosnmp/gosnmp.go
+++ b/vendor/github.com/soniah/gosnmp/gosnmp.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 The GoSNMP Authors. All rights reserved.  Use of this
+// Copyright 2012-2018 The GoSNMP Authors. All rights reserved.  Use of this
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
@@ -115,7 +115,6 @@ var Default = &GoSNMP{
 
 // SnmpPDU will be used when doing SNMP Set's
 type SnmpPDU struct {
-
 	// Name is an oid in string format eg ".1.3.6.1.4.9.27"
 	Name string
 
@@ -130,15 +129,18 @@ type SnmpPDU struct {
 	Logger Logger
 }
 
+// AsnExtensionID mask to identify types > 30 in subsequent byte
+const AsnExtensionID = 0x1F
+
 // Asn1BER is the type of the SNMP PDU
 type Asn1BER byte
 
 // Asn1BER's - http://www.ietf.org/rfc/rfc1442.txt
 const (
 	EndOfContents     Asn1BER = 0x00
-	UnknownType               = 0x00 // TODO these should all be type Asn1BER, however
-	Boolean                   = 0x01 // tests fail if implemented. See for example
-	Integer                   = 0x02 /// http://stackoverflow.com/questions/5037610/typed-constant-declaration-list.
+	UnknownType               = 0x00
+	Boolean                   = 0x01
+	Integer                   = 0x02
 	BitString                 = 0x03
 	OctetString               = 0x04
 	Null                      = 0x05
@@ -152,6 +154,8 @@ const (
 	NsapAddress               = 0x45
 	Counter64                 = 0x46
 	Uinteger32                = 0x47
+	OpaqueFloat               = 0x78
+	OpaqueDouble              = 0x79
 	NoSuchObject              = 0x80
 	NoSuchInstance            = 0x81
 	EndOfMibView              = 0x82

--- a/vendor/github.com/soniah/gosnmp/gosnmp_api_test.go
+++ b/vendor/github.com/soniah/gosnmp/gosnmp_api_test.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 The GoSNMP Authors. All rights reserved.  Use of this
+// Copyright 2012-2018 The GoSNMP Authors. All rights reserved.  Use of this
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
@@ -6,6 +6,8 @@
 //
 // IMPORTANT: If you're modifying _any_ existing code in this file, you
 // should be asking yourself about API compatibility!
+
+// +build all api
 
 package gosnmp_test // force external view
 

--- a/vendor/github.com/soniah/gosnmp/helper.go
+++ b/vendor/github.com/soniah/gosnmp/helper.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 The GoSNMP Authors. All rights reserved.  Use of this
+// Copyright 2012-2018 The GoSNMP Authors. All rights reserved.  Use of this
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
@@ -66,6 +66,11 @@ func Check(err error) {
 
 func (x *GoSNMP) decodeValue(data []byte, msg string) (retVal *variable, err error) {
 	retVal = new(variable)
+
+	// values matching this mask have the type in subsequent byte
+	if data[0]&AsnExtensionID == AsnExtensionID {
+		data = data[1:]
+	}
 
 	switch Asn1BER(data[0]) {
 
@@ -155,13 +160,20 @@ func (x *GoSNMP) decodeValue(data []byte, msg string) (retVal *variable, err err
 		// 0x43
 		x.logPrint("decodeValue: type is TimeTicks")
 		length, cursor := parseLength(data)
-		ret, err := parseInt(data[cursor:length])
+		ret, err := parseUint(data[cursor:length])
 		if err != nil {
 			x.logPrintf("decodeValue: err is %v", err)
 			break
 		}
 		retVal.Type = TimeTicks
 		retVal.Value = ret
+	case Opaque:
+		// 0x44
+		x.logPrint("decodeValue: type is Opaque")
+		length, cursor := parseLength(data)
+		opaqueData := data[cursor:length]
+		// recursively decode opaque data
+		return x.decodeValue(opaqueData, msg)
 	case Counter64:
 		// 0x46
 		x.logPrint("decodeValue: type is Counter64")
@@ -173,6 +185,18 @@ func (x *GoSNMP) decodeValue(data []byte, msg string) (retVal *variable, err err
 		}
 		retVal.Type = Counter64
 		retVal.Value = ret
+	case OpaqueFloat:
+		// 0x78
+		x.logPrint("decodeValue: type is OpaqueFloat")
+		length, cursor := parseLength(data)
+		retVal.Type = OpaqueFloat
+		retVal.Value, err = parseFloat32(data[cursor:length])
+	case OpaqueDouble:
+		// 0x79
+		x.logPrint("decodeValue: type is OpaqueDouble")
+		length, cursor := parseLength(data)
+		retVal.Type = OpaqueDouble
+		retVal.Value, err = parseFloat64(data[cursor:length])
 	case NoSuchObject:
 		// 0x80
 		x.logPrint("decodeValue: type is NoSuchObject")
@@ -451,7 +475,7 @@ func oidToString(oid []int) (ret string) {
 	return strings.Join(oidAsString, ".")
 }
 
-// MrSpock changes. TODO NO tests for this yet - waiting for .pcap
+// TODO no tests
 func ipv4toBytes(ip net.IP) []byte {
 	return []byte(ip)[12:]
 }
@@ -619,9 +643,9 @@ func parseRawField(data []byte, msg string) (interface{}, int, error) {
 		}
 	case TimeTicks:
 		length, cursor := parseLength(data)
-		ret, err := parseInt(data[cursor:length])
+		ret, err := parseUint(data[cursor:length])
 		if err != nil {
-			return nil, 0, fmt.Errorf("Error in parseInt: %s", err)
+			return nil, 0, fmt.Errorf("Error in parseUint: %s", err)
 		}
 		return ret, length, nil
 	}
@@ -655,6 +679,26 @@ func parseUint(bytes []byte) (uint, error) {
 		return 0, errors.New("integer too large")
 	}
 	return uint(ret64), nil
+}
+
+func parseFloat32(bytes []byte) (ret float32, err error) {
+	if len(bytes) > 4 {
+		// We'll overflow a uint64 in this case.
+		err = errors.New("float too large")
+		return
+	}
+	ret = math.Float32frombits(binary.BigEndian.Uint32(bytes))
+	return
+}
+
+func parseFloat64(bytes []byte) (ret float64, err error) {
+	if len(bytes) > 8 {
+		// We'll overflow a uint64 in this case.
+		err = errors.New("float too large")
+		return
+	}
+	ret = math.Float64frombits(binary.BigEndian.Uint64(bytes))
+	return
 }
 
 // Issue 4389: math/big: add SetUint64 and Uint64 functions to *Int

--- a/vendor/github.com/soniah/gosnmp/helper_test.go
+++ b/vendor/github.com/soniah/gosnmp/helper_test.go
@@ -1,6 +1,8 @@
-// Copyright 2012-2016 The GoSNMP Authors. All rights reserved.  Use of this
+// Copyright 2012-2018 The GoSNMP Authors. All rights reserved.  Use of this
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
+
+// +build all helper
 
 package gosnmp
 

--- a/vendor/github.com/soniah/gosnmp/marshal_test.go
+++ b/vendor/github.com/soniah/gosnmp/marshal_test.go
@@ -1,6 +1,8 @@
-// Copyright 2012-2016 The GoSNMP Authors. All rights reserved.  Use of this
+// Copyright 2012-2018 The GoSNMP Authors. All rights reserved.  Use of this
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
+
+// +build all marshal
 
 package gosnmp
 
@@ -622,6 +624,40 @@ var testsUnmarshal = []struct {
 			},
 		},
 	},
+	{opaqueFloatResponse,
+		&SnmpPacket{
+			Version:    Version2c,
+			Community:  "public",
+			PDUType:    GetResponse,
+			RequestID:  601216773,
+			Error:      0,
+			ErrorIndex: 0,
+			Variables: []SnmpPDU{
+				{
+					Name:  ".1.3.6.1.4.1.6574.4.2.12.1.0",
+					Type:  OpaqueFloat,
+					Value: float32(10.0),
+				},
+			},
+		},
+	},
+	{opaqueDoubleResponse,
+		&SnmpPacket{
+			Version:    Version2c,
+			Community:  "public",
+			PDUType:    GetResponse,
+			RequestID:  601216773,
+			Error:      0,
+			ErrorIndex: 0,
+			Variables: []SnmpPDU{
+				{
+					Name:  ".1.3.6.1.4.1.6574.4.2.12.1.0",
+					Type:  OpaqueDouble,
+					Value: float64(10.0),
+				},
+			},
+		},
+	},
 }
 
 func TestUnmarshal(t *testing.T) {
@@ -706,6 +742,14 @@ SANITY:
 				}
 			case Null, NoSuchObject, NoSuchInstance:
 				if (vb.Value != nil) || (vbr.Value != nil) {
+					t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+				}
+			case OpaqueFloat:
+				if vb.Value.(float32) != vbr.Value.(float32) {
+					t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
+				}
+			case OpaqueDouble:
+				if vb.Value.(float64) != vbr.Value.(float64) {
 					t.Errorf("#%d:%d Value result: %v, test: %v", i, n, vbr.Value, vb.Value)
 				}
 			default:
@@ -1205,6 +1249,34 @@ func counter64Response() []byte {
 		0x02, 0x01, 0x00, 0x30, 0x14, 0x30, 0x12, 0x06, 0x0b, 0x2b, 0x06, 0x01,
 		0x02, 0x01, 0x1f, 0x01, 0x01, 0x01, 0x0a, 0x01, 0x46, 0x03, 0x17, 0x50,
 		0x87,
+	}
+}
+
+/*
+Opaque Float, observed from Synology NAS UPS MIB
+ snmpget -v 2c -c public host 1.3.6.1.4.1.6574.4.2.12.1.0
+*/
+func opaqueFloatResponse() []byte {
+	return []byte{
+		0x30, 0x34, 0x02, 0x01, 0x01, 0x04, 0x06, 0x70, 0x75, 0x62, 0x6c, 0x69,
+		0x63, 0xa2, 0x27, 0x02, 0x04, 0x23, 0xd5, 0xd7, 0x05, 0x02, 0x01, 0x00,
+		0x02, 0x01, 0x00, 0x30, 0x19, 0x30, 0x17, 0x06, 0x0c, 0x2b, 0x06, 0x01,
+		0x04, 0x01, 0xb3, 0x2e, 0x04, 0x02, 0x0c, 0x01, 0x00, 0x44, 0x07, 0x9f,
+		0x78, 0x04, 0x41, 0x20, 0x00, 0x00,
+	}
+}
+
+/*
+Opaque Double, not observed, crafted based on description:
+ https://tools.ietf.org/html/draft-perkins-float-00
+*/
+func opaqueDoubleResponse() []byte {
+	return []byte{
+		0x30, 0x38, 0x02, 0x01, 0x01, 0x04, 0x06, 0x70, 0x75, 0x62, 0x6c, 0x69,
+		0x63, 0xa2, 0x2b, 0x02, 0x04, 0x23, 0xd5, 0xd7, 0x05, 0x02, 0x01, 0x00,
+		0x02, 0x01, 0x00, 0x30, 0x1d, 0x30, 0x17, 0x06, 0x0c, 0x2b, 0x06, 0x01,
+		0x04, 0x01, 0xb3, 0x2e, 0x04, 0x02, 0x0c, 0x01, 0x00, 0x44, 0x0b, 0x9f,
+		0x79, 0x08, 0x40, 0x24, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
 	}
 }
 

--- a/vendor/github.com/soniah/gosnmp/misc_test.go
+++ b/vendor/github.com/soniah/gosnmp/misc_test.go
@@ -1,6 +1,8 @@
-// Copyright 2012-2016 The GoSNMP Authors. All rights reserved.  Use of this
+// Copyright 2012-2018 The GoSNMP Authors. All rights reserved.  Use of this
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
+
+// +build all misc
 
 package gosnmp
 

--- a/vendor/github.com/soniah/gosnmp/trap.go
+++ b/vendor/github.com/soniah/gosnmp/trap.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 The GoSNMP Authors. All rights reserved.  Use of this
+// Copyright 2012-2018 The GoSNMP Authors. All rights reserved.  Use of this
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
@@ -26,33 +26,53 @@ import (
 // Management Station).
 //
 // See also Listen() and examples for creating an NMS.
-func (x *GoSNMP) SendTrap(pdus []SnmpPDU) (result *SnmpPacket, err error) {
+func (x *GoSNMP) SendTrap(trap SnmpTrap) (result *SnmpPacket, err error) {
+	var pdutype PDUType
+
+	if len(trap.Variables) == 0 {
+		return nil, fmt.Errorf("SendTrap requires at least 1 PDU")
+	}
+
+	if trap.Variables[0].Type == TimeTicks {
+		// check is uint32
+		if _, ok := trap.Variables[0].Value.(uint32); !ok {
+			return nil, fmt.Errorf("SendTrap TimeTick must be uint32")
+		}
+	}
+
 	switch x.Version {
 	case Version2c, Version3:
-		// do nothing
+		pdutype = SNMPv2Trap
+
+		if trap.Variables[0].Type != TimeTicks {
+			now := uint32(time.Now().Unix())
+			timetickPDU := SnmpPDU{"1.3.6.1.2.1.1.3.0", TimeTicks, now, x.Logger}
+			// prepend timetickPDU
+			trap.Variables = append([]SnmpPDU{timetickPDU}, trap.Variables...)
+		}
+
+	case Version1:
+		pdutype = Trap
+		if len(trap.Enterprise) == 0 {
+			return nil, fmt.Errorf("SendTrap for SNMPV1 requires an Enterprise OID")
+		}
+		if len(trap.AgentAddress) == 0 {
+			return nil, fmt.Errorf("SendTrap for SNMPV1 requires an Agent Address")
+		}
+
 	default:
 		err = fmt.Errorf("SendTrap doesn't support %s", x.Version)
 		return nil, err
 	}
 
-	if len(pdus) == 0 {
-		return nil, fmt.Errorf("Sendtrap requires at least 1 pdu")
+	packetOut := x.mkSnmpPacket(pdutype, trap.Variables, 0, 0)
+	if x.Version == Version1 {
+		packetOut.Enterprise = trap.Enterprise
+		packetOut.AgentAddress = trap.AgentAddress
+		packetOut.GenericTrap = trap.GenericTrap
+		packetOut.SpecificTrap = trap.SpecificTrap
+		packetOut.Timestamp = trap.Timestamp
 	}
-
-	if pdus[0].Type == TimeTicks {
-		// check is uint32
-		if _, ok := pdus[0].Value.(uint32); !ok {
-			return nil, fmt.Errorf("Sendtrap TimeTick must be uint32")
-		}
-	}
-
-	// add a timetick to start, set to now
-	now := uint32(time.Now().Unix())
-	timetickPDU := SnmpPDU{"1.3.6.1.2.1.1.3.0", TimeTicks, now, x.Logger}
-	// prepend timetickPDU
-	pdus = append([]SnmpPDU{timetickPDU}, pdus...)
-
-	packetOut := x.mkSnmpPacket(SNMPv2Trap, pdus, 0, 0)
 
 	// all sends wait for the return packet, except for SNMPv2Trap
 	// -> wait is false
@@ -66,35 +86,48 @@ func (x *GoSNMP) SendTrap(pdus []SnmpPDU) (result *SnmpPacket, err error) {
 // GoSNMP.unmarshal() currently only handles SNMPv2Trap (ie v2c, v3)
 //
 
-// A TrapListener defineds parameters for running a SNMP Trap receiver.
+// A TrapListener defines parameters for running a SNMP Trap receiver.
 // nil values will be replaced by default values.
 type TrapListener struct {
+	sync.Mutex
 	OnNewTrap func(s *SnmpPacket, u *net.UDPAddr)
 	Params    *GoSNMP
 
-	// these unexported fields are for letting test cases
-	// know we are ready
-	listening bool
-	c         *sync.Cond
-	m         sync.Mutex
+	// These unexported fields are for letting test cases
+	// know we are ready.
+	conn      *net.UDPConn
+	finish    chan bool
+	done      chan bool
+	listening chan bool
 }
 
-// optional constructor for TrapListener
+// NewTrapListener returns an initialized TrapListener.
 func NewTrapListener() *TrapListener {
 	tl := &TrapListener{}
-	tl.c = sync.NewCond(&sync.Mutex{})
+	tl.finish = make(chan bool)
+	tl.done = make(chan bool)
+	// Buffered because one doesn't have to block on it.
+	tl.listening = make(chan bool, 1)
 	return tl
 }
 
-// safely check if TrapListener is ready and listening
-func (t *TrapListener) ready() bool {
-	t.m.Lock()
-	defer t.m.Unlock()
+// Listening returns a sentinel channel on which one can block
+// until the listener is ready to receive requests.
+func (t *TrapListener) Listening() <-chan bool {
+	t.Lock()
+	defer t.Unlock()
 	return t.listening
 }
 
+// Close terminates the listening on TrapListener socket
+func (t *TrapListener) Close() {
+	t.conn.Close()
+	t.finish <- true
+	<-t.done
+}
+
 // Listen listens on the UDP address addr and calls the OnNewTrap
-// function specified in *TrapListener for every trap recieved.
+// function specified in *TrapListener for every trap received.
 func (t *TrapListener) Listen(addr string) (err error) {
 	if t.Params == nil {
 		t.Params = Default
@@ -109,41 +142,36 @@ func (t *TrapListener) Listen(addr string) (err error) {
 	if err != nil {
 		return err
 	}
-
 	conn, err := net.ListenUDP("udp", udpAddr)
 	if err != nil {
 		return err
 	}
+	t.conn = conn
 	defer conn.Close()
 
-	// mark that we are listening now
-	func() {
-		t.m.Lock()
-		defer t.m.Unlock()
-		t.listening = true
-		t.c.Broadcast()
-	}()
-
-	// don't forget to mark that we are no longer listening later on
-	defer func() {
-		t.m.Lock()
-		defer t.m.Unlock()
-		t.listening = false
-		t.c.Broadcast()
-	}()
+	// Mark that we are listening now.
+	t.listening <- true
 
 	for {
-		var buf [4096]byte
-		rlen, remote, err := conn.ReadFromUDP(buf[:])
-		if err != nil {
-			t.Params.logPrintf("TrapListener: error in read %s\n", err)
+		select {
+		case <-t.finish:
+			t.done <- true
+			return
+
+		default:
+			var buf [4096]byte
+			rlen, remote, err := conn.ReadFromUDP(buf[:])
+			if err != nil {
+				t.Params.logPrintf("TrapListener: error in read %s\n", err)
+			}
+
+			msg := buf[:rlen]
+			traps := t.Params.UnmarshalTrap(msg)
+			if traps != nil {
+				t.OnNewTrap(traps, remote)
+			}
 		}
 
-		msg := buf[:rlen]
-		traps := t.Params.unmarshalTrap(msg)
-		if traps != nil {
-			t.OnNewTrap(traps, remote)
-		}
 	}
 }
 
@@ -152,8 +180,8 @@ func debugTrapHandler(s *SnmpPacket, u *net.UDPAddr) {
 	log.Printf("got trapdata from %+v: %+v\n", u, s)
 }
 
-// Unmarshal SNMP Trap
-func (x *GoSNMP) unmarshalTrap(trap []byte) (result *SnmpPacket) {
+// UnmarshalTrap unpacks the SNMP Trap.
+func (x *GoSNMP) UnmarshalTrap(trap []byte) (result *SnmpPacket) {
 	result = new(SnmpPacket)
 
 	if x.SecurityParameters != nil {
@@ -162,7 +190,7 @@ func (x *GoSNMP) unmarshalTrap(trap []byte) (result *SnmpPacket) {
 
 	cursor, err := x.unmarshalHeader(trap, result)
 	if err != nil {
-		x.logPrintf("unmarshalTrap: %s\n", err)
+		x.logPrintf("UnmarshalTrap: %s\n", err)
 		return nil
 	}
 
@@ -170,7 +198,7 @@ func (x *GoSNMP) unmarshalTrap(trap []byte) (result *SnmpPacket) {
 		if result.SecurityModel == UserSecurityModel {
 			err = x.testAuthentication(trap, result)
 			if err != nil {
-				x.logPrintf("unmarshalTrap v3 auth: %s\n", err)
+				x.logPrintf("UnmarshalTrap v3 auth: %s\n", err)
 				return nil
 			}
 		}
@@ -178,7 +206,7 @@ func (x *GoSNMP) unmarshalTrap(trap []byte) (result *SnmpPacket) {
 	}
 	err = x.unmarshalPayload(trap, cursor, result)
 	if err != nil {
-		x.logPrintf("unmarshalTrap: %s\n", err)
+		x.logPrintf("UnmarshalTrap: %s\n", err)
 		return nil
 	}
 	return result

--- a/vendor/github.com/soniah/gosnmp/v3.go
+++ b/vendor/github.com/soniah/gosnmp/v3.go
@@ -1,6 +1,6 @@
 package gosnmp
 
-// Copyright 2012-2016 The GoSNMP Authors. All rights reserved.  Use of this
+// Copyright 2012-2018 The GoSNMP Authors. All rights reserved.  Use of this
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 

--- a/vendor/github.com/soniah/gosnmp/walk.go
+++ b/vendor/github.com/soniah/gosnmp/walk.go
@@ -1,4 +1,4 @@
-// Copyright 2012-2016 The GoSNMP Authors. All rights reserved.  Use of this
+// Copyright 2012-2018 The GoSNMP Authors. All rights reserved.  Use of this
 // source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -401,10 +401,10 @@
 			"revisionTime": "2017-08-21T07:31:01Z"
 		},
 		{
-			"checksumSHA1": "Dz2Bic+6H0Yg/eeZnDYdCPxTBWg=",
+			"checksumSHA1": "YBv42NkWiFP+5+kiXeEwTQ1oRQo=",
 			"path": "github.com/soniah/gosnmp",
-			"revision": "9e43ddcdf483fefbf03e30d033510d4c981292ac",
-			"revisionTime": "2017-10-05T16:44:14Z"
+			"revision": "f15472a4cd6f6ea7929e4c7d9f163c49f059924f",
+			"revisionTime": "2018-02-19T07:25:37Z"
 		},
 		{
 			"checksumSHA1": "Y9SmG2U/qez70e6PIe03dts063Y=",


### PR DESCRIPTION
updated vendored version of gosnmp to latest, which now supports
returning values from opaque float and double

updated generator to recognize opaque float/double and configure
it to work as a gauge

updated collector to extract these values correctly

@brian-brazil 