### PR TITLE
Remove incorrect InetAddress implementation.

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -379,31 +379,6 @@ func indexOidsAsString(indexOids []int, typ string, fixedSize int) (string, []in
 		}
 		// ASCII, so can convert staight to utf-8.
 		return string(parts), subOid, indexOids
-	case "InetAddress":
-		addressType, indexOids := splitOid(indexOids, 1)
-		octets, indexOids := splitOid(indexOids, 1)
-		address, indexOids := splitOid(indexOids, octets[0])
-		subOid := append(addressType, octets...)
-		subOid = append(subOid, address...)
-		if addressType[0] == 1 { // IPv4.
-			parts := make([]string, 4)
-			for i, o := range address {
-				parts[i] = strconv.Itoa(o)
-			}
-			return strings.Join(parts, "."), subOid, indexOids
-		} else if addressType[0] == 2 { // IPv6.
-			parts := make([]string, 8)
-			for i := 0; i < 8; i++ {
-				parts[i] = fmt.Sprintf("%02X%02X", address[i*2], address[i*2+1])
-			}
-			return strings.Join(parts, ":"), subOid, indexOids
-		} else { // Unknown, treat as OctetString.
-			parts := make([]byte, octets[0])
-			for i, o := range address {
-				parts[i] = byte(o)
-			}
-			return fmt.Sprintf("0x%X", string(parts)), subOid, indexOids
-		}
 	case "IpAddr":
 		subOid, indexOids := splitOid(indexOids, 4)
 		parts := make([]string, 4)

--- a/collector_test.go
+++ b/collector_test.go
@@ -530,42 +530,6 @@ func TestIndexesToLabels(t *testing.T) {
 			result:   map[string]string{"l": "octet"},
 		},
 		{
-			oid:      []int{1, 4, 192, 168, 1, 2},
-			metric:   config.Metric{Indexes: []*config.Index{{Labelname: "l", Type: "InetAddress"}}},
-			oidToPdu: map[string]gosnmp.SnmpPDU{},
-			result:   map[string]string{"l": "192.168.1.2"},
-		},
-		{
-			oid: []int{1, 4, 192, 168, 1, 2, 7},
-			metric: config.Metric{
-				Indexes: []*config.Index{{Labelname: "l", Type: "InetAddress"}, {Labelname: "b", Type: "gauge"}},
-				Lookups: []*config.Lookup{{Labels: []string{"l"}, Labelname: "l", Oid: "3"}},
-			},
-			oidToPdu: map[string]gosnmp.SnmpPDU{"3.1.4.192.168.1.2": gosnmp.SnmpPDU{Value: "ipv4"}},
-			result:   map[string]string{"l": "ipv4", "b": "7"},
-		},
-		{
-			oid:      []int{2, 16, 42, 6, 29, 128, 0, 1, 0, 3, 0, 0, 0, 0, 0, 1, 1, 52},
-			metric:   config.Metric{Indexes: []*config.Index{{Labelname: "l", Type: "InetAddress"}}},
-			oidToPdu: map[string]gosnmp.SnmpPDU{},
-			result:   map[string]string{"l": "2A06:1D80:0001:0003:0000:0000:0001:0134"},
-		},
-		{
-			oid:      []int{3, 1, 9},
-			metric:   config.Metric{Indexes: []*config.Index{{Labelname: "l", Type: "InetAddress"}}},
-			oidToPdu: map[string]gosnmp.SnmpPDU{},
-			result:   map[string]string{"l": "0x09"},
-		},
-		{
-			oid: []int{2, 16, 42, 6, 29, 128, 0, 1, 0, 3, 0, 0, 0, 0, 0, 1, 1, 52, 7},
-			metric: config.Metric{
-				Indexes: []*config.Index{{Labelname: "l", Type: "InetAddress"}, {Labelname: "b", Type: "gauge"}},
-				Lookups: []*config.Lookup{{Labels: []string{"l"}, Labelname: "l", Oid: "3"}},
-			},
-			oidToPdu: map[string]gosnmp.SnmpPDU{"3.2.16.42.6.29.128.0.1.0.3.0.0.0.0.0.1.1.52": gosnmp.SnmpPDU{Value: "ipv6"}},
-			result:   map[string]string{"l": "ipv6", "b": "7"},
-		},
-		{
 			oid:      []int{192, 168, 1, 2},
 			metric:   config.Metric{Indexes: []*config.Index{{Labelname: "l", Type: "IpAddr"}}},
 			oidToPdu: map[string]gosnmp.SnmpPDU{},

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -113,11 +113,8 @@ func metricType(t string) (string, bool) {
 		return "counter", true
 	case "OCTETSTR", "BITSTRING":
 		return "OctetString", true
-	case "IPADDR":
+	case "IPADDR", "NETADDR":
 		return "IpAddr", true
-	case "NETADDR":
-		// TODO: Not sure about this one.
-		return "InetAddress", true
 	case "PhysAddress48", "DisplayString", "Float", "Double":
 		return t, true
 	default:

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -296,7 +296,7 @@ func TestGenerateConfigModule(t *testing.T) {
 					{
 						Name: "NETADDR",
 						Oid:  "1.4",
-						Type: "InetAddress",
+						Type: "IpAddr",
 						Help: " - 1.4",
 					},
 					{
@@ -589,11 +589,11 @@ func TestGenerateConfigModule(t *testing.T) {
 						Name: "netaddrIndex",
 						Oid:  "1.4.1.1",
 						Help: " - 1.4.1.1",
-						Type: "InetAddress",
+						Type: "IpAddr",
 						Indexes: []*config.Index{
 							{
 								Labelname: "netaddrIndex",
-								Type:      "InetAddress",
+								Type:      "IpAddr",
 							},
 						},
 					},
@@ -605,7 +605,7 @@ func TestGenerateConfigModule(t *testing.T) {
 						Indexes: []*config.Index{
 							{
 								Labelname: "netaddrIndex",
-								Type:      "InetAddress",
+								Type:      "IpAddr",
 							},
 						},
 					},


### PR DESCRIPTION
It also turns out that NETADDR is a (depreceted) way
of having an ipv4 address.

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>

@SuperQ Looks like I got this completely wrong, so remove the bad code.