### PR TITLE
Add support for SNMP community string as a parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ releases](https://github.com/prometheus/snmp_exporter/releases) page.
 
 Visit http://localhost:9116/snmp?target=1.2.3.4 where 1.2.3.4 is the IP of the
 SNMP device to get metrics from. You can also specify a `module` parameter, to
-choose which module to use from the config file.
+choose which module to use from the config file. You can also specify a
+'community' paramter, to override the community string from the config file.
 
 ## Configuration
 
@@ -47,21 +48,48 @@ scrape_configs:
     static_configs:
       - targets:
         - 192.168.1.2  # SNMP device.
+    file_sd_configs:
+      - files:
+        - '/data/*.json'
     metrics_path: /snmp
     params:
       module: [if_mib]
+      community: [public]
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
       - source_labels: [__param_target]
         target_label: instance
+      - source_labels: [community]
+        target_label: __param_community
+      - source_labels: [module]
+        target_label: __param_module
       - target_label: __address__
         replacement: 127.0.0.1:9116  # The SNMP exporter's real hostname:port.
+```
+
+Optionally, provide a json file as a file based service discovery. Only
+community and module are needed. Other labels are optional for snmp_exporter
+purposes.
+
+```JSON
+[
+  {
+    "targets": [ "192.168.1.2" ],
+    "labels": {
+      "name": "router",
+      "community": "publicCommunity",
+      "module": "ddwrt"
+    }
+  }
+]
 ```
 
 This setup allows Prometheus to provide scheduling and service discovery, as
 unlike all other exporters running an exporter on the machine from which we are
 getting the metrics from is not possible.
+
+
 
 ## Large counter value handling
 

--- a/cryptotool/Makefile
+++ b/cryptotool/Makefile
@@ -1,0 +1,30 @@
+.DEFAULT_GOAL := build
+
+.PHONY: test
+test: build ## Run tests in atomic mode
+	echo 'mode: atomic' > coverage.out && go test -covermode=atomic -coverprofile=coverage.out -v -race -timeout=30s ./...
+
+.PHONY: cover
+cover: test ## Run test and then give text coverage report
+	go tool cover -func=coverage.out
+
+.PHONY: coverhtml
+coverhtml: test ## Run test and then give html coverage report
+	go tool cover -html=coverage.out
+
+.PHONY: build
+build: ## Build binary
+	go build -v ./...
+
+.PHONY: clean
+clean: ## Remove tem files
+	go clean
+
+.PHONY: help
+help:   # From http://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+	@echo
+	@echo "  make commands available in cryptotool:"
+	@echo
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@echo
+

--- a/cryptotool/README.md
+++ b/cryptotool/README.md
@@ -1,0 +1,30 @@
+# cryptotool
+
+Run make to build the binary
+
+```sh
+make
+go build -v ./...
+```
+
+This is a tool to encrypt (and decrypt) your community string with a passphrase. (In this implementation, the sha256 hash of your passphrase is used for the 32byte key needed for AES)
+
+To encrypt your community of 'public' with the passphrase 'password'
+
+```sh
+./cryptotool encryptAesGcm password public
+Xj3Ag6RZwwSm5PiBoongcPnxCb3q7yLe9Ptcfi7JZCMQNA==
+```
+
+Test the decryption with the same tool
+
+```sh
+./cryptotool decryptAesGcm password Xj3Ag6RZwwSm5PiBoongcPnxCb3q7yLe9Ptcfi7JZCMQNA==
+public
+```
+
+AES GCM is used instead of AES CFB due to the ability to have a random initial 
+vector. This means each ciphertext generated is unique even with the same passphrase 
+and community string. If you have multiple devices with the same community, you
+should generate multiple encrypted community strings. This way, no one will
+know that multiple devices have the same community string.

--- a/cryptotool/cryptotool.go
+++ b/cryptotool/cryptotool.go
@@ -1,0 +1,81 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+)
+
+func passphraseToAesKey(password string) []byte {
+	key := sha256.Sum256([]byte(password))
+	return key[:]
+}
+
+func encryptStringAesGcm(data []byte, passphrase string) []byte {
+	block, _ := aes.NewCipher(passphraseToAesKey(passphrase))
+	gcm, _ := cipher.NewGCM(block)
+	nonce := make([]byte, gcm.NonceSize())
+	io.ReadFull(rand.Reader, nonce)
+	ciphertext := gcm.Seal(nonce, nonce, data, nil)
+	return ciphertext
+}
+
+func decryptStringAesGcm(data []byte, passphrase string) ([]byte, error) {
+	block, _ := aes.NewCipher(passphraseToAesKey(passphrase))
+	gcm, _ := cipher.NewGCM(block)
+	nonceSize := gcm.NonceSize()
+	if len(data) < nonceSize {
+		return nil, errors.New(fmt.Sprintf("AesGcm cipher size of %0d too short (Should be at least %0d)\n", len(data), nonceSize))
+	}
+	nonce, ciphertext := data[:nonceSize], data[nonceSize:]
+	plaintext, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return plaintext, nil
+}
+
+func main() {
+	if len(os.Args) != 4 {
+		fmt.Printf("Usage: %s [encryptAesGcm|encryptAesGcm] <passphrase> <data string>\n", os.Args[0])
+		os.Exit(1)
+	} else {
+		if os.Args[1] == "encryptAesGcm" {
+			ciphertext := encryptStringAesGcm([]byte(os.Args[3]), os.Args[2])
+			fmt.Println(base64.StdEncoding.EncodeToString(ciphertext))
+		} else if os.Args[1] == "decryptAesGcm" {
+			ciphertext, err := base64.StdEncoding.DecodeString(os.Args[3])
+			if err != nil {
+				log.Fatalf("base64 decode error: %s", err)
+			}
+			plaintext, err := decryptStringAesGcm(ciphertext, os.Args[2])
+			if err != nil {
+				log.Fatalf("decryptStringAesGcm error: %s", err)
+			}
+			fmt.Println(string(plaintext))
+		} else {
+			log.Fatalf("Usage: %s [encryptAesGcm|decryptAesGcm] <passphrase> <data string>\n", os.Args[0])
+		}
+	}
+}

--- a/cryptotool/cryptotool_test.go
+++ b/cryptotool/cryptotool_test.go
@@ -1,0 +1,51 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package main
+
+import (
+	"testing"
+)
+
+func TestAesGcm(t *testing.T) {
+	data := []struct {
+		input      string
+		passphrase string
+	}{
+		{"input", "passphrase"},
+		{"input", ""},
+		{"", "passphrase"},
+		{"Long input with more than 16 characters", "passphrase"},
+		{"input", "Long password with more then 16 characters"},
+	}
+	for _, d := range data {
+		enc := encryptStringAesGcm([]byte(d.input), d.passphrase)
+		dec, _ := decryptStringAesGcm(enc, d.passphrase)
+		if string(dec) != d.input {
+			t.Errorf("Decrypt passphrase %v\n  Input: %v\n  Expect: %v\n  Actual: %v", d.passphrase, enc, d.input, enc)
+		}
+	}
+}
+
+func TestAesGcmEmptyError(t *testing.T) {
+	_, err := decryptStringAesGcm([]byte(""), "password")
+	if err == nil {
+		t.Errorf("decryptStringAesGcm did not return an error for an empty ciphertext")
+	}
+}
+
+func TestAesGcmInvalidError(t *testing.T) {
+	_, err := decryptStringAesGcm([]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, "password")
+	if err == nil {
+		t.Errorf("decryptStringAesGcm did not return an error for a bad ciphertext")
+	}
+}

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 	if moduleName == "" {
 		moduleName = "if_mib"
 	}
+	communityString := r.URL.Query().Get("community")
 	sc.RLock()
 	module, ok := (*(sc.C))[moduleName]
 	sc.RUnlock()
@@ -88,7 +89,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 
 	start := time.Now()
 	registry := prometheus.NewRegistry()
-	collector := collector{target: target, module: module}
+	collector := collector{target: target, module: module, community: communityString}
 	registry.MustRegister(collector)
 	// Delegate http serving to Prometheus client library, which will call collector.Collect.
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
@@ -204,6 +205,7 @@ func main() {
             <form action="/snmp">
             <label>Target:</label> <input type="text" name="target" placeholder="X.X.X.X" value="1.2.3.4"><br>
             <label>Module:</label> <input type="text" name="module" placeholder="module" value="if_mib"><br>
+            <label>Community:</label> <input type="text" name="community" placeholder="community" value="public"><br>
             <input type="submit" value="Submit">
             </form>
 						<p><a href="/config">Config</a></p>


### PR DESCRIPTION
The whole idea is to allow configurations of target/community/module from prometheus instead of snmp_exporter's snmp.yml. Currently you can only specify target/module in snmp_exporter. This adds the community string (So its only for v1/v2) 

I've updated the README.md with an example of having a list of targets via a JSON file.