### PR TITLE
Install snmp-mibs-downloader in the generator's Dockerfile

### DIFF
--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:latest
 
-RUN apt-get update && apt-get install -y libsnmp-dev
+RUN sed -i 's/main$/main non-free/' /etc/apt/sources.list # Enable the non-free repository
+RUN apt-get update && apt-get install -y libsnmp-dev snmp-mibs-downloader
 
 RUN go get github.com/prometheus/snmp_exporter/generator
 RUN cd /go/src/github.com/prometheus/snmp_exporter/generator \


### PR DESCRIPTION
There are no MIBs installed by default in the generator Dockerfile. This enables the non-free debian repository and installs the `snmp-mibs-downloader` in the Docker image.