### PR TITLE
Properly parse the value of PhysAddress48 string metrics

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -552,6 +552,14 @@ func pduValueAsString(pdu *gosnmp.SnmpPDU, typ string) string {
 			// Trim leading period.
 			return pdu.Value.(string)[1:]
 		}
+		if typ == "PhysAddress48" {
+			parts := make([]int, len([]byte(pdu.Value.(string))))
+			for i, o := range []byte(pdu.Value.(string)) {
+				parts[i] = int(o)
+			}
+			str, _, _ := indexOidsAsString(parts, typ, 0, false, nil)
+			return str
+		}
 		// DisplayString.
 		return pdu.Value.(string)
 	case []byte:

--- a/collector_test.go
+++ b/collector_test.go
@@ -514,6 +514,22 @@ func TestPduToSample(t *testing.T) {
 				`Desc{fqName: "test_metric", help: "Help string (Bits)", constLabels: {}, variableLabels: [test_metric]} label:<name:"test_metric" value:"missing" > gauge:<value:0 > `,
 			},
 		},
+		{
+			pdu: &gosnmp.SnmpPDU{
+				Name:  "1.1",
+				Type:  gosnmp.OctetString,
+				Value: "\u0000�H\u0000\u0011\"",
+			},
+			metric: &config.Metric{
+				Name: "test_metric",
+				Oid:  "1.1",
+				Type: "PhysAddress48",
+				Help: "Help string",
+			},
+			expectedMetrics: []string{
+				`Desc{fqName: "test_metric", help: "Help string", constLabels: {}, variableLabels: [test_metric]} label:<name:"test_metric" value:"00:EF:BF:BD:48:00" > gauge:<value:1 > `,
+			},
+		},
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
I discovered what appears to be a small bug. After generating an snmp.yml that contained following section
```yaml
  - name: ifPhysAddress
    oid: 1.3.6.1.2.1.2.2.1.6
    type: PhysAddress48
    help: The interface's address at its protocol sub-layer - 1.3.6.1.2.1.2.2.1.6
    indexes:
    - labelname: ifIndex
      type: gauge
```

Not sure if it matters, but my case was retrieving physical addresses from mac minis. I did some digging and as it turns out the snmp_exporter only handles the `PhysAddress48` type if it is returned as a `[]byte` but it appears that in some cases it is actually returned from gosnmp as a `string`. Included is the simple logic and test to handle this case.  
When a user such as I encounters this case, the snmp_exporter will scrape but not return any values scraped, instead errors generated by [this line](https://github.com/prometheus/snmp_exporter/blob/master/collector.go#L409) show. 

The one case I did not handle is that it is possible for the string to come back as `""` in this case the resulting mac address is `00:00:00:00:00:00`.  

@brian-brazil small fix as per contributing instructions. 