### PR TITLE
Fix codespell issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The default `snmp.yml` covers a variety of common hardware for which
 MIBs are available to the public, walking them using SNMP v2 GETBULK.
 
 You'll need to use the generator in all but the simplest of setups. It is
-needed to customise which objects are walked, use non-public MIBs or specify
+needed to customize which objects are walked, use non-public MIBs or specify
 authentication parameters.
 
 ## Prometheus Configuration

--- a/config_test.go
+++ b/config_test.go
@@ -32,7 +32,7 @@ func TestHideConfigSecrets(t *testing.T) {
 	c, err := yaml.Marshal(sc.C)
 	sc.RUnlock()
 	if err != nil {
-		t.Errorf("Error marshalling config: %v", err)
+		t.Errorf("Error marshaling config: %v", err)
 	}
 	if strings.Contains(string(c), "mysecret") {
 		t.Fatal("config's String method reveals authentication credentials.")
@@ -49,6 +49,6 @@ func TestLoadConfigWithOverrides(t *testing.T) {
 	_, err = yaml.Marshal(sc.C)
 	sc.RUnlock()
 	if err != nil {
-		t.Errorf("Error marshalling config: %v", err)
+		t.Errorf("Error marshaling config: %v", err)
 	}
 }

--- a/generator/main.go
+++ b/generator/main.go
@@ -64,7 +64,7 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node) {
 	out, err := yaml.Marshal(outputConfig)
 	config.DoNotHideSecrets = false
 	if err != nil {
-		log.Fatalf("Error marshalling yml: %s", err)
+		log.Fatalf("Error marshaling yml: %s", err)
 	}
 
 	// Check the generated config to catch auth/version issues.

--- a/generator/net_snmp.go
+++ b/generator/net_snmp.go
@@ -126,7 +126,7 @@ var (
 	}
 )
 
-// Initialise NetSNMP. Returns MIB parse errors.
+// Initialize NetSNMP. Returns MIB parse errors.
 //
 // Warning: This function plays with the stderr file descriptor.
 func initSNMP() string {

--- a/generator/net_snmp.go
+++ b/generator/net_snmp.go
@@ -126,7 +126,7 @@ var (
 	}
 )
 
-// Initilise NetSNMP. Returns MIB parse errors.
+// Initialise NetSNMP. Returns MIB parse errors.
 //
 // Warning: This function plays with the stderr file descriptor.
 func initSNMP() string {
@@ -158,7 +158,7 @@ func initSNMP() string {
 		ch <- string(data)
 	}()
 
-	// Do the initilization.
+	// Do the initialization.
 	C.netsnmp_init_mib()
 
 	// Restore stderr to normal.

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -50,7 +50,7 @@ func prepareTree(nodes *Node) map[string]*Node {
 		nameToNode[n.Label] = n
 	})
 
-	// Trim down description to first sentance, removing extra whitespace.
+	// Trim down description to first sentence, removing extra whitespace.
 	walkNode(nodes, func(n *Node) {
 		s := strings.Join(strings.Fields(n.Description), " ")
 		n.Description = strings.Split(s, ". ")[0]

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -29,8 +29,8 @@ func TestTreePrepare(t *testing.T) {
 	}{
 		// Descriptions trimmed.
 		{
-			in:  &Node{Oid: "1", Description: "A long   sentance.      Even more detail!"},
-			out: &Node{Oid: "1", Description: "A long sentance"},
+			in:  &Node{Oid: "1", Description: "A long   sentence.      Even more detail!"},
+			out: &Node{Oid: "1", Description: "A long sentence"},
 		},
 		// Indexes copied down.
 		{
@@ -144,7 +144,7 @@ func TestTreePrepare(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		// Indexes always end up initilized.
+		// Indexes always end up initialized.
 		walkNode(c.out, func(n *Node) {
 			if n.Indexes == nil {
 				n.Indexes = []string{}
@@ -1705,7 +1705,7 @@ func TestGenerateConfigModule(t *testing.T) {
 		},
 	}
 	for i, c := range cases {
-		// Indexes and lookups always end up initilized.
+		// Indexes and lookups always end up initialized.
 		for _, m := range c.out.Metrics {
 			if m.Indexes == nil {
 				m.Indexes = []*config.Index{}

--- a/main.go
+++ b/main.go
@@ -144,7 +144,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error parsing config file: %s", err)
 	}
-	// Initialise metrics.
+	// Initialize metrics.
 	for module := range *sc.C {
 		snmpDuration.WithLabelValues(module)
 	}
@@ -208,7 +208,7 @@ func main() {
 		c, err := yaml.Marshal(sc.C)
 		sc.RUnlock()
 		if err != nil {
-			log.Warnf("Error marshalling configuration: %v", err)
+			log.Warnf("Error marshaling configuration: %v", err)
 			http.Error(w, err.Error(), 500)
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -144,7 +144,7 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error parsing config file: %s", err)
 	}
-	// Initilise metrics.
+	// Initialise metrics.
 	for module := range *sc.C {
 		snmpDuration.WithLabelValues(module)
 	}


### PR DESCRIPTION
Hi @brian-brazil @SuperQ ,

I fixed the misspellings issues reported by [codespell](https://github.com/codespell-project/codespell).

What is about adding this to CircleCI too? There is only one word to be excluded `uinit` and one file `snmp.yml` (because of the upstream mibs misspellings issues).
It should be something like `$ codespell -S './vendor*,./.git*' -L uint -x snmp.yml`.

Signed-off-by: Mario Trangoni <mjtrangoni@gmail.com>