### PR TITLE
Clarify that MIBDIRS doesn't have to use system mibs to generate clean snmp.yml

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -22,7 +22,7 @@ make mibs
 ## Running
 
 ```sh
-export MIBDIRS=$HOME/.snmp/mibs:mibs:/usr/share/snmp/mibs
+export MIBDIRS=mibs
 ./generator generate
 ```
 
@@ -36,7 +36,7 @@ If you would like to run the generator in docker to generate your `snmp.yml` con
 
 The Docker image expects a directory containing the `generator.yml` and a directory called `mibs` that contains all MIBs you wish to use.
 
-This example will generate the example `snmp.yml`:
+This example will generate the example `snmp.yml` which is included in the top level of the snmp_exporter repo:
 ```sh
 make mibs
 docker build -t snmp-generator .


### PR DESCRIPTION
Closes #395

Signed-off-by: Brian Candler <b.candler@pobox.com>