### PR TITLE
Split collector into separate package

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package collector
 
 import (
 	"context"
@@ -26,13 +26,14 @@ import (
 	"github.com/go-kit/kit/log/level"
 	"github.com/gosnmp/gosnmp"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"gopkg.in/alecthomas/kingpin.v2"
 
 	"github.com/prometheus/snmp_exporter/config"
 )
 
 var (
-	snmpUnexpectedPduType = prometheus.NewCounter(
+	snmpUnexpectedPduType = promauto.NewCounter(
 		prometheus.CounterOpts{
 			Name: "snmp_unexpected_pdu_type_total",
 			Help: "Unexpected Go types in a PDU.",
@@ -42,10 +43,6 @@ var (
 	float64Mantissa uint64 = 9007199254740992
 	wrapCounters           = kingpin.Flag("snmp.wrap-large-counters", "Wrap 64-bit counters to avoid floating point rounding.").Default("true").Bool()
 )
-
-func init() {
-	prometheus.MustRegister(snmpUnexpectedPduType)
-}
 
 // Types preceded by an enum with their actual type.
 var combinedTypeMapping = map[string]map[int]string{
@@ -209,6 +206,10 @@ type collector struct {
 	target string
 	module *config.Module
 	logger log.Logger
+}
+
+func New(target string, module *config.Module, logger log.Logger) *collector {
+	return &collector{target: target, module: module, logger: logger}
 }
 
 // Describe implements Prometheus.Collector.

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package main
+package collector
 
 import (
 	"errors"

--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 )
 
-go 1.13
+go 1.14

--- a/snmp.yml
+++ b/snmp.yml
@@ -341,6 +341,7 @@ apcups:
       298: ax25
       299: ieee19061nanocom
       300: cpri
+      301: omni
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -2659,6 +2660,7 @@ arista_sw:
       298: ax25
       299: ieee19061nanocom
       300: cpri
+      301: omni
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -3894,6 +3896,7 @@ cisco_wlc:
       298: ax25
       299: ieee19061nanocom
       300: cpri
+      301: omni
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -5022,6 +5025,7 @@ ddwrt:
       298: ax25
       299: ieee19061nanocom
       300: cpri
+      301: omni
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -6441,6 +6445,7 @@ if_mib:
       298: ax25
       299: ieee19061nanocom
       300: cpri
+      301: omni
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -9244,6 +9249,7 @@ kemp_loadmaster:
       298: ax25
       299: ieee19061nanocom
       300: cpri
+      301: omni
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -13029,6 +13035,7 @@ mikrotik:
       298: ax25
       299: ieee19061nanocom
       300: cpri
+      301: omni
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -19647,6 +19654,7 @@ paloalto_fw:
       298: ax25
       299: ieee19061nanocom
       300: cpri
+      301: omni
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -24220,6 +24228,7 @@ synology:
       298: ax25
       299: ieee19061nanocom
       300: cpri
+      301: omni
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -26771,6 +26780,7 @@ ubiquiti_airfiber:
       298: ax25
       299: ieee19061nanocom
       300: cpri
+      301: omni
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -28619,6 +28629,7 @@ ubiquiti_airmax:
       298: ax25
       299: ieee19061nanocom
       300: cpri
+      301: omni
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -29944,6 +29955,7 @@ ubiquiti_unifi:
       298: ax25
       299: ieee19061nanocom
       300: cpri
+      301: omni
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge


### PR DESCRIPTION
Make it easier to embed the snmp_exporter into other systems.
* Update metric registration to use promauto.
* Update minimum version to Go 1.14. (required for exporter-toolkit)
* Update snmp.yml with latest mibs.

Re-implementation of https://github.com/prometheus/snmp_exporter/pull/456

Signed-off-by: Ben Kochie <superq@gmail.com>