### PR TITLE
eliminate extra SNMP parsing error warning

### DIFF
--- a/generator/main.go
+++ b/generator/main.go
@@ -97,8 +97,10 @@ func main() {
 	command := kingpin.Parse()
 
 	parseErrors := initSNMP()
-	log.Warnf("NetSNMP reported %d parse errors", len(strings.Split(parseErrors, "\n")))
 
+	if len(parseErrors) != 0 {
+		log.Warnf("NetSNMP reported %d parse errors", len(strings.Split(parseErrors, "\n")))
+	}
 	nodes := getMIBTree()
 	nameToNode := prepareTree(nodes)
 


### PR DESCRIPTION
When parseErrors is empty, strings.Split(parseErrors, "\n") will return
[""]. This should not be reported as an error.