### PR TITLE
printer_mib: walks prtMarkerSuppliesDescription

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -313,6 +313,7 @@ modules:
       - prtAlertCriticalEvents
       - prtAlertAllEvents
       - prtCoverStatus
+      - prtMarkerSuppliesDescription
       - prtMarkerSuppliesLevel
       - prtMarkerSuppliesMaxCapacity
       - prtMarkerSuppliesType
@@ -332,4 +333,6 @@ modules:
         type: DisplayString
       prtCoverStatus:
         type: EnumAsStateSet
+      prtMarkerSuppliesDescription:
+        type: DisplayString
 

--- a/snmp.yml
+++ b/snmp.yml
@@ -9189,6 +9189,7 @@ printer_mib:
   walk:
   - 1.3.6.1.2.1.25.3.5.1.1
   - 1.3.6.1.2.1.43.11.1.1.5
+  - 1.3.6.1.2.1.43.11.1.1.6
   - 1.3.6.1.2.1.43.11.1.1.8
   - 1.3.6.1.2.1.43.11.1.1.9
   - 1.3.6.1.2.1.43.5.1.1.13
@@ -9272,6 +9273,23 @@ printer_mib:
       34: covers
       35: matteToner
       36: matteInk
+  - name: prtMarkerSuppliesDescription
+    oid: 1.3.6.1.2.1.43.11.1.1.6
+    type: DisplayString
+    help: The description of this supply container/receptacle in the localization
+      specified by prtGeneralCurrentLocalization. - 1.3.6.1.2.1.43.11.1.1.6
+    indexes:
+    - labelname: hrDeviceIndex
+      type: gauge
+    - labelname: prtMarkerSuppliesIndex
+      type: gauge
+    lookups:
+    - labels:
+      - hrDeviceIndex
+      - prtMarkerSuppliesIndex
+      labelname: prtMarkerSuppliesType
+      oid: 1.3.6.1.2.1.43.11.1.1.5
+      type: gauge
   - name: prtMarkerSuppliesMaxCapacity
     oid: 1.3.6.1.2.1.43.11.1.1.8
     type: gauge


### PR DESCRIPTION
Characteristics (level, max capacity) of printer supplies are already collected, however not the description of each supply.

This PR makes the exporter walk the descriptions too.