### PR TITLE
Add net-snmp-devel as a dependency for building the generator on RHEL

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -11,7 +11,7 @@ Due to the dynamic dependency on NetSNMP, you must build the generator yourself.
 # Debian-based distributions.
 sudo apt-get install build-essential libsnmp-dev # Debian-based distros
 # Redhat-based distributions.
-sudo yum install gcc gcc-g++ make net-snmp net-snmp-utils net-snmp-libs # RHEL-based distros
+sudo yum install gcc gcc-g++ make net-snmp net-snmp-utils net-snmp-libs net-snmp-devel # RHEL-based distros
 
 go get github.com/prometheus/snmp_exporter/generator
 cd ${GOPATH-$HOME/go}/src/github.com/prometheus/snmp_exporter/generator


### PR DESCRIPTION
cc: @SuperQ 

This is a real small fix to the generator README to address issue #345, which I also ran into today (RHEL 7.5)