### PR TITLE
Handle trailing linefeed in NetSNMP output adding 1 to the error count

### DIFF
--- a/generator/main.go
+++ b/generator/main.go
@@ -98,11 +98,10 @@ func main() {
 	kingpin.HelpFlag.Short('h')
 	command := kingpin.Parse()
 
-	parseErrors := strings.TrimSpace(initSNMP())
-	parseErrorCount := len(parseErrors)
-
-	if parseErrorCount != 0 {
-		log.Warnf("NetSNMP reported %d parse error(s)", len(strings.Split(parseErrors, "\n")))
+	parseOutput := strings.TrimSpace(initSNMP())
+	parseErrors := len(parseOutput) != 0
+	if parseErrors {
+		log.Warnf("NetSNMP reported %d parse error(s)", len(strings.Split(parseOutput, "\n")))
 	}
 
 	nodes := getMIBTree()
@@ -112,7 +111,7 @@ func main() {
 	case generateCommand.FullCommand():
 		generateConfig(nodes, nameToNode)
 	case parseErrorsCommand.FullCommand():
-		fmt.Println(parseErrors)
+		fmt.Println(parseOutput)
 	case dumpCommand.FullCommand():
 		walkNode(nodes, func(n *Node) {
 			t := n.Type
@@ -127,7 +126,7 @@ func main() {
 				n.Oid, n.Label, t, n.TextualConvention, n.Hint, n.Indexes, implied, n.EnumValues, n.Description)
 		})
 	}
-	if *failOnParseErrors && parseErrorCount != 0 {
+	if *failOnParseErrors && parseErrors {
 		os.Exit(1)
 	}
 }

--- a/generator/main.go
+++ b/generator/main.go
@@ -98,11 +98,11 @@ func main() {
 	kingpin.HelpFlag.Short('h')
 	command := kingpin.Parse()
 
-	parseErrors := initSNMP()
+	parseErrors := strings.TrimSpace(initSNMP())
 	parseErrorCount := len(parseErrors)
 
 	if parseErrorCount != 0 {
-		log.Warnf("NetSNMP reported %d parse errors", len(strings.Split(parseErrors, "\n")))
+		log.Warnf("NetSNMP reported %d parse error(s)", len(strings.Split(parseErrors, "\n")))
 	}
 
 	nodes := getMIBTree()


### PR DESCRIPTION
When non-empty, NetSNMP's output string is terminated with `\n`. Splitting this string by `\n` produces a slice of the number of errors + 1, however this is not being compensated for, resulting in e + 1 errors being reported when e > 0.

Before:

    $ ./generator parse_errors
    INFO[0000] Loading MIBs from $HOME/.snmp/mibs:/usr/share/snmp/mibs:/usr/share/snmp/mibs/iana:/usr/share/snmp/mibs/ietf:/usr/share/mibs/site:/usr/share/snmp/mibs:/usr/share/mibs/iana:/usr/share/mibs/ietf:/usr/share/mibs/netsnmp  source="net_snmp.go:141"
    WARN[0000] NetSNMP reported 2 parse errors               source="main.go:105"
    Bad operator (INTEGER): At line 73 in /usr/share/snmp/mibs/ietf/SNMPv2-PDU
   
    $ 

After:

    $ ./generator parse_errors
    INFO[0000] Loading MIBs from $HOME/.snmp/mibs:/usr/share/snmp/mibs:/usr/share/snmp/mibs/iana:/usr/share/snmp/mibs/ietf:/usr/share/mibs/site:/usr/share/snmp/mibs:/usr/share/mibs/iana:/usr/share/mibs/ietf:/usr/share/mibs/netsnmp  source="net_snmp.go:141"
    WARN[0000] NetSNMP reported 1 parse error(s)             source="main.go:105"
    Bad operator (INTEGER): At line 73 in /usr/share/snmp/mibs/ietf/SNMPv2-PDU
    $

@brian-brazil 