### PR TITLE
generator: add --compressed to curl options

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -14,7 +14,7 @@
 MIBDIR   := mibs
 MIB_PATH := 'mibs'
 
-CURL_OPTS ?= -s --retry 3 --retry-delay 3
+CURL_OPTS ?= -s --retry 3 --retry-delay 3 --compressed --location
 
 DOCKER_IMAGE_NAME ?= snmp-generator
 DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))


### PR DESCRIPTION
Plain text MIBs' download speed will benefit from `Accept-Encoding: deflate, gzip`.  This also workarounds currently broken Synology CDN since they return 3xx redirect.