### PR TITLE
Add dry-run option to validate configuration

### DIFF
--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ import (
 var (
 	configFile    = kingpin.Flag("config.file", "Path to configuration file.").Default("snmp.yml").String()
 	listenAddress = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9116").String()
+	dryRun        = kingpin.Flag("dry-run", "Only verify configuration is valid and exit.").Default("false").Bool()
 
 	// Metrics about the SNMP exporter itself.
 	snmpDuration = prometheus.NewSummaryVec(
@@ -144,6 +145,13 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error parsing config file: %s", err)
 	}
+
+	// Exit if in dry-run mode.
+	if *dryRun {
+		log.Infoln("Configuration parsed successfully.")
+		return
+	}
+
 	// Initialize metrics.
 	for module := range *sc.C {
 		snmpDuration.WithLabelValues(module)


### PR DESCRIPTION
Add dry-run flag to just parse configuration and exit. Fixes #355.

Signed-off-by: Silvio Gissi <silvio@gissilabs.com>