### PR TITLE
collector: move out of main package

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package collector
 
 import (
 	"encoding/binary"
@@ -198,6 +198,10 @@ type collector struct {
 	target string
 	module *config.Module
 	logger log.Logger
+}
+
+func New(target string, module *config.Module, logger log.Logger) *collector {
+	return &collector{target: target, module: module, logger: logger}
 }
 
 // Describe implements Prometheus.Collector.

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package collector
 
 import (
 	"errors"

--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ import (
 	"gopkg.in/alecthomas/kingpin.v2"
 	yaml "gopkg.in/yaml.v2"
 
+	"github.com/prometheus/snmp_exporter/collector"
 	"github.com/prometheus/snmp_exporter/config"
 )
 
@@ -92,8 +93,8 @@ func handler(w http.ResponseWriter, r *http.Request, logger log.Logger) {
 
 	start := time.Now()
 	registry := prometheus.NewRegistry()
-	collector := collector{target: target, module: module, logger: logger}
-	registry.MustRegister(collector)
+	c := collector.New(target, module, logger)
+	registry.MustRegister(c)
 	// Delegate http serving to Prometheus client library, which will call collector.Collect.
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	h.ServeHTTP(w, r)


### PR DESCRIPTION
Moving collector out of main package allows to use `snmp_exporter` as a library in other programs.