### PR TITLE
update port to variable from hard code

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -93,7 +93,7 @@ func ScrapeTarget(ctx context.Context, target string, config *config.Module, log
 	snmp.Timeout = config.WalkParams.Timeout * time.Duration(snmp.Retries)
 
 	snmp.Target = target
-	snmp.Port = 161
+	snmp.Port = config.WalkParams.Port
 	if host, port, err := net.SplitHostPort(target); err == nil {
 		snmp.Target = host
 		p, err := strconv.Atoi(port)

--- a/config/config.go
+++ b/config/config.go
@@ -49,6 +49,7 @@ var (
 		Retries:        3,
 		Timeout:        time.Second * 20,
 		Auth:           DefaultAuth,
+		Port:           161,
 	}
 	DefaultModule = Module{
 		WalkParams: DefaultWalkParams,
@@ -67,6 +68,7 @@ type WalkParams struct {
 	Retries        int           `yaml:"retries,omitempty"`
 	Timeout        time.Duration `yaml:"timeout,omitempty"`
 	Auth           Auth          `yaml:"auth,omitempty"`
+	Port           uint16        `yaml:"port,omitempty"`
 }
 
 type Module struct {

--- a/generator/README.md
+++ b/generator/README.md
@@ -64,6 +64,7 @@ modules:
                          # May need to be reduced for buggy devices.
     retries: 3   # How many times to retry a failed request, defaults to 3.
     timeout: 10s # Timeout for each walk, defaults to 10s.
+    port: 161    # Port for each walk, defaults to 161.
 
     auth:
       # Community string is used with SNMP v1 and v2. Defaults to "public".


### PR DESCRIPTION
## Issue
Snmp port number is hard code (161).
  - https://github.com/prometheus/snmp_exporter/blob/v0.17.0/collector.go#L96

So I cannot use this exporter when not using default port by snmpd

## Proposal
User can set port number on snmp.yml (via generator)