### PR TITLE
circleci: switch to 2.1 config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,5 @@
 ---
-version: 2
+version: 2.1
 
 jobs:
   test:


### PR DESCRIPTION
Similar to https://github.com/prometheus/prometheus/pull/4713 and https://github.com/prometheus/alertmanager/pull/1579. Once the 2.1 config is enabled, we can reduce duplication in `.circleci/config.yml` a bit.