### PR TITLE
Unifi SNMP Version Fix

### DIFF
--- a/snmp.yml
+++ b/snmp.yml
@@ -10219,3 +10219,4 @@ ubiquiti_unifi:
     oid: 1.3.6.1.4.1.41112.1.6.3.6
     type: DisplayString
     help: ' - 1.3.6.1.4.1.41112.1.6.3.6'
+  version: 1


### PR DESCRIPTION
The existing UAPs leverage 'tinysnmp' which is a lightweight SNMP daemon, which in turn only supports SNMPv1.