### PR TITLE
append missing dependencies into generator/README.md

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -9,7 +9,7 @@ Due to the dynamic dependency on NetSNMP, you must build the generator yourself.
 
 ```
 # Debian-based distributions.
-sudo apt-get install build-essential libsnmp-dev # Debian-based distros
+sudo apt-get install unzip build-essential libsnmp-dev # Debian-based distros
 # Redhat-based distributions.
 sudo yum install gcc gcc-g++ make net-snmp net-snmp-utils net-snmp-libs net-snmp-devel # RHEL-based distros
 


### PR DESCRIPTION
unzip is required for make mibs, but it isn't installed on Ubuntu Server. so I append extra dependencies into README.md.

Signed-off-by: proelbtn <proelbtn@users.noreply.github.com>