### PR TITLE
Update generator readme.md to include full make

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -16,7 +16,7 @@ sudo yum install gcc gcc-g++ make net-snmp net-snmp-utils net-snmp-libs net-snmp
 go get github.com/prometheus/snmp_exporter/generator
 cd ${GOPATH-$HOME/go}/src/github.com/prometheus/snmp_exporter/generator
 go build
-make mibs
+make && make mibs
 ```
 
 ## Running


### PR DESCRIPTION
Centos 7 has an issue with the generator parsing the default MIBs when using just 'make mibs'. Instead running the full 'make' command inside generator resolves the unmet dependency and allows the generator to run correctly. Without running full make the generator will always fail on generating MIBs, even when more are added in later as one of the defaults is incorrectly functioning.