### PR TITLE
Fix issue where macOS would error on 'make mibs'

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -166,7 +166,7 @@ $(MIBDIR)/.kemp-lm:
 	@curl $(CURL_OPTS) -o $(TMP) $(KEMP_LM_URL)
 	@unzip -j -d $(MIBDIR) $(TMP) *.txt
 	# Workaround invalid timestamps.
-	@sed -i -E 's/"([0-9]{12})[0-9]{2}Z"/"\1Z"/' $(MIBDIR)/*.RELEASE-B100-MIB.txt
+	@sed -i -E 's/"\([0-9]{12}\)[0-9]{2}Z"/"\1Z"/' $(MIBDIR)/*.RELEASE-B100-MIB.txt
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.kemp-lm
 

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -166,7 +166,7 @@ $(MIBDIR)/.kemp-lm:
 	@curl $(CURL_OPTS) -o $(TMP) $(KEMP_LM_URL)
 	@unzip -j -d $(MIBDIR) $(TMP) *.txt
 	# Workaround invalid timestamps.
-	@sed -i -E 's/"\([0-9]{12}\)[0-9]{2}Z"/"\1Z"/' $(MIBDIR)/*.RELEASE-B100-MIB.txt
+	@sed -i -e 's/"\([0-9]{12}\)[0-9]{2}Z"/"\1Z"/' $(MIBDIR)/*.RELEASE-B100-MIB.txt
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.kemp-lm
 


### PR DESCRIPTION
While trying to pull the MIBs using the ```make mibs``` command on macOS, it would fail with the following error:
```
sed: 1: "s/"([0-9]{12})[0-9]{2}Z ...": \1 not defined in the RE
make: *** [mibs/.kemp-lm] Error 1
```
This was fixed by properly escaping the regex in the Makefile. See also: 
https://stackoverflow.com/questions/24717676/bash-profile-sed-1-not-defined-in-the-re