### PR TITLE
Add support for Printer MIB v2

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -14,20 +14,23 @@
 MIBDIR   := mibs
 MIB_PATH := 'mibs'
 
-APC_URL        := 'https://download.schneider-electric.com/files?p_File_Name=powernet426.mib'
-ARISTA_URL     := https://www.arista.com/assets/data/docs/MIBS
-CISCO_URL      := 'ftp://ftp.cisco.com/pub/mibs/v2/v2.tar.gz'
-FRAMEWORK_URL  := http://www.net-snmp.org/docs/mibs/SNMP-FRAMEWORK-MIB.txt
-KEEPALIVED_URL := 'https://raw.githubusercontent.com/acassen/keepalived/master/doc/KEEPALIVED-MIB.txt'
-MIKROTIK_URL   := 'http://download2.mikrotik.com/Mikrotik.mib'
-NET_SNMP_URL   := http://www.net-snmp.org/docs/mibs/NET-SNMP-MIB.txt
-NET_TC_URL     := http://www.net-snmp.org/docs/mibs/NET-SNMP-TC.txt
-PALOALTO_URL   := 'https://www.paloaltonetworks.com/content/dam/pan/en_US/assets/zip/technical-documentation/snmp-mib-modules/PAN-MIB-MODULES-7.0.zip'
-SERVERTECH_URL := 'ftp://ftp.servertech.com/Pub/SNMP/sentry3/Sentry3.mib'
-SYNOLOGY_URL   := 'https://global.download.synology.com/download/Document/MIBGuide/Synology_MIB_File.zip'
-UBNT_DL_URL    := http://dl.ubnt-ut.com/snmp
-UBNT_AIROS_URL := https://dl.ubnt.com/firmwares/airos-ubnt-mib/ubnt-mib.zip
-UCD_URL        := http://www.net-snmp.org/docs/mibs/UCD-SNMP-MIB.txt
+APC_URL          := 'https://download.schneider-electric.com/files?p_File_Name=powernet426.mib'
+ARISTA_URL       := https://www.arista.com/assets/data/docs/MIBS
+CISCO_URL        := 'ftp://ftp.cisco.com/pub/mibs/v2/v2.tar.gz'
+FRAMEWORK_URL    := http://www.net-snmp.org/docs/mibs/SNMP-FRAMEWORK-MIB.txt
+IANA_CHARSET_URL := https://www.iana.org/assignments/ianacharset-mib/ianacharset-mib
+IANA_PRINTER_URL := https://www.iana.org/assignments/ianaprinter-mib/ianaprinter-mib
+KEEPALIVED_URL   := 'https://raw.githubusercontent.com/acassen/keepalived/master/doc/KEEPALIVED-MIB.txt'
+MIKROTIK_URL     := 'http://download2.mikrotik.com/Mikrotik.mib'
+NET_SNMP_URL     := http://www.net-snmp.org/docs/mibs/NET-SNMP-MIB.txt
+NET_TC_URL       := http://www.net-snmp.org/docs/mibs/NET-SNMP-TC.txt
+PALOALTO_URL     := 'https://www.paloaltonetworks.com/content/dam/pan/en_US/assets/zip/technical-documentation/snmp-mib-modules/PAN-MIB-MODULES-7.0.zip'
+PRINTER_URL      := https://ftp.pwg.org/pub/pwg/pmp/mibs/rfc3805b.mib
+SERVERTECH_URL   := 'ftp://ftp.servertech.com/Pub/SNMP/sentry3/Sentry3.mib'
+SYNOLOGY_URL     := 'https://global.download.synology.com/download/Document/MIBGuide/Synology_MIB_File.zip'
+UBNT_DL_URL      := http://dl.ubnt-ut.com/snmp
+UBNT_AIROS_URL   := https://dl.ubnt.com/firmwares/airos-ubnt-mib/ubnt-mib.zip
+UCD_URL          := http://www.net-snmp.org/docs/mibs/UCD-SNMP-MIB.txt
 
 .DEFAULT: all
 
@@ -57,13 +60,16 @@ mibs: mib-dir \
   $(MIBDIR)/ARISTA-SMI-MIB \
   $(MIBDIR)/ARISTA-SW-IP-FORWARDING-MIB \
   $(MIBDIR)/cisco_v2 \
-  $(MIBDIR)/SNMP-FRAMEWORK-MIB \
+  $(MIBDIR)/IANA-CHARSET-MIB.txt \
+  $(MIBDIR)/IANA-PRINTER-MIB.txt \
   $(MIBDIR)/KEEPALIVED-MIB \
   $(MIBDIR)/MIKROTIK-MIB \
   $(MIBDIR)/NET-SNMP-MIB \
   $(MIBDIR)/NET-SNMP-TC \
   $(MIBDIR)/.paloalto_panos \
+  $(MIBDIR)/PRINTER-MIB-V2.txt \
   $(MIBDIR)/servertech-sentry3-mib \
+  $(MIBDIR)/SNMP-FRAMEWORK-MIB \
   $(MIBDIR)/.synology \
   $(MIBDIR)/UBNT-MIB \
   $(MIBDIR)/UBNT-UniFi-MIB \
@@ -108,10 +114,13 @@ $(MIBDIR)/cisco_v2:
 	cp mibs/cisco_v2/SNMPv2-SMI.my mibs/SNMPv2-SMI
 	cp mibs/cisco_v2/SNMPv2-TC.my mibs/SNMPv2-TC
 
+$(MIBDIR)/IANA-CHARSET-MIB.txt:
+	@echo ">> Donwloading IANA charset MIB"
+	@curl -s -o $(MIBDIR)/IANA-CHARSET-MIB.txt -L $(IANA_CHARSET_URL)
 
-$(MIBDIR)/SNMP-FRAMEWORK-MIB:
-	@echo ">> Downloading SNMP-FRAMEWORK-MIB"
-	@curl -s -o $(MIBDIR)/SNMP-FRAMEWORK-MIB -L $(FRAMEWORK_URL)
+$(MIBDIR)/IANA-PRINTER-MIB.txt:
+	@echo ">> Donwloading IANA printer MIB"
+	@curl -s -o $(MIBDIR)/IANA-PRINTER-MIB.txt -L $(IANA_PRINTER_URL)
 
 $(MIBDIR)/KEEPALIVED-MIB:
 	@echo ">> Downloading KEEPALIVED-MIB"
@@ -137,9 +146,17 @@ $(MIBDIR)/.paloalto_panos:
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.paloalto_panos
 
+$(MIBDIR)/PRINTER-MIB-V2.txt:
+	@echo ">> Downloading Printer MIB v2"
+	@curl -s -o $(MIBDIR)/PRINTER-MIB-V2.txt -L $(PRINTER_URL)
+
 $(MIBDIR)/servertech-sentry3-mib:
 	@echo ">> Downloading servertech-sentry3-mib"
 	@curl -s -o $(MIBDIR)/servertech-sentry3-mib -L $(SERVERTECH_URL)
+
+$(MIBDIR)/SNMP-FRAMEWORK-MIB:
+	@echo ">> Downloading SNMP-FRAMEWORK-MIB"
+	@curl -s -o $(MIBDIR)/SNMP-FRAMEWORK-MIB -L $(FRAMEWORK_URL)
 
 $(MIBDIR)/.synology:
 	$(eval TMP := $(shell mktemp))

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -291,3 +291,35 @@ modules:
         ignore: true # Non-metric display string.
       vrrpInstanceScriptMstrRxLowerPri:
         ignore: true # Non-metric display string.
+
+# Printer: RFC 3805
+#
+# https://tools.ietf.org/html/rfc3805
+# https://www.iana.org/assignments/ianaprinter-mib/ianaprinter-mib.xhtml
+  printer_mib:
+    walk:
+      - sysUpTime
+      - hrPrinterStatus
+      - prtGeneralReset
+      - prtConsoleDisable
+      - prtGeneralPrinterName
+      - prtGeneralSerialNumber
+      - prtAlertCriticalEvents
+      - prtAlertAllEvents
+      - prtCoverStatus
+      - prtMarkerSuppliesLevel
+      - prtMarkerSuppliesMaxCapacity
+    overrides:
+      hrPrinterStatus:
+        type: EnumAsStateSet
+      prtGeneralReset:
+        type: EnumAsStateSet
+      prtConsoleDisable:
+        type: EnumAsStateSet
+      prtGeneralPrinterName:
+        type: DisplayString
+      prtGeneralSerialNumber:
+        type: DisplayString
+      prtCoverStatus:
+        type: EnumAsStateSet
+

--- a/snmp.yml
+++ b/snmp.yml
@@ -8747,6 +8747,130 @@ paloalto_fw:
     oid: 1.3.6.1.4.1.25461.2.1.2.5.1.3
     type: gauge
     help: Number of active tunnels - 1.3.6.1.4.1.25461.2.1.2.5.1.3
+printer_mib:
+  walk:
+  - 1.3.6.1.2.1.25.3.5.1.1
+  - 1.3.6.1.2.1.43.11.1.1.8
+  - 1.3.6.1.2.1.43.11.1.1.9
+  - 1.3.6.1.2.1.43.5.1.1.13
+  - 1.3.6.1.2.1.43.5.1.1.16
+  - 1.3.6.1.2.1.43.5.1.1.17
+  - 1.3.6.1.2.1.43.5.1.1.18
+  - 1.3.6.1.2.1.43.5.1.1.19
+  - 1.3.6.1.2.1.43.5.1.1.3
+  - 1.3.6.1.2.1.43.6.1.1.3
+  get:
+  - 1.3.6.1.2.1.1.3.0
+  metrics:
+  - name: sysUpTime
+    oid: 1.3.6.1.2.1.1.3
+    type: gauge
+    help: The time (in hundredths of a second) since the network management portion
+      of the system was last re-initialized. - 1.3.6.1.2.1.1.3
+  - name: hrPrinterStatus
+    oid: 1.3.6.1.2.1.25.3.5.1.1
+    type: EnumAsStateSet
+    help: The current status of this printer device. - 1.3.6.1.2.1.25.3.5.1.1
+    indexes:
+    - labelname: hrDeviceIndex
+      type: gauge
+    enum_values:
+      1: other
+      2: unknown
+      3: idle
+      4: printing
+      5: warmup
+  - name: prtMarkerSuppliesMaxCapacity
+    oid: 1.3.6.1.2.1.43.11.1.1.8
+    type: gauge
+    help: The maximum capacity of this supply container/receptacle expressed in prtMarkerSuppliesSupplyUnit
+      - 1.3.6.1.2.1.43.11.1.1.8
+    indexes:
+    - labelname: hrDeviceIndex
+      type: gauge
+    - labelname: prtMarkerSuppliesIndex
+      type: gauge
+  - name: prtMarkerSuppliesLevel
+    oid: 1.3.6.1.2.1.43.11.1.1.9
+    type: gauge
+    help: The current level if this supply is a container; the remaining space if
+      this supply is a receptacle - 1.3.6.1.2.1.43.11.1.1.9
+    indexes:
+    - labelname: hrDeviceIndex
+      type: gauge
+    - labelname: prtMarkerSuppliesIndex
+      type: gauge
+  - name: prtConsoleDisable
+    oid: 1.3.6.1.2.1.43.5.1.1.13
+    type: EnumAsStateSet
+    help: This value indicates how input is (or is not) accepted from the operator
+      console - 1.3.6.1.2.1.43.5.1.1.13
+    indexes:
+    - labelname: hrDeviceIndex
+      type: gauge
+    enum_values:
+      3: enabled
+      4: disabled
+  - name: prtGeneralPrinterName
+    oid: 1.3.6.1.2.1.43.5.1.1.16
+    type: DisplayString
+    help: An administrator-specified name for this printer - 1.3.6.1.2.1.43.5.1.1.16
+    indexes:
+    - labelname: hrDeviceIndex
+      type: gauge
+  - name: prtGeneralSerialNumber
+    oid: 1.3.6.1.2.1.43.5.1.1.17
+    type: DisplayString
+    help: A recorded serial number for this device that indexes some type device catalog
+      or inventory - 1.3.6.1.2.1.43.5.1.1.17
+    indexes:
+    - labelname: hrDeviceIndex
+      type: gauge
+  - name: prtAlertCriticalEvents
+    oid: 1.3.6.1.2.1.43.5.1.1.18
+    type: counter
+    help: A running counter of the number of critical alert events that have been
+      recorded in the alert table - 1.3.6.1.2.1.43.5.1.1.18
+    indexes:
+    - labelname: hrDeviceIndex
+      type: gauge
+  - name: prtAlertAllEvents
+    oid: 1.3.6.1.2.1.43.5.1.1.19
+    type: counter
+    help: A running counter of the total number of alert event entries (critical and
+      non-critical) that have been recorded in the alert table - 1.3.6.1.2.1.43.5.1.1.19
+    indexes:
+    - labelname: hrDeviceIndex
+      type: gauge
+  - name: prtGeneralReset
+    oid: 1.3.6.1.2.1.43.5.1.1.3
+    type: EnumAsStateSet
+    help: Setting this value to 'powerCycleReset', 'resetToNVRAM', or 'resetToFactoryDefaults'
+      will result in the resetting of the printer - 1.3.6.1.2.1.43.5.1.1.3
+    indexes:
+    - labelname: hrDeviceIndex
+      type: gauge
+    enum_values:
+      3: notResetting
+      4: powerCycleReset
+      5: resetToNVRAM
+      6: resetToFactoryDefaults
+  - name: prtCoverStatus
+    oid: 1.3.6.1.2.1.43.6.1.1.3
+    type: EnumAsStateSet
+    help: The status of this cover sub-unit. - 1.3.6.1.2.1.43.6.1.1.3
+    indexes:
+    - labelname: hrDeviceIndex
+      type: gauge
+    - labelname: prtCoverIndex
+      type: gauge
+    enum_values:
+      1: other
+      2: unknown
+      3: coverOpen
+      4: coverClosed
+      5: interlockOpen
+      6: interlockClosed
 servertech_sentry3:
   walk:
   - 1.3.6.1.4.1.1718.3.2.2


### PR DESCRIPTION
This adds support for PRINTER-MIB-v2 as defined in RFC 3805. It allows for the monitoring of printers including their supply levels (toners/ink cartridges etc).

Signed-off-by: Daniele Sluijters <daenney@users.noreply.github.com>