### PR TITLE
Include the name of the index in the error message when the generator can't handle an index

### DIFF
--- a/generator/tree.go
+++ b/generator/tree.go
@@ -344,7 +344,7 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 				}
 				index.Type, ok = metricType(indexNode.Type)
 				if !ok {
-					log.Warnf("Error, can't handle index type %s for node %s", indexNode.Type, n.Label)
+					log.Warnf("Error, can't handle index type %s for index %s on node %s", indexNode.Type, i, n.Label)
 					return
 				}
 				index.FixedSize = indexNode.FixedSize


### PR DESCRIPTION
I added this to help debug an error I was hitting, I can confirm that it helps.