### PR TITLE
add EnumAsHumanReadableLabel option to metric types

### DIFF
--- a/collector_test.go
+++ b/collector_test.go
@@ -430,6 +430,21 @@ func TestPduToSample(t *testing.T) {
 			metric: &config.Metric{
 				Name:       "test_metric",
 				Oid:        "1.1",
+				Type:       "EnumAsHumanReadableLabel",
+				Help:       "Help string",
+				EnumValues: map[int]string{0: "foo", 1: "bar", 2: "baz"},
+			},
+			expectedMetrics: []string{`Desc{fqName: "test_metric", help: "Help string (EnumAsHumanReadableLabel)", constLabels: {}, variableLabels: [human_readable]} label:<name:"human_readable" value:"baz" > gauge:<value:2 > `},
+		},
+		{
+			pdu: &gosnmp.SnmpPDU{
+				Name:  "1.1",
+				Type:  gosnmp.Integer,
+				Value: 2,
+			},
+			metric: &config.Metric{
+				Name:       "test_metric",
+				Oid:        "1.1",
 				Type:       "EnumAsInfo",
 				Help:       "Help string",
 				EnumValues: map[int]string{0: "foo", 1: "bar", 2: "baz"},

--- a/generator/README.md
+++ b/generator/README.md
@@ -125,6 +125,7 @@ modules:
                              #   InetAddress: An InetAddress per RFC 4001. Must be preceded by an InetAddressType.
                              #   InetAddressMissingSize: An InetAddress that violates section 4.1 of RFC 4001 by
                              #       not having the size in the index. Must be preceded by an InetAddressType.
+                             #   EnumAsHumanReadableLabel: An enum which does not change the metric exept for adding a `human_readable` label. Similar to EnumAsInfo, but preserves the metrics value.
                              #   EnumAsInfo: An enum for which a single timeseries is created. Good for constant values.
                              #   EnumAsStateSet: An enum with a time series per state. Good for variable low-cardinality enums.
                              #   Bits: An RFC 2578 BITS construct, which produces a StateSet with a time series per bit.


### PR DESCRIPTION
I've been playing around with Enums and built the additional EnumAsHumanReadableLabel type. An example:

```
# EnumAsStateSet, creates a metric for any of the 6 BGP Session States
bgp_peer_state{bgp_peer_state="established",peer="80.81.195.42",remote_as="3856"} 1
bgp_peer_state{bgp_peer_state="idle",peer="80.81.195.42",remote_as="3856"} 0

# EnumAsInfo, sets the renamed metric to a constant 1 and encodes the info as label
bgp_peer_state_info{bgp_peer_state="established",peer="80.81.195.42",remote_as="3856"} 1

# EnumAsHumanReadableLabel, changes nothing about the metric, but adds a label to make the metric self-documenting
bgp_peer_state{human_readable="established",peer="80.81.195.42",remote_as="3856"} 6
```
I'm not sureabout the implications on cardinality/efficiency, but I find it convenient myself.

The `snmp.yml` I've been testing with:
```
bgp:
  walk:
  - 1.3.6.1.4.1.9.9.187.1.2.5.1.3  # cbgpPeer2State
  - 1.3.6.1.4.1.9.9.187.1.2.5.1.11 # cbgpPeer2RemoteAs
  metrics:
  - name: bgp_peer_state
    oid: 1.3.6.1.4.1.9.9.187.1.2.5.1.3
    type: EnumAsXXXXX
    help: The BGP peer connection state. - 1.3.6.1.4.1.9.9.187.1.2.5.1.3
    enum_values:
      1: idle
      2: connect
      3: active
      4: opensent
      5: openconfirm
      6: established
    indexes:
    - labelname: peer
      type: InetAddress
    lookups:
    - labelname: remote_as
      labels: [peer]
      oid: 1.3.6.1.4.1.9.9.187.1.2.5.1.11
      type: gauge
```