### PR TITLE
the feature which allows to upload config and reload, was developed to snmp_exporter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,3 +69,12 @@ In order to provide accurate counters for large Counter64 values, the exporter w
 wrap the value every 2^53 to avoid 64-bit float rounding.
 
 To disable this feature, use the command line flag `--no-snmp.wrap-large-counters`.
+
+## Upload dynamic config
+
+Snmp exporter allow to upload config file and reload it.
+
+To enable this feature, use the command line flag `--upload.config`.
+
+If the uploaded file is desired to be permanent, use the command line flag `--upload.persistent`.
+It will overwrite current config file.


### PR DESCRIPTION
Thanks to the feature, config file can be upload and reload. Also, uploaded config can be permanent if prefer it. @brian-brazil 
