### PR TITLE
Fixed extra wrapping of regexp

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -257,7 +257,7 @@ func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if err := unmarshal(&s); err != nil {
 		return err
 	}
-	regex, err := regexp.Compile("^(?:" + s + ")$")
+	regex, err := regexp.Compile(s)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
I have device which return some metrics as multiline string
```
D1 : 5973 R
D2 : 6053 R
...
```
I wrote regexp which allows to me extract numeric value using override:
```
overrides:
   myStrangeString:
     regex_extracts:
       D1:
         - regex: D1 . (\d*) R
           value: $1
```
In generated snmp.yml I found that my expression was wraped:
```
    regex_extracts:
      D1:
      - value: $1
        regex: ^(?:D1 . (\d*) R)$
```
I tested this expression with my device and got nothing.
After that i tried to see debug info and found extra wrapping:
```
level=debug ts=2019-09-23T13:27:17.223Z caller=collector.go:410 module=mydevice target=192.168.250.54 msg="No match found for regexp" metric=myStrangeString value="D1 : 5973 R\nD2 : 6053 R\n" regex="^(?:^(?:D1 . (\\d*) R')$)$"
```
After fixing the code I got working collector and got expected result from regexp.