### PR TITLE
constant label parameter added

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -327,12 +327,30 @@ func pduToSamples(indexOids []int, pdu *gosnmp.SnmpPDU, metric *config.Metric, o
 
 	value := getPduValue(pdu)
 	t := prometheus.UntypedValue
+	
+	labels_length := len(labels) + len(metric.Labels) + 1
 
-	labelnames := make([]string, 0, len(labels)+1)
-	labelvalues := make([]string, 0, len(labels)+1)
+	labelnames := make([]string, 0, labels_length)
+	labelvalues := make([]string, 0, labels_length)
+
+	// Add labels returned from "indexes to labels"
 	for k, v := range labels {
 		labelnames = append(labelnames, k)
 		labelvalues = append(labelvalues, v)
+	}
+
+	// Add constant labels if any
+	if len(metric.Labels) > 0 {
+		level.Debug(logger).Log("msg", "Metric:", "Name", metric.Name, "OID", metric.Oid)
+
+		for ln, lv := range metric.Labels {
+			tmp_label_name := string(ln)
+			tmp_label_value := string(lv)
+			level.Debug(logger).Log("msg", "Constant Label", "name", tmp_label_name, "value", tmp_label_value)
+
+			labelnames = append(labelnames, tmp_label_name)
+			labelvalues = append(labelvalues, tmp_label_value)
+		}
 	}
 
 	switch metric.Type {

--- a/config/config.go
+++ b/config/config.go
@@ -178,7 +178,7 @@ type Metric struct {
 	Lookups        []*Lookup                  `yaml:"lookups,omitempty"`
 	RegexpExtracts map[string][]RegexpExtract `yaml:"regex_extracts,omitempty"`
 	EnumValues     map[int]string             `yaml:"enum_values,omitempty"`
-	Labels    	   model.LabelSet             `yaml:"const_labels,omitempty"`
+	Labels         model.LabelSet             `yaml:"const_labels,omitempty"`
 }
 
 type Index struct {

--- a/config/config.go
+++ b/config/config.go
@@ -18,7 +18,7 @@ import (
 	"io/ioutil"
 	"regexp"
 	"time"
-
+	"github.com/prometheus/common/model"
 	"github.com/soniah/gosnmp"
 	"gopkg.in/yaml.v2"
 )
@@ -178,6 +178,7 @@ type Metric struct {
 	Lookups        []*Lookup                  `yaml:"lookups,omitempty"`
 	RegexpExtracts map[string][]RegexpExtract `yaml:"regex_extracts,omitempty"`
 	EnumValues     map[int]string             `yaml:"enum_values,omitempty"`
+	Labels    	   model.LabelSet             `yaml:"const_labels,omitempty"`
 }
 
 type Index struct {


### PR DESCRIPTION
@brian-brazil 

Here the use case is as follows;
* We have thousands of interfaces on the network elements that we need to monitor (say 10000)
* We're only interested in a subset of these interfaces (say 100)
* We know the "ifIndex" of these specific interfaces along with their descriptions etc. (we have network inventory)
* If snmp_exporter allows us to "specify" "constant labels" for the metrics, we're able to define "metrics" and assign "constant labels" to each metric.

Example config:

```yaml
10.0.0.2:
  get:
  - 1.3.6.1.2.1.31.1.1.1.6.1
  - 1.3.6.1.2.1.31.1.1.1.6.10
  metrics:
  - name: ifHCInOctets
    oid: 1.3.6.1.2.1.31.1.1.1.6.1
    type: counter
    const_labels:
      lag_name: LAG00
      port_name: Ge 1/1/0
      region_name: NY
      city_name: NYC
      ifIndex: 1 

  - name: ifHCInOctets
    oid: 1.3.6.1.2.1.31.1.1.1.6.10
    type: counter
    const_labels:
      lag_name: LAG01
      port_name: Ge 2/0
      region_name: NY
      city_name: NYC
      ifIndex: 10
```