### PR TITLE
lookup description with storage index

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -232,6 +232,9 @@ modules:
     - source_indexes: [laIndex]
       lookup: laNames
       drop_source_indexes: true
+    - source_indexes: [hrStorageIndex]
+      lookup: hrStorageDescr
+      drop_source_indexes: true
     overrides:
       ifType:
         type: EnumAsInfo

--- a/snmp.yml
+++ b/snmp.yml
@@ -4722,6 +4722,14 @@ ddwrt:
     indexes:
     - labelname: hrStorageIndex
       type: gauge
+    lookups:
+    - labels:
+      - hrStorageIndex
+      labelname: hrStorageDescr
+      oid: 1.3.6.1.2.1.25.2.3.1.3
+      type: DisplayString
+    - labels: []
+      labelname: hrStorageIndex
   - name: hrStorageDescr
     oid: 1.3.6.1.2.1.25.2.3.1.3
     type: DisplayString
@@ -4730,6 +4738,14 @@ ddwrt:
     indexes:
     - labelname: hrStorageIndex
       type: gauge
+    lookups:
+    - labels:
+      - hrStorageIndex
+      labelname: hrStorageDescr
+      oid: 1.3.6.1.2.1.25.2.3.1.3
+      type: DisplayString
+    - labels: []
+      labelname: hrStorageIndex
   - name: hrStorageAllocationUnits
     oid: 1.3.6.1.2.1.25.2.3.1.4
     type: gauge
@@ -4737,6 +4753,14 @@ ddwrt:
     indexes:
     - labelname: hrStorageIndex
       type: gauge
+    lookups:
+    - labels:
+      - hrStorageIndex
+      labelname: hrStorageDescr
+      oid: 1.3.6.1.2.1.25.2.3.1.3
+      type: DisplayString
+    - labels: []
+      labelname: hrStorageIndex
   - name: hrStorageSize
     oid: 1.3.6.1.2.1.25.2.3.1.5
     type: gauge
@@ -4745,6 +4769,14 @@ ddwrt:
     indexes:
     - labelname: hrStorageIndex
       type: gauge
+    lookups:
+    - labels:
+      - hrStorageIndex
+      labelname: hrStorageDescr
+      oid: 1.3.6.1.2.1.25.2.3.1.3
+      type: DisplayString
+    - labels: []
+      labelname: hrStorageIndex
   - name: hrStorageUsed
     oid: 1.3.6.1.2.1.25.2.3.1.6
     type: gauge
@@ -4753,6 +4785,14 @@ ddwrt:
     indexes:
     - labelname: hrStorageIndex
       type: gauge
+    lookups:
+    - labels:
+      - hrStorageIndex
+      labelname: hrStorageDescr
+      oid: 1.3.6.1.2.1.25.2.3.1.3
+      type: DisplayString
+    - labels: []
+      labelname: hrStorageIndex
   - name: hrStorageAllocationFailures
     oid: 1.3.6.1.2.1.25.2.3.1.7
     type: counter
@@ -4761,6 +4801,14 @@ ddwrt:
     indexes:
     - labelname: hrStorageIndex
       type: gauge
+    lookups:
+    - labels:
+      - hrStorageIndex
+      labelname: hrStorageDescr
+      oid: 1.3.6.1.2.1.25.2.3.1.3
+      type: DisplayString
+    - labels: []
+      labelname: hrStorageIndex
   - name: ifName
     oid: 1.3.6.1.2.1.31.1.1.1.1
     type: DisplayString


### PR DESCRIPTION
Minor change to lookup ddwrt storage descriptions using the relevant index. An example result:

```
# HELP hrStorageUsed The amount of the storage represented by this entry that is allocated, in units of hrStorageAllocationUnits. - 1.3.6.1.2.1.25.2.3.1.6
# TYPE hrStorageUsed gauge
hrStorageUsed{hrStorageDescr="/"} 74
hrStorageUsed{hrStorageDescr="/overlay"} 74
hrStorageUsed{hrStorageDescr="/rom"} 10
hrStorageUsed{hrStorageDescr="/sys/fs/cgroup"} 0
hrStorageUsed{hrStorageDescr="Cached memory"} 7516
hrStorageUsed{hrStorageDescr="Memory buffers"} 2400
hrStorageUsed{hrStorageDescr="Physical memory"} 30880
hrStorageUsed{hrStorageDescr="Shared memory"} 136
hrStorageUsed{hrStorageDescr="Swap space"} 0
hrStorageUsed{hrStorageDescr="Virtual memory"} 30880
```
Thanks @brian-brazil, your book was instrumental in helping me get up and running with Prometheus.   I'll have to spend some time reading your blog, as more nuggets of useful details remain to be discovered there.