### PR TITLE
Warning comment on snmp.yaml being auto-generated

### DIFF
--- a/generator/main.go
+++ b/generator/main.go
@@ -77,6 +77,7 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node) {
 	if err != nil {
 		log.Fatalf("Error opening output file: %s", err)
 	}
+	out = append([]byte("# WARNING: This file was auto-generated using snmp_exporter generator, do not edit.\n"), out...)
 	_, err = f.Write(out)
 	if err != nil {
 		log.Fatalf("Error writing to output file: %s", err)

--- a/generator/main.go
+++ b/generator/main.go
@@ -77,7 +77,7 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node) {
 	if err != nil {
 		log.Fatalf("Error opening output file: %s", err)
 	}
-	out = append([]byte("# WARNING: This file was auto-generated using snmp_exporter generator, do not edit.\n"), out...)
+	out = append([]byte("# WARNING: This file was auto-generated using snmp_exporter generator, manual changes will be lost.\n"), out...)
 	_, err = f.Write(out)
 	if err != nil {
 		log.Fatalf("Error writing to output file: %s", err)

--- a/snmp.yml
+++ b/snmp.yml
@@ -1,3 +1,4 @@
+# WARNING: This file was auto-generated using snmp_exporter generator, manual changes will be lost.
 apcups:
   walk:
   - 1.3.6.1.2.1.2


### PR DESCRIPTION
Add a warning comment on snmp.yaml file being auto-generated. Fixes #326.

Signed-off-by: Silvio Gissi <silvio@gissilabs.com>