### PR TITLE
Hard code version for AirMax devices in generator config

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -206,6 +206,7 @@ modules:
 # https://dl.ubnt.com/firmwares/airos-ubnt-mib/ubnt-mib.zip
 #
   ubiquiti_airmax:
+    version: 1
     walk:
       - sysUpTime
       - interfaces

--- a/snmp.yml
+++ b/snmp.yml
@@ -8892,6 +8892,7 @@ synology:
       oid: 1.3.6.1.4.1.6574.6.1.1.2
       type: OctetString
 ubiquiti_airmax:
+  version: 1
   walk:
   - 1.3.6.1.2.1.2
   - 1.3.6.1.2.1.31.1.1

--- a/snmp.yml
+++ b/snmp.yml
@@ -8892,7 +8892,6 @@ synology:
       oid: 1.3.6.1.4.1.6574.6.1.1.2
       type: OctetString
 ubiquiti_airmax:
-  version: 1
   walk:
   - 1.3.6.1.2.1.2
   - 1.3.6.1.2.1.31.1.1

--- a/snmp.yml
+++ b/snmp.yml
@@ -9759,6 +9759,7 @@ ubiquiti_airmax:
     oid: 1.3.6.1.4.1.41112.1.4.8.4
     type: gauge
     help: Host system temperature - 1.3.6.1.4.1.41112.1.4.8.4
+  version: 1
 ubiquiti_unifi:
   walk:
   - 1.3.6.1.2.1.2


### PR DESCRIPTION
This pull request updates the `ubiquiti_airmax` section of the default `snmp.yml` files to be hard coded to use SNMP v1 since that's all that it supports.

I've run into the problem outlined in https://github.com/prometheus/snmp_exporter/issues/313 a few times now, and thought that this might save someone the trouble of investigating in the future.