### PR TITLE
Add metric name validation to config loader.

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -56,6 +56,7 @@ var (
 	DefaultRegexpExtract = RegexpExtract{
 		Value: "$1",
 	}
+	metricNameRE = regexp.MustCompile(`^[a-zA-Z_]([a-zA-Z0-9_])*$`)
 )
 
 // Config for the snmp_exporter.
@@ -82,6 +83,12 @@ func (c *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type plain Module
 	if err := unmarshal((*plain)(c)); err != nil {
 		return err
+	}
+
+	for _, m := range c.Metrics {
+		if !metricNameRE.MatchString(m.Name) {
+			return fmt.Errorf("invalid metric name %q", m.Name)
+		}
 	}
 
 	wp := c.WalkParams

--- a/config_test.go
+++ b/config_test.go
@@ -52,3 +52,12 @@ func TestLoadConfigWithOverrides(t *testing.T) {
 		t.Errorf("Error marshalling config: %v", err)
 	}
 }
+
+func TestLoadConfigWithInvalidMetricName(t *testing.T) {
+	testConfig := "testdata/snmp-invalid-metric-name.yml"
+	sc := &SafeConfig{}
+	err := sc.ReloadConfig(testConfig)
+	if err == nil {
+		t.Errorf("Did not get error loading config %v: %v", testConfig, err)
+	}
+}

--- a/testdata/snmp-invalid-metric-name.yml
+++ b/testdata/snmp-invalid-metric-name.yml
@@ -1,0 +1,11 @@
+if_mib:
+  walk:
+  - 1.3.6.1.2.1.2
+  get:
+  - 1.3.6.1.2.1.1.3.0
+  metrics:
+  - name: sys.UpTime
+    oid: 1.3.6.1.2.1.1.3
+    type: gauge
+    help: The time (in hundredths of a second) since the network management portion
+      of the system was last re-initialized. - 1.3.6.1.2.1.1.3


### PR DESCRIPTION
Avoid loading invalid config files by passing metric names through the
validator regexp.

Closes: https://github.com/prometheus/snmp_exporter/issues/315