### PR TITLE
Add support for mini_snmpd

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -241,6 +241,25 @@ modules:
       ifType:
         type: EnumAsInfo
 
+# mini_snmpd / OpenWRT
+#
+# Small SNMP daemon included in OpenWRT (among others).
+# The list of SNMP OIDs to care about can be found here: https://openwrt.org/docs/guide-user/services/snmp/mini_snmpd
+#
+# Tested on TP-LINK TL-WR703N v1 with OpenWRT 17.01.7.
+#
+  mini_snmpd:
+    walk: [hrSystemUptime, sysUpTime, interfaces]
+    lookups:
+      - source_indexes: [ifIndex]
+        # Uis OID to avoid conflict with PaloAlto PAN-COMMON-MIB.
+        lookup: 1.3.6.1.2.1.2.2.1.2 # ifDescr
+    overrides:
+      ifDescr:
+        ignore: true # Lookup metric
+      ifType:
+        type: EnumAsInfo
+
 # Ubiquiti / AirFiber
 #
 # https://www.ui.com/downloads/firmwares/airfiber5X/v4.0.5/UBNT-MIB.txt


### PR DESCRIPTION
Some small devices running openWRT can't afford proper SNMP daemons and use mini_snmpd instead, this adds support for this basic daemon, which does not implement if_mib.