### PR TITLE
Fix staticcheck linting

### DIFF
--- a/collector_test.go
+++ b/collector_test.go
@@ -145,7 +145,7 @@ func TestPduToSample(t *testing.T) {
 					"Blank": []config.RegexpExtract{
 						{
 							Regex: config.Regexp{
-								regexp.MustCompile("XXXX"),
+								regexp.MustCompile("^XXXX$"),
 							},
 							Value: "4",
 						},
@@ -161,13 +161,13 @@ func TestPduToSample(t *testing.T) {
 					"MultipleRegexes": []config.RegexpExtract{
 						{
 							Regex: config.Regexp{
-								regexp.MustCompile("XXXX"),
+								regexp.MustCompile("^XXXX$"),
 							},
 							Value: "123",
 						},
 						{
 							Regex: config.Regexp{
-								regexp.MustCompile("123"),
+								regexp.MustCompile("123.*"),
 							},
 							Value: "999",
 						},


### PR DESCRIPTION
Make regexps anchored to make staticcheck happy.

Signed-off-by: Ben Kochie <superq@gmail.com>