### PR TITLE
Reduce and fix timeout/docs for SNMP requests

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -88,9 +88,8 @@ func ScrapeTarget(ctx context.Context, target string, config *config.Module, log
 	snmp := gosnmp.GoSNMP{}
 	snmp.Context = ctx
 	snmp.MaxRepetitions = config.WalkParams.MaxRepetitions
-	// User specifies timeout of each retry attempt but GoSNMP expects total timeout for all attempts.
 	snmp.Retries = config.WalkParams.Retries
-	snmp.Timeout = config.WalkParams.Timeout * time.Duration(snmp.Retries)
+	snmp.Timeout = config.WalkParams.Timeout
 
 	snmp.Target = target
 	snmp.Port = 161

--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,7 @@ var (
 		Version:        2,
 		MaxRepetitions: 25,
 		Retries:        3,
-		Timeout:        time.Second * 20,
+		Timeout:        time.Second * 5,
 		Auth:           DefaultAuth,
 	}
 	DefaultModule = Module{

--- a/generator/README.md
+++ b/generator/README.md
@@ -63,7 +63,7 @@ modules:
     max_repetitions: 25  # How many objects to request with GET/GETBULK, defaults to 25.
                          # May need to be reduced for buggy devices.
     retries: 3   # How many times to retry a failed request, defaults to 3.
-    timeout: 10s # Timeout for each walk, defaults to 10s.
+    timeout: 5s  # Timeout for each individual SNMP request, defaults to 5s.
 
     auth:
       # Community string is used with SNMP v1 and v2. Defaults to "public".


### PR DESCRIPTION
Upstream changed how their timeout&retries interacted, so
we no longer need to adjust things.

Our docs and code were also out of sync, but let's just reduce timeouts
to 2s as that should be plenty of time for a single GETBULK

Fixes #507

Signed-off-by: Brian Brazil <brian.brazil@robustperception.io>