### PR TITLE
Add support for Raritan PDUs.

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -36,6 +36,7 @@ SERVERTECH_URL   := 'https://cdn10.servertech.com/assets/documents/documents/817
 SYNOLOGY_URL     := 'https://global.download.synology.com/download/Document/MIBGuide/Synology_MIB_File.zip'
 UBNT_AIROS_URL   := https://dl.ubnt.com/firmwares/airos-ubnt-mib/ubnt-mib.zip
 UBNT_DL_URL      := http://dl.ubnt-ut.com/snmp
+RARITAN_URL      := http://cdn.raritan.com/download/PX/v1.5.20/PDU-MIB.txt
 
 .DEFAULT: all
 
@@ -94,7 +95,8 @@ mibs: mib-dir \
   $(MIBDIR)/.synology \
   $(MIBDIR)/UBNT-MIB \
   $(MIBDIR)/UBNT-UniFi-MIB \
-  $(MIBDIR)/UBNT-AirMAX-MIB.txt
+  $(MIBDIR)/UBNT-AirMAX-MIB.txt \
+  ${MIBDIR}/PDU-MIB.txt
 
 mib-dir:
 	@mkdir -p -v $(MIBDIR)
@@ -217,3 +219,7 @@ $(MIBDIR)/UBNT-AirMAX-MIB.txt:
 	@curl $(CURL_OPTS) -o $(TMP) $(UBNT_AIROS_URL)
 	@unzip -j -d $(MIBDIR) $(TMP) UBNT-AirMAX-MIB.txt
 	@rm -v $(TMP)
+
+$(MIBDIR)/PDU-MIB.txt:
+	@echo ">> Downloading PDU-MIB"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/PDU-MIB.txt "$(RARITAN_URL)"

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -361,3 +361,25 @@ modules:
       - picoMobileMIB
       - picoIPv4MIB
       - picoIPv6MIB
+
+  raritan:
+    walk:
+      - sysUpTime
+      - 1.3.6.1.4.1.13742.4.1.20.2.1.7 # inletCurrent
+      - 1.3.6.1.4.1.13742.4.1.20.2.1.8 # inletVoltage
+      - 1.3.6.1.4.1.13742.4.1.20.2.1.9 # inletActivePower
+      - 1.3.6.1.4.1.13742.4.1.2.2.1.31 # outletWattHours
+      - 1.3.6.1.4.1.13742.4.1.2.2.1.3  # outletOperationalState
+      - 1.3.6.1.4.1.13742.4.1.2.2.1.4  # outletCurrent
+      - 1.3.6.1.4.1.13742.4.1.2.2.1.5  # outletMaxCurrent
+      - 1.3.6.1.4.1.13742.4.1.2.2.1.6  # outletVoltage
+      - 1.3.6.1.4.1.13742.4.1.2.2.1.7  # outletActivePower
+      - 1.3.6.1.4.1.13742.4.1.3.1.5    # unitCpuTemp
+    lookups:
+      - source_indexes: [outletIndex]
+        lookup: outletLabel
+    overrides:
+      outletOperationalState:
+        type: EnumAsStateSet
+    auth:
+      community: raritan_public

--- a/snmp.yml
+++ b/snmp.yml
@@ -11672,6 +11672,141 @@ printer_mib:
       4: coverClosed
       5: interlockOpen
       6: interlockClosed
+raritan:
+  walk:
+  - 1.3.6.1.4.1.13742.4.1.2.2.1.2
+  - 1.3.6.1.4.1.13742.4.1.2.2.1.3
+  - 1.3.6.1.4.1.13742.4.1.2.2.1.31
+  - 1.3.6.1.4.1.13742.4.1.2.2.1.4
+  - 1.3.6.1.4.1.13742.4.1.2.2.1.5
+  - 1.3.6.1.4.1.13742.4.1.2.2.1.6
+  - 1.3.6.1.4.1.13742.4.1.2.2.1.7
+  - 1.3.6.1.4.1.13742.4.1.20.2.1.7
+  - 1.3.6.1.4.1.13742.4.1.20.2.1.8
+  - 1.3.6.1.4.1.13742.4.1.20.2.1.9
+  get:
+  - 1.3.6.1.2.1.1.3.0
+  - 1.3.6.1.4.1.13742.4.1.3.1.5.0
+  metrics:
+  - name: sysUpTime
+    oid: 1.3.6.1.2.1.1.3
+    type: gauge
+    help: The time (in hundredths of a second) since the network management portion
+      of the system was last re-initialized. - 1.3.6.1.2.1.1.3
+  - name: outletOperationalState
+    oid: 1.3.6.1.4.1.13742.4.1.2.2.1.3
+    type: EnumAsStateSet
+    help: A value for each outlet which describes the operational state of the outlet
+      - 1.3.6.1.4.1.13742.4.1.2.2.1.3
+    indexes:
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - outletIndex
+      labelname: outletLabel
+      oid: 1.3.6.1.4.1.13742.4.1.2.2.1.2
+      type: DisplayString
+    enum_values:
+      -1: error
+      0: "off"
+      1: "on"
+      2: cycling
+  - name: outletWattHours
+    oid: 1.3.6.1.4.1.13742.4.1.2.2.1.31
+    type: gauge
+    help: The value of the cumulative active energy for this outlet - 1.3.6.1.4.1.13742.4.1.2.2.1.31
+    indexes:
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - outletIndex
+      labelname: outletLabel
+      oid: 1.3.6.1.4.1.13742.4.1.2.2.1.2
+      type: DisplayString
+  - name: outletCurrent
+    oid: 1.3.6.1.4.1.13742.4.1.2.2.1.4
+    type: gauge
+    help: A unique value for the current sensor attached to the outlet - 1.3.6.1.4.1.13742.4.1.2.2.1.4
+    indexes:
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - outletIndex
+      labelname: outletLabel
+      oid: 1.3.6.1.4.1.13742.4.1.2.2.1.2
+      type: DisplayString
+  - name: outletMaxCurrent
+    oid: 1.3.6.1.4.1.13742.4.1.2.2.1.5
+    type: gauge
+    help: A unique value for the max - 1.3.6.1.4.1.13742.4.1.2.2.1.5
+    indexes:
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - outletIndex
+      labelname: outletLabel
+      oid: 1.3.6.1.4.1.13742.4.1.2.2.1.2
+      type: DisplayString
+  - name: outletVoltage
+    oid: 1.3.6.1.4.1.13742.4.1.2.2.1.6
+    type: gauge
+    help: A unique value for the voltage sensor attached to the outlet.This value
+      is reported in millivolts (1/1000th of a volt) - 1.3.6.1.4.1.13742.4.1.2.2.1.6
+    indexes:
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - outletIndex
+      labelname: outletLabel
+      oid: 1.3.6.1.4.1.13742.4.1.2.2.1.2
+      type: DisplayString
+  - name: outletActivePower
+    oid: 1.3.6.1.4.1.13742.4.1.2.2.1.7
+    type: gauge
+    help: A unique value for the active power sensor attached to the outlet - 1.3.6.1.4.1.13742.4.1.2.2.1.7
+    indexes:
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - outletIndex
+      labelname: outletLabel
+      oid: 1.3.6.1.4.1.13742.4.1.2.2.1.2
+      type: DisplayString
+  - name: inletCurrent
+    oid: 1.3.6.1.4.1.13742.4.1.20.2.1.7
+    type: gauge
+    help: A unique value for the current sensor attached to the inlet - 1.3.6.1.4.1.13742.4.1.20.2.1.7
+    indexes:
+    - labelname: inletIndex
+      type: gauge
+  - name: inletVoltage
+    oid: 1.3.6.1.4.1.13742.4.1.20.2.1.8
+    type: gauge
+    help: A unique value for the voltage sensor attached to the intlet.This value
+      is reported in millivolts (1/1000th of a volt) - 1.3.6.1.4.1.13742.4.1.20.2.1.8
+    indexes:
+    - labelname: inletIndex
+      type: gauge
+  - name: inletActivePower
+    oid: 1.3.6.1.4.1.13742.4.1.20.2.1.9
+    type: gauge
+    help: The active power for the inlet This value is reported in Watts. - 1.3.6.1.4.1.13742.4.1.20.2.1.9
+    indexes:
+    - labelname: inletIndex
+      type: gauge
+  - name: unitCpuTemp
+    oid: 1.3.6.1.4.1.13742.4.1.3.1.5
+    type: gauge
+    help: The value for the unit's CPU temperature sensor in tenth degrees celsius.
+      - 1.3.6.1.4.1.13742.4.1.3.1.5
+  auth:
+    community: raritan_public
 servertech_sentry3:
   walk:
   - 1.3.6.1.4.1.1718.3.2.2


### PR DESCRIPTION
This change downloads the latest PDU-MIB definition from Raritan,
which was last updated February 22, 2016, and then defines a handful
of useful values for monitoring.  This includes the current, voltage,
and wattage of both inlets and outlets on the PDU, and the current
switch status of each outlet.

This configuration has been tested and verified to work with a
Raritan DPXR8-15 unit in production.