### PR TITLE
Get net-snmp from new GitHub source

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -14,7 +14,7 @@
 MIBDIR   := mibs
 MIB_PATH := 'mibs'
 
-CURL_OPTS ?= -s --retry 3 --retry-delay 3 --compressed --location
+CURL_OPTS ?= -s --retry 3 --retry-delay 3 --compressed --location --fail
 
 DOCKER_IMAGE_NAME ?= snmp-generator
 DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
@@ -23,23 +23,19 @@ DOCKER_REPO       ?= prom
 APC_URL          := 'https://download.schneider-electric.com/files?p_File_Name=powernet428.mib'
 ARISTA_URL       := https://www.arista.com/assets/data/docs/MIBS
 CISCO_URL        := 'ftp://ftp.cisco.com/pub/mibs/v2/v2.tar.gz'
-FRAMEWORK_URL    := http://www.net-snmp.org/docs/mibs/SNMP-FRAMEWORK-MIB.txt
 IANA_CHARSET_URL := https://www.iana.org/assignments/ianacharset-mib/ianacharset-mib
 IANA_IFTYPE_URL  := https://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib
 IANA_PRINTER_URL := https://www.iana.org/assignments/ianaprinter-mib/ianaprinter-mib
-IPV6_TC_URL      := http://www.net-snmp.org/docs/mibs/IPV6-TC.txt
 KEEPALIVED_URL   := 'https://raw.githubusercontent.com/acassen/keepalived/master/doc/KEEPALIVED-MIB.txt'
 MIKROTIK_URL     := 'http://download2.mikrotik.com/Mikrotik.mib'
 NEC_URL          := https://jpn.nec.com/univerge/ix/Manual/MIB
-NET_SNMP_URL     := http://www.net-snmp.org/docs/mibs/NET-SNMP-MIB.txt
-NET_TC_URL       := http://www.net-snmp.org/docs/mibs/NET-SNMP-TC.txt
+NET_SNMP_URL     := https://raw.githubusercontent.com/net-snmp/net-snmp/v5.8/mibs
 PALOALTO_URL     := 'https://www.paloaltonetworks.com/content/dam/pan/en_US/assets/zip/technical-documentation/snmp-mib-modules/PAN-MIB-MODULES-7.0.zip'
 PRINTER_URL      := https://ftp.pwg.org/pub/pwg/pmp/mibs/rfc3805b.mib
 SERVERTECH_URL   := 'https://cdn10.servertech.com/assets/documents/documents/817/original/Sentry3.mib'
 SYNOLOGY_URL     := 'https://global.download.synology.com/download/Document/MIBGuide/Synology_MIB_File.zip'
 UBNT_AIROS_URL   := https://dl.ubnt.com/firmwares/airos-ubnt-mib/ubnt-mib.zip
 UBNT_DL_URL      := http://dl.ubnt-ut.com/snmp
-UCD_URL          := http://www.net-snmp.org/docs/mibs/UCD-SNMP-MIB.txt
 
 .DEFAULT: all
 
@@ -51,6 +47,7 @@ clean:
 		$(MIBDIR)/* \
 		$(MIBDIR)/cisco_v2 \
 		$(MIBDIR)/.cisco_v2 \
+		$(MIBDIR)/.net-snmp \
 		$(MIBDIR)/.paloalto_panos \
 		$(MIBDIR)/.synology
 
@@ -85,48 +82,44 @@ mibs: mib-dir \
   $(MIBDIR)/IANA-CHARSET-MIB.txt \
   $(MIBDIR)/IANA-IFTYPE-MIB.txt \
   $(MIBDIR)/IANA-PRINTER-MIB.txt \
-  $(MIBDIR)/IPV6-TC \
   $(MIBDIR)/KEEPALIVED-MIB \
   $(MIBDIR)/MIKROTIK-MIB \
-  $(MIBDIR)/NET-SNMP-MIB \
-  $(MIBDIR)/NET-SNMP-TC \
+  $(MIBDIR)/.net-snmp \
   $(MIBDIR)/.paloalto_panos \
   $(MIBDIR)/PICO-IPSEC-FLOW-MONITOR-MIB.txt \
   $(MIBDIR)/PICO-SMI-ID-MIB.txt \
   $(MIBDIR)/PICO-SMI-MIB.txt \
   $(MIBDIR)/PRINTER-MIB-V2.txt \
   $(MIBDIR)/servertech-sentry3-mib \
-  $(MIBDIR)/SNMP-FRAMEWORK-MIB \
   $(MIBDIR)/.synology \
   $(MIBDIR)/UBNT-MIB \
   $(MIBDIR)/UBNT-UniFi-MIB \
-  $(MIBDIR)/UBNT-AirMAX-MIB.txt \
-  $(MIBDIR)/UCD-SNMP-MIB.txt
+  $(MIBDIR)/UBNT-AirMAX-MIB.txt
 
 mib-dir:
 	@mkdir -p -v $(MIBDIR)
 
 $(MIBDIR)/apc-powernet-mib:
 	@echo ">> Downloading apc-powernet-mib"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/apc-powernet-mib -L $(APC_URL)
+	@curl $(CURL_OPTS) -o $(MIBDIR)/apc-powernet-mib $(APC_URL)
 
 $(MIBDIR)/ARISTA-ENTITY-SENSOR-MIB:
 	@echo ">> Downloading ARISTA-ENTITY-SENSOR-MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/ARISTA-ENTITY-SENSOR-MIB -L "$(ARISTA_URL)/ARISTA-ENTITY-SENSOR-MIB.txt"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/ARISTA-ENTITY-SENSOR-MIB "$(ARISTA_URL)/ARISTA-ENTITY-SENSOR-MIB.txt"
 
 $(MIBDIR)/ARISTA-SMI-MIB:
 	@echo ">> Downloading ARISTA-SMI-MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/ARISTA-SMI-MIB -L "$(ARISTA_URL)/ARISTA-SMI-MIB.txt"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/ARISTA-SMI-MIB "$(ARISTA_URL)/ARISTA-SMI-MIB.txt"
 
 $(MIBDIR)/ARISTA-SW-IP-FORWARDING-MIB:
 	@echo ">> Downloading ARISTA-SW-IP-FORWARDING-MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/ARISTA-SW-IP-FORWARDING-MIB -L "$(ARISTA_URL)/ARISTA-SW-IP-FORWARDING-MIB.txt"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/ARISTA-SW-IP-FORWARDING-MIB "$(ARISTA_URL)/ARISTA-SW-IP-FORWARDING-MIB.txt"
 
 $(MIBDIR)/.cisco_v2:
 	$(eval TMP := $(shell mktemp))
 	@echo ">> Downloading cisco_v2"
 	@mkdir -p $(MIBDIR)/cisco_v2
-	@curl $(CURL_OPTS) -o $(TMP) -L $(CISCO_URL)
+	@curl $(CURL_OPTS) -o $(TMP) $(CISCO_URL)
 	tar --no-same-owner -C $(MIBDIR)/cisco_v2 --strip-components=3 -zxvf $(TMP)
 	cp mibs/cisco_v2/AIRESPACE-REF-MIB.my mibs/AIRESPACE-REF-MIB
 	cp mibs/cisco_v2/AIRESPACE-WIRELESS-MIB.my mibs/AIRESPACE-WIRELESS-MIB
@@ -134,103 +127,93 @@ $(MIBDIR)/.cisco_v2:
 	cp mibs/cisco_v2/ENTITY-SENSOR-MIB.my mibs/ENTITY-SENSOR-MIB
 	cp mibs/cisco_v2/ENTITY-STATE-MIB.my mibs/ENTITY-STATE-MIB
 	cp mibs/cisco_v2/ENTITY-STATE-TC-MIB.my mibs/ENTITY-STATE-TC-MIB
-	cp mibs/cisco_v2/HOST-RESOURCES-MIB.my mibs/HOST-RESOURCES-MIB
-	cp mibs/cisco_v2/IF-MIB.my mibs/IF-MIB
-	cp mibs/cisco_v2/INET-ADDRESS-MIB.my mibs/INET-ADDRESS-MIB
 	cp mibs/cisco_v2/ISDN-MIB.my mibs/ISDN-MIB
-	cp mibs/cisco_v2/SNMPv2-MIB.my mibs/SNMPv2-MIB
-	cp mibs/cisco_v2/SNMPv2-SMI.my mibs/SNMPv2-SMI
-	cp mibs/cisco_v2/SNMPv2-TC.my mibs/SNMPv2-TC
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.cisco_v2
 
 $(MIBDIR)/IANA-CHARSET-MIB.txt:
 	@echo ">> Downloading IANA charset MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/IANA-CHARSET-MIB.txt -L $(IANA_CHARSET_URL)
+	@curl $(CURL_OPTS) -o $(MIBDIR)/IANA-CHARSET-MIB.txt $(IANA_CHARSET_URL)
 
 $(MIBDIR)/IANA-IFTYPE-MIB.txt:
 	@echo ">> Downloading IANA ifType MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/IANA-IFTYPE-MIB.txt -L $(IANA_IFTYPE_URL)
+	@curl $(CURL_OPTS) -o $(MIBDIR)/IANA-IFTYPE-MIB.txt $(IANA_IFTYPE_URL)
 
 $(MIBDIR)/IANA-PRINTER-MIB.txt:
 	@echo ">> Downloading IANA printer MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/IANA-PRINTER-MIB.txt -L $(IANA_PRINTER_URL)
-
-$(MIBDIR)/IPV6-TC:
-	@echo ">> Downloading IPV6-TC"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/IPV6-TC -L $(IPV6_TC_URL)
+	@curl $(CURL_OPTS) -o $(MIBDIR)/IANA-PRINTER-MIB.txt $(IANA_PRINTER_URL)
 
 $(MIBDIR)/KEEPALIVED-MIB:
 	@echo ">> Downloading KEEPALIVED-MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/KEEPALIVED-MIB -L $(KEEPALIVED_URL)
+	@curl $(CURL_OPTS) -o $(MIBDIR)/KEEPALIVED-MIB $(KEEPALIVED_URL)
 
 $(MIBDIR)/MIKROTIK-MIB:
 	@echo ">> Downloading MIKROTIK-MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/MIKROTIK-MIB -L $(MIKROTIK_URL)
+	@curl $(CURL_OPTS) -o $(MIBDIR)/MIKROTIK-MIB $(MIKROTIK_URL)
 
-$(MIBDIR)/NET-SNMP-MIB:
-	@echo ">> Downloading NET-SNMP-MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/NET-SNMP-MIB -L $(NET_SNMP_URL)
-
-$(MIBDIR)/NET-SNMP-TC:
-	@echo ">> Downloading NET-SNMP-TC"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/NET-SNMP-TC -L $(NET_TC_URL)
+$(MIBDIR)/.net-snmp:
+	@echo ">> Downloading NET-SNMP mibs"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/HCNUM-TC $(NET_SNMP_URL)/HCNUM-TC.txt
+	@curl $(CURL_OPTS) -o $(MIBDIR)/HOST-RESOURCES-MIB $(NET_SNMP_URL)/HOST-RESOURCES-MIB.txt
+	@curl $(CURL_OPTS) -o $(MIBDIR)/IF-MIB $(NET_SNMP_URL)/IF-MIB.txt
+	@curl $(CURL_OPTS) -o $(MIBDIR)/INET-ADDRESS-MIB $(NET_SNMP_URL)/INET-ADDRESS-MIB.txt
+	@curl $(CURL_OPTS) -o $(MIBDIR)/IPV6-TC $(NET_SNMP_URL)/IPV6-TC.txt
+	@curl $(CURL_OPTS) -o $(MIBDIR)/NET-SNMP-MIB $(NET_SNMP_URL)/NET-SNMP-MIB.txt
+	@curl $(CURL_OPTS) -o $(MIBDIR)/NET-SNMP-TC $(NET_SNMP_URL)/NET-SNMP-TC.txt
+	@curl $(CURL_OPTS) -o $(MIBDIR)/SNMP-FRAMEWORK-MIB $(NET_SNMP_URL)/SNMP-FRAMEWORK-MIB.txt
+	@curl $(CURL_OPTS) -o $(MIBDIR)/SNMPv2-MIB $(NET_SNMP_URL)/SNMPv2-MIB.txt
+	@curl $(CURL_OPTS) -o $(MIBDIR)/SNMPv2-SMI $(NET_SNMP_URL)/SNMPv2-SMI.txt
+	@curl $(CURL_OPTS) -o $(MIBDIR)/SNMPv2-TC $(NET_SNMP_URL)/SNMPv2-TC.txt
+	@curl $(CURL_OPTS) -o $(MIBDIR)/UCD-SNMP-MIB $(NET_SNMP_URL)/UCD-SNMP-MIB.txt
+	@touch $(MIBDIR)/.net-snmp
 
 $(MIBDIR)/PICO-IPSEC-FLOW-MONITOR-MIB.txt:
 	@echo ">> Downloading PICO-IPSEC-FLOW-MONITOR-MIB.txt"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/PICO-IPSEC-FLOW-MONITOR-MIB.txt -L "$(NEC_URL)/PICO-IPSEC-FLOW-MONITOR-MIB.txt"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/PICO-IPSEC-FLOW-MONITOR-MIB.txt "$(NEC_URL)/PICO-IPSEC-FLOW-MONITOR-MIB.txt"
 
 $(MIBDIR)/PICO-SMI-MIB.txt:
 	@echo ">> Downloading PICO-SMI-MIB.txt"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/PICO-SMI-MIB.txt -L "$(NEC_URL)/PICO-SMI-MIB.txt"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/PICO-SMI-MIB.txt "$(NEC_URL)/PICO-SMI-MIB.txt"
 
 $(MIBDIR)/PICO-SMI-ID-MIB.txt:
 	@echo ">> Downloading PICO-SMI-ID-MIB.txt"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/PICO-SMI-ID-MIB.txt -L "$(NEC_URL)/PICO-SMI-ID-MIB.txt"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/PICO-SMI-ID-MIB.txt "$(NEC_URL)/PICO-SMI-ID-MIB.txt"
 
 $(MIBDIR)/.paloalto_panos:
 	$(eval TMP := $(shell mktemp))
 	@echo ">> Downloading paloalto_pano to $(TMP)"
-	@curl $(CURL_OPTS) -o $(TMP) -L $(PALOALTO_URL)
+	@curl $(CURL_OPTS) -o $(TMP) $(PALOALTO_URL)
 	@unzip -j -d $(MIBDIR) $(TMP)
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.paloalto_panos
 
 $(MIBDIR)/PRINTER-MIB-V2.txt:
 	@echo ">> Downloading Printer MIB v2"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/PRINTER-MIB-V2.txt -L $(PRINTER_URL)
+	@curl $(CURL_OPTS) -o $(MIBDIR)/PRINTER-MIB-V2.txt $(PRINTER_URL)
 
 $(MIBDIR)/servertech-sentry3-mib:
 	@echo ">> Downloading servertech-sentry3-mib"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/servertech-sentry3-mib -L $(SERVERTECH_URL)
-
-$(MIBDIR)/SNMP-FRAMEWORK-MIB:
-	@echo ">> Downloading SNMP-FRAMEWORK-MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/SNMP-FRAMEWORK-MIB -L $(FRAMEWORK_URL)
+	@curl $(CURL_OPTS) -o $(MIBDIR)/servertech-sentry3-mib $(SERVERTECH_URL)
 
 $(MIBDIR)/.synology:
 	$(eval TMP := $(shell mktemp))
 	@echo ">> Downloading synology to $(TMP)"
-	@curl $(CURL_OPTS) -o $(TMP) -L $(SYNOLOGY_URL)
+	@curl $(CURL_OPTS) -o $(TMP) $(SYNOLOGY_URL)
 	@unzip -j -d $(MIBDIR) $(TMP)
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.synology
 
 $(MIBDIR)/UBNT-MIB:
 	@echo ">> Downloading UBNT-MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/UBNT-MIB -L "$(UBNT_DL_URL)/UBNT-MIB"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/UBNT-MIB "$(UBNT_DL_URL)/UBNT-MIB"
 
 $(MIBDIR)/UBNT-UniFi-MIB:
 	@echo ">> Downloading UBNT-UniFi-MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/UBNT-UniFi-MIB -L "$(UBNT_DL_URL)/UBNT-UniFi-MIB"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/UBNT-UniFi-MIB "$(UBNT_DL_URL)/UBNT-UniFi-MIB"
 
 $(MIBDIR)/UBNT-AirMAX-MIB.txt:
 	$(eval TMP := $(shell mktemp))
 	@echo ">> Downloading ubnt-airos to $(TMP)"
-	@curl $(CURL_OPTS) -o $(TMP) -L $(UBNT_AIROS_URL)
+	@curl $(CURL_OPTS) -o $(TMP) $(UBNT_AIROS_URL)
 	@unzip -j -d $(MIBDIR) $(TMP) UBNT-AirMAX-MIB.txt
 	@rm -v $(TMP)
-
-$(MIBDIR)/UCD-SNMP-MIB.txt:
-	@echo ">> Downloading UCD-SNMP-MIB.txt"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/UCD-SNMP-MIB.txt -L "$(UCD_URL)"

--- a/snmp.yml
+++ b/snmp.yml
@@ -5311,6 +5311,10 @@ ddwrt:
     type: counter
     help: The number of 'ticks' (typically 1/100s) spent by the CPU to run a niced
       virtual CPU (guest) - 1.3.6.1.4.1.2021.11.66
+  - name: ssCpuNumCpus
+    oid: 1.3.6.1.4.1.2021.11.67
+    type: gauge
+    help: The number of processors, as counted by the agent - 1.3.6.1.4.1.2021.11.67
   - name: memIndex
     oid: 1.3.6.1.4.1.2021.4.1
     type: gauge
@@ -5389,6 +5393,46 @@ ddwrt:
     type: gauge
     help: The amount of real/physical memory currently being used by text pages on
       this host - 1.3.6.1.4.1.2021.4.17
+  - name: memTotalSwapX
+    oid: 1.3.6.1.4.1.2021.4.18
+    type: counter
+    help: The total amount of swap space configured for this host. - 1.3.6.1.4.1.2021.4.18
+  - name: memAvailSwapX
+    oid: 1.3.6.1.4.1.2021.4.19
+    type: counter
+    help: The amount of swap space currently unused or available. - 1.3.6.1.4.1.2021.4.19
+  - name: memTotalRealX
+    oid: 1.3.6.1.4.1.2021.4.20
+    type: counter
+    help: The total amount of real/physical memory installed on this host. - 1.3.6.1.4.1.2021.4.20
+  - name: memAvailRealX
+    oid: 1.3.6.1.4.1.2021.4.21
+    type: counter
+    help: The amount of real/physical memory currently unused or available. - 1.3.6.1.4.1.2021.4.21
+  - name: memTotalFreeX
+    oid: 1.3.6.1.4.1.2021.4.22
+    type: counter
+    help: The total amount of memory free or available for use on this host - 1.3.6.1.4.1.2021.4.22
+  - name: memMinimumSwapX
+    oid: 1.3.6.1.4.1.2021.4.23
+    type: counter
+    help: The minimum amount of swap space expected to be kept free or available during
+      normal operation of this host - 1.3.6.1.4.1.2021.4.23
+  - name: memSharedX
+    oid: 1.3.6.1.4.1.2021.4.24
+    type: counter
+    help: The total amount of real or virtual memory currently allocated for use as
+      shared memory - 1.3.6.1.4.1.2021.4.24
+  - name: memBufferX
+    oid: 1.3.6.1.4.1.2021.4.25
+    type: counter
+    help: The total amount of real or virtual memory currently allocated for use as
+      memory buffers - 1.3.6.1.4.1.2021.4.25
+  - name: memCachedX
+    oid: 1.3.6.1.4.1.2021.4.26
+    type: counter
+    help: The total amount of real or virtual memory currently allocated for use as
+      cached memory - 1.3.6.1.4.1.2021.4.26
   - name: memSwapError
     oid: 1.3.6.1.4.1.2021.4.100
     type: gauge
@@ -13374,6 +13418,46 @@ synology:
     type: gauge
     help: The amount of real/physical memory currently being used by text pages on
       this host - 1.3.6.1.4.1.2021.4.17
+  - name: memTotalSwapX
+    oid: 1.3.6.1.4.1.2021.4.18
+    type: counter
+    help: The total amount of swap space configured for this host. - 1.3.6.1.4.1.2021.4.18
+  - name: memAvailSwapX
+    oid: 1.3.6.1.4.1.2021.4.19
+    type: counter
+    help: The amount of swap space currently unused or available. - 1.3.6.1.4.1.2021.4.19
+  - name: memTotalRealX
+    oid: 1.3.6.1.4.1.2021.4.20
+    type: counter
+    help: The total amount of real/physical memory installed on this host. - 1.3.6.1.4.1.2021.4.20
+  - name: memAvailRealX
+    oid: 1.3.6.1.4.1.2021.4.21
+    type: counter
+    help: The amount of real/physical memory currently unused or available. - 1.3.6.1.4.1.2021.4.21
+  - name: memTotalFreeX
+    oid: 1.3.6.1.4.1.2021.4.22
+    type: counter
+    help: The total amount of memory free or available for use on this host - 1.3.6.1.4.1.2021.4.22
+  - name: memMinimumSwapX
+    oid: 1.3.6.1.4.1.2021.4.23
+    type: counter
+    help: The minimum amount of swap space expected to be kept free or available during
+      normal operation of this host - 1.3.6.1.4.1.2021.4.23
+  - name: memSharedX
+    oid: 1.3.6.1.4.1.2021.4.24
+    type: counter
+    help: The total amount of real or virtual memory currently allocated for use as
+      shared memory - 1.3.6.1.4.1.2021.4.24
+  - name: memBufferX
+    oid: 1.3.6.1.4.1.2021.4.25
+    type: counter
+    help: The total amount of real or virtual memory currently allocated for use as
+      memory buffers - 1.3.6.1.4.1.2021.4.25
+  - name: memCachedX
+    oid: 1.3.6.1.4.1.2021.4.26
+    type: counter
+    help: The total amount of real or virtual memory currently allocated for use as
+      cached memory - 1.3.6.1.4.1.2021.4.26
   - name: memSwapError
     oid: 1.3.6.1.4.1.2021.4.100
     type: gauge


### PR DESCRIPTION
* Use new GitHub repo for gathering net-snmp MIBs[0].
* Pin to v5.8 release.
* Simplify net-snmp MIB downloads.
* Remove duplicate `-L` from curl args.
* Add `--fail` to curl opts to cause broken downloads to fail make.
* Move more MIB downloads from Cisco to net-snmp.
* Update snmp.yml.

[0]: https://sourceforge.net/p/net-snmp/mailman/message/36754760/

Signed-off-by: Ben Kochie <superq@gmail.com>