### PR TITLE
Add support for RFC 2579 DateAndTime

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -105,6 +105,7 @@ modules:
                              #   gauge:   An integer with type gauge.
                              #   counter: An integer with type counter.
                              #   OctetString: A bit string, rendered as 0xff34.
+                             #   DateAndTime: An RFC 2579 DateAndTime byte sequence. If the device has no time zone data, UTC is used.
                              #   DisplayString: An ASCII or UTF-8 string.
                              #   PhysAddress48: A 48 bit MAC address, rendered as 00:01:02:03:04:ff.
                              #   Float: A 32 bit floating-point value with type gauge.

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -115,6 +115,13 @@ func prepareTree(nodes *Node) map[string]*Node {
 		}
 	})
 
+	// Convert RFC 2579 DateAndTime textual conversion to type.
+	walkNode(nodes, func(n *Node) {
+		if n.TextualConvention == "DateAndTime" {
+			n.Type = "DateAndTime"
+		}
+	})
+
 	return nameToNode
 }
 
@@ -129,6 +136,8 @@ func metricType(t string) (string, bool) {
 	case "IpAddr", "IPADDR", "NETADDR":
 		return "IpAddr", true
 	case "PhysAddress48", "DisplayString", "Float", "Double":
+		return t, true
+	case "DateAndTime":
 		return t, true
 	default:
 		// Unsupported type.

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -90,8 +90,9 @@ func prepareTree(nodes *Node) map[string]*Node {
 	// is technically only ASCII.
 	displayStringRe := regexp.MustCompile(`^\d+[at]$`)
 
-	// Set type on MAC addresses and strings.
+	// Apply various tweaks to the types.
 	walkNode(nodes, func(n *Node) {
+		// Set type on MAC addresses and strings.
 		// RFC 2579
 		switch n.Hint {
 		case "1x:":
@@ -106,17 +107,13 @@ func prepareTree(nodes *Node) map[string]*Node {
 		if n.TextualConvention == "DisplayString" {
 			n.Type = "DisplayString"
 		}
-	})
 
-	// Promote Opaque Float/Double textual convention to type.
-	walkNode(nodes, func(n *Node) {
+		// Promote Opaque Float/Double textual convention to type.
 		if n.TextualConvention == "Float" || n.TextualConvention == "Double" {
 			n.Type = n.TextualConvention
 		}
-	})
 
-	// Convert RFC 2579 DateAndTime textual conversion to type.
-	walkNode(nodes, func(n *Node) {
+		// Convert RFC 2579 DateAndTime textual conversion to type.
 		if n.TextualConvention == "DateAndTime" {
 			n.Type = "DateAndTime"
 		}

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -119,6 +119,11 @@ func TestTreePrepare(t *testing.T) {
 			in:  &Node{Oid: "1", Type: "OPAQUE", TextualConvention: "Double"},
 			out: &Node{Oid: "1", Type: "Double", TextualConvention: "Double"},
 		},
+		// RFC 2579 DateAndTime.
+		{
+			in:  &Node{Oid: "1", Type: "DisplayString", TextualConvention: "DateAndTime"},
+			out: &Node{Oid: "1", Type: "DateAndTime", TextualConvention: "DateAndTime"},
+		},
 	}
 	for i, c := range cases {
 		// Indexes always end up initilized.
@@ -312,6 +317,7 @@ func TestGenerateConfigModule(t *testing.T) {
 					{Oid: "1.100", Access: "ACCESS_READONLY", Label: "MacAddress", Type: "OCTETSTR", Hint: "1x:"},
 					{Oid: "1.200", Access: "ACCESS_READONLY", Label: "Float", Type: "OPAQUE", TextualConvention: "Float"},
 					{Oid: "1.201", Access: "ACCESS_READONLY", Label: "Double", Type: "OPAQUE", TextualConvention: "Double"},
+					{Oid: "1.202", Access: "ACCESS_READONLY", Label: "DateAndTime", Type: "DisplayString", TextualConvention: "DateAndTime"},
 				}},
 			cfg: &ModuleConfig{
 				Walk: []string{"root", "1.3"},
@@ -408,6 +414,12 @@ func TestGenerateConfigModule(t *testing.T) {
 						Oid:  "1.201",
 						Type: "Double",
 						Help: " - 1.201",
+					},
+					{
+						Name: "DateAndTime",
+						Oid:  "1.202",
+						Type: "DateAndTime",
+						Help: " - 1.202",
 					},
 				},
 			},

--- a/snmp.yml
+++ b/snmp.yml
@@ -5788,7 +5788,7 @@ paloalto_fw:
     help: The amount of time since this host was last initialized - 1.3.6.1.2.1.25.1.1
   - name: hrSystemDate
     oid: 1.3.6.1.2.1.25.1.2
-    type: DisplayString
+    type: DateAndTime
     help: The host's notion of the local date and time of day. - 1.3.6.1.2.1.25.1.2
   - name: hrSystemInitialLoadDevice
     oid: 1.3.6.1.2.1.25.1.3
@@ -6047,7 +6047,7 @@ paloalto_fw:
       type: gauge
   - name: hrFSLastFullBackupDate
     oid: 1.3.6.1.2.1.25.3.8.1.8
-    type: DisplayString
+    type: DateAndTime
     help: The last date at which this complete file system was copied to another storage
       device for backup - 1.3.6.1.2.1.25.3.8.1.8
     indexes:
@@ -6055,7 +6055,7 @@ paloalto_fw:
       type: gauge
   - name: hrFSLastPartialBackupDate
     oid: 1.3.6.1.2.1.25.3.8.1.9
-    type: DisplayString
+    type: DateAndTime
     help: The last date at which a portion of this file system was copied to another
       storage device for backup - 1.3.6.1.2.1.25.3.8.1.9
     indexes:


### PR DESCRIPTION
Extract a UNIX timestamp from RFC 2579 DateAndTime textual conversions.
* Add support to the generator.
* Add support to the collector.
* Update snmp.yml with new DateAndTime metrics.

Fixes: https://github.com/prometheus/snmp_exporter/issues/321

Signed-off-by: Ben Kochie <superq@gmail.com>