### PR TITLE
add external label support for each metric

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -637,6 +637,9 @@ func indexesToLabels(indexOids []int, metric *config.Metric, oidToPdu map[string
 	labels := map[string]string{}
 	labelOids := map[string][]int{}
 
+	for k, v := range metric.ExternalLabels {
+		labels[k] = v
+	}
 	// Covert indexes to useful strings.
 	for _, index := range metric.Indexes {
 		str, subOid, remainingOids := indexOidsAsString(indexOids, index.Type, index.FixedSize, index.Implied)

--- a/config/config.go
+++ b/config/config.go
@@ -176,6 +176,7 @@ type Metric struct {
 	Help           string                     `yaml:"help"`
 	Indexes        []*Index                   `yaml:"indexes,omitempty"`
 	Lookups        []*Lookup                  `yaml:"lookups,omitempty"`
+	ExternalLabels map[string]string          `yaml:"external_labels,omitempty"`
 	RegexpExtracts map[string][]RegexpExtract `yaml:"regex_extracts,omitempty"`
 	EnumValues     map[int]string             `yaml:"enum_values,omitempty"`
 }


### PR DESCRIPTION
add external label support for each metric. 
We now move from zabbix to promethues, we need cutomize some label key/value for each metric, though it can be completed by metric_relabel_configs of prometheus, it's complicated and I'm afraid promethues cannot handle them when many tagets there.

external labels for each metric gives an option for snmp exporter user to customize their own label key values.