### PR TITLE
Add looked up labels into LabelOids to allow using new label as a label for lookup

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -602,6 +602,7 @@ func indexesToLabels(indexOids []int, metric *config.Metric, oidToPdu map[string
 		}
 		if pdu, ok := oidToPdu[oid]; ok {
 			labels[lookup.Labelname] = pduValueAsString(&pdu, lookup.Type)
+			labelOids[lookup.Labelname] = oidToList(labels[lookup.Labelname])
 		} else {
 			labels[lookup.Labelname] = ""
 		}


### PR DESCRIPTION
This allows to use a label which is generated by lookups to also be used in lookups.
For example: 
```
  metrics:
  - name: mpegVideoSessionState
    oid: 1.3.6.1.4.1.5591.1.11.5.4.1.1.4.1.5
    type: gauge
    help: active means in-use, provisioned means not-in-use or active such as video
      session provisioned for redundant source. - 1.3.6.1.4.1.5591.1.11.5.4.1.1.4.1.5
    indexes:
    - labelname: mpegVideoSessionIndex
      type: gauge
    lookups:
    - labels:
      - mpegVideoSessionIndex
      - mpegVideoSessionIndex
      labelname: mmpegOutputUdpDestinationIfIndex
      oid: 1.3.6.1.4.1.5591.1.11.5.4.1.1.2.6.1.3
      type: gauge
    - labels:
      - mmpegOutputUdpDestinationIfIndex
      labelname: qamChannelFrequency
      oid: 1.3.6.1.4.1.5591.1.11.5.3.1.1.1.1.1
      type: gauge
```
