### PR TITLE
Allow lookup chaining for uints

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -702,9 +702,7 @@ func indexesToLabels(indexOids []int, metric *config.Metric, oidToPdu map[string
 		}
 		if pdu, ok := oidToPdu[oid]; ok {
 			labels[lookup.Labelname] = pduValueAsString(&pdu, lookup.Type)
-			if _, ok := pdu.Value.(int); ok {
-				labelOids[lookup.Labelname] = []int{pdu.Value.(int)}
-			}
+			labelOids[lookup.Labelname] = []int{int(gosnmp.ToBigInt(pdu.Value).Int64())}
 		} else {
 			labels[lookup.Labelname] = ""
 		}

--- a/collector_test.go
+++ b/collector_test.go
@@ -972,6 +972,22 @@ func TestIndexesToLabels(t *testing.T) {
 			},
 			result: map[string]string{"a": "1", "chainable_id": "42", "targetlabel": "targetvalue"},
 		},
+		{
+			oid: []int{1, 1, 1, 1},
+			metric: config.Metric{
+				Indexes: []*config.Index{{Labelname: "a", Type: "gauge"}},
+				Lookups: []*config.Lookup{
+					{Labels: []string{"a"}, Labelname: "chainable_id", Oid: "1.1.1.2"},
+					{Labels: []string{"chainable_id"}, Labelname: "targetlabel", Oid: "2.2.2"},
+				},
+			},
+			oidToPdu: map[string]gosnmp.SnmpPDU{
+				"1.1.1.1.1": gosnmp.SnmpPDU{Value: "source_obj0"},
+				"1.1.1.2.1": gosnmp.SnmpPDU{Value: uint(42)},
+				"2.2.2.42":  gosnmp.SnmpPDU{Value: "targetvalue"},
+			},
+			result: map[string]string{"a": "1", "chainable_id": "42", "targetlabel": "targetvalue"},
+		},
 	}
 	for _, c := range cases {
 		got := indexesToLabels(c.oid, &c.metric, c.oidToPdu)


### PR DESCRIPTION
I don't see how `gosnmp.ToBigInt` could return anything else than ints so I think it's safe to do it without any additional checks. Also added testcase that failed before but do not fail any more.