### PR TITLE
Minor fixes to "make mibs"

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -134,15 +134,15 @@ $(MIBDIR)/.cisco_v2:
 	@touch $(MIBDIR)/.cisco_v2
 
 $(MIBDIR)/IANA-CHARSET-MIB.txt:
-	@echo ">> Donwloading IANA charset MIB"
+	@echo ">> Downloading IANA charset MIB"
 	@curl -s -o $(MIBDIR)/IANA-CHARSET-MIB.txt -L $(IANA_CHARSET_URL)
 
 $(MIBDIR)/IANA-IFTYPE-MIB.txt:
-	@echo ">> Donwloading IANA ifType MIB"
+	@echo ">> Downloading IANA ifType MIB"
 	@curl -s -o $(MIBDIR)/IANA-IFTYPE-MIB.txt -L $(IANA_IFTYPE_URL)
 
 $(MIBDIR)/IANA-PRINTER-MIB.txt:
-	@echo ">> Donwloading IANA printer MIB"
+	@echo ">> Downloading IANA printer MIB"
 	@curl -s -o $(MIBDIR)/IANA-PRINTER-MIB.txt -L $(IANA_PRINTER_URL)
 
 $(MIBDIR)/KEEPALIVED-MIB:

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -46,6 +46,7 @@ clean:
 	rm -v \
 		$(MIBDIR)/* \
 		$(MIBDIR)/cisco_v2 \
+		$(MIBDIR)/.cisco_v2 \
 		$(MIBDIR)/.paloalto_panos \
 		$(MIBDIR)/.synology
 
@@ -76,7 +77,7 @@ mibs: mib-dir \
   $(MIBDIR)/ARISTA-ENTITY-SENSOR-MIB \
   $(MIBDIR)/ARISTA-SMI-MIB \
   $(MIBDIR)/ARISTA-SW-IP-FORWARDING-MIB \
-  $(MIBDIR)/cisco_v2 \
+  $(MIBDIR)/.cisco_v2 \
   $(MIBDIR)/IANA-CHARSET-MIB.txt \
   $(MIBDIR)/IANA-IFTYPE-MIB.txt \
   $(MIBDIR)/IANA-PRINTER-MIB.txt \
@@ -113,9 +114,9 @@ $(MIBDIR)/ARISTA-SW-IP-FORWARDING-MIB:
 	@echo ">> Downloading ARISTA-SW-IP-FORWARDING-MIB"
 	@curl -s -o $(MIBDIR)/ARISTA-SW-IP-FORWARDING-MIB -L "$(ARISTA_URL)/ARISTA-SW-IP-FORWARDING-MIB.txt"
 
-$(MIBDIR)/cisco_v2:
+$(MIBDIR)/.cisco_v2:
 	@echo ">> Downloading cisco_v2"
-	@mkdir $(MIBDIR)/cisco_v2
+	@mkdir -p $(MIBDIR)/cisco_v2
 	@curl -s -L $(CISCO_URL) \
 		| tar -C $(MIBDIR)/cisco_v2 --strip-components=3 -zxv
 	cp mibs/cisco_v2/AIRESPACE-REF-MIB.my mibs/AIRESPACE-REF-MIB
@@ -130,6 +131,7 @@ $(MIBDIR)/cisco_v2:
 	cp mibs/cisco_v2/SNMPv2-MIB.my mibs/SNMPv2-MIB
 	cp mibs/cisco_v2/SNMPv2-SMI.my mibs/SNMPv2-SMI
 	cp mibs/cisco_v2/SNMPv2-TC.my mibs/SNMPv2-TC
+	@touch $(MIBDIR)/.cisco_v2
 
 $(MIBDIR)/IANA-CHARSET-MIB.txt:
 	@echo ">> Donwloading IANA charset MIB"

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -118,7 +118,7 @@ $(MIBDIR)/.cisco_v2:
 	@echo ">> Downloading cisco_v2"
 	@mkdir -p $(MIBDIR)/cisco_v2
 	@curl -s -L $(CISCO_URL) \
-		| tar -C $(MIBDIR)/cisco_v2 --strip-components=3 -zxv
+		| tar --no-same-owner -C $(MIBDIR)/cisco_v2 --strip-components=3 -zxv
 	cp mibs/cisco_v2/AIRESPACE-REF-MIB.my mibs/AIRESPACE-REF-MIB
 	cp mibs/cisco_v2/AIRESPACE-WIRELESS-MIB.my mibs/AIRESPACE-WIRELESS-MIB
 	cp mibs/cisco_v2/ENTITY-MIB.my mibs/ENTITY-MIB


### PR DESCRIPTION
Here are three minor amendments to MIB fetching.

* Correct spelling of "Downloading" in progress messages
* Make the cisco_v2 downloader robust against failures, by touching a flag file only on successful completion.  Otherwise, if download is attempted and fails, it skips over the download next time
* Add `--no-same-owner` flag to tar

The latter is because the mib tarball supplied by Cisco contains some high UIDs (>65535).  If you untar as root, and don't have the named users, then tar will attempt to create files with these UIDs; however when inside an unprivileged lxd container, only UIDs 0 to 65535 are usable (mapped to a different range in the host).

```
# tar -tvzf v2.tar.gz | head -5
-rw-rw-r-- tinhuang/mibfolks 30336 2002-11-21 19:52 auto/mibs/v2/ACCOUNTING-CONTROL-MIB.my
-rw-rw-r-- tinhuang/mibfolks 39991 2010-08-12 18:05 auto/mibs/v2/ACTONA-ACTASTOR-MIB.my
-rw-r--r-- miblib/eng        10304 2011-01-27 21:34 auto/mibs/v2/ADMIN-AUTH-STATS-MIB.my
-rw-rw-r-- tinhuang/mibfolks 24097 2000-04-14 07:00 auto/mibs/v2/ADSL-DMT-LINE-MIB.my
-rw-rw-r-- tinhuang/mibfolks 159225 2001-12-04 04:25 auto/mibs/v2/ADSL-LINE-MIB.my
# tar --numeric-owner -tvzf v2.tar.gz | head -5
-rw-rw-r-- 155379/1515   30336 2002-11-21 19:52 auto/mibs/v2/ACCOUNTING-CONTROL-MIB.my
-rw-rw-r-- 155379/1515   39991 2010-08-12 18:05 auto/mibs/v2/ACTONA-ACTASTOR-MIB.my
-rw-r--r-- 903623/25     10304 2011-01-27 21:34 auto/mibs/v2/ADMIN-AUTH-STATS-MIB.my
-rw-rw-r-- 155379/1515   24097 2000-04-14 07:00 auto/mibs/v2/ADSL-DMT-LINE-MIB.my
-rw-rw-r-- 155379/1515  159225 2001-12-04 04:25 auto/mibs/v2/ADSL-LINE-MIB.my
```