### PR TITLE
Add Vertiv Geist PDU support and some generator cleanup

### DIFF
--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:latest
+FROM golang:1.15
 
 RUN apt-get update && \
     apt-get install -y libsnmp-dev p7zip-full unzip && \

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -42,6 +42,7 @@ SYNOLOGY_URL      := 'https://global.download.synology.com/download/Document/Sof
 UBNT_AIRFIBER_URL := https://dl.ubnt.com/firmwares/airfiber5X/v4.1.0/UBNT-MIB.txt
 UBNT_AIROS_URL    := https://dl.ubnt.com/firmwares/airos-ubnt-mib/ubnt-mib.zip
 UBNT_DL_URL       := http://dl.ubnt-ut.com/snmp
+VERTIV_GEIST_URL  := https://www.vertiv.com/4ae12a/globalassets/documents/firmware/geist/geist-r05-5_7_0-11112020.zip
 WIENER_URL        := https://file.wiener-d.com/software/net-snmp/WIENER-CRATE-MIB-5704.zip
 
 .DEFAULT: all
@@ -94,6 +95,7 @@ mibs: mib-dir \
   $(MIBDIR)/ARISTA-ENTITY-SENSOR-MIB \
   $(MIBDIR)/ARISTA-SMI-MIB \
   $(MIBDIR)/ARISTA-SW-IP-FORWARDING-MIB \
+  $(MIBDIR)/geist_v5.mib \
   $(MIBDIR)/IANA-CHARSET-MIB.txt \
   $(MIBDIR)/IANA-IFTYPE-MIB.txt \
   $(MIBDIR)/IANA-PRINTER-MIB.txt \
@@ -268,6 +270,14 @@ $(MIBDIR)/UBNT-AirMAX-MIB.txt:
 $(MIBDIR)/UBNT-UniFi-MIB:
 	@echo ">> Downloading UBNT-UniFi-MIB"
 	@curl $(CURL_OPTS) -o $(MIBDIR)/UBNT-UniFi-MIB "$(UBNT_DL_URL)/UBNT-UniFi-MIB"
+
+# vertiv_geist
+$(MIBDIR)/geist_v5.mib:
+	$(eval TMP := $(shell mktemp))
+	@echo ">> Downloading vertiv_geist to $(TMP)"
+	@curl $(CURL_OPTS) -o $(TMP) $(VERTIV_GEIST_URL)
+	@unzip -j -d $(MIBDIR) $(TMP)
+	@rm -v $(TMP)
 
 $(MIBDIR)/WIENER-CRATE-MIB-5704.txt:
 	$(eval TMP := $(shell mktemp))

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -71,6 +71,10 @@ parse_errors: generator mibs
 docker:
 	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
 
+.PHONY: docker-generate
+docker-generate: docker
+	docker run --rm -it -v $(PWD):/workdir -w /workdir "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)"
+
 .PHONY: docker-publish
 docker-publish:
 	docker push "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)"

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -26,23 +26,23 @@ CISCO_URL         := 'ftp://ftp.cisco.com/pub/mibs/v2/v2.tar.gz'
 IANA_CHARSET_URL  := https://www.iana.org/assignments/ianacharset-mib/ianacharset-mib
 IANA_IFTYPE_URL   := https://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib
 IANA_PRINTER_URL  := https://www.iana.org/assignments/ianaprinter-mib/ianaprinter-mib
+INFRAPOWER_URL    := https://www.austin-hughes.com/support/software/infrapower/IPD-MIB.7z
 KEEPALIVED_URL    := https://raw.githubusercontent.com/acassen/keepalived/v2.1.5/doc/KEEPALIVED-MIB.txt
 KEMP_LM_URL       := https://kemptechnologies.com/files/packages/current/LM_mibs.zip
+LIEBERT_URL       := https://www.vertiv.com/492204/contentassets/b00273585e0a453a9c983523e8a0d6ff/lgpmib-unix_rev16.tar
 MIKROTIK_URL      := 'https://box.mikrotik.com/f/a41daf63d0c14347a088/?dl=1'
 NEC_URL           := https://jpn.nec.com/univerge/ix/Manual/MIB
 NET_SNMP_URL      := https://raw.githubusercontent.com/net-snmp/net-snmp/v5.9/mibs
 PALOALTO_URL      := https://docs.paloaltonetworks.com/content/dam/techdocs/en_US/zip/snmp-mib/pan-10-0-snmp-mib-modules.zip
 PRINTER_URL       := https://ftp.pwg.org/pub/pwg/pmp/mibs/rfc3805b.mib
+RARITAN_URL       := http://cdn.raritan.com/download/PX/v1.5.20/PDU-MIB.txt
 SERVERTECH_URL    := 'https://cdn10.servertech.com/assets/documents/documents/817/original/Sentry3.mib'
 SERVERTECH4_URL   := 'https://cdn10.servertech.com/assets/documents/documents/815/original/Sentry4.mib'
 SYNOLOGY_URL      := 'https://global.download.synology.com/download/Document/Software/DeveloperGuide/Firmware/DSM/All/enu/Synology_MIB_File.zip'
-UBNT_AIROS_URL    := https://dl.ubnt.com/firmwares/airos-ubnt-mib/ubnt-mib.zip
 UBNT_AIRFIBER_URL := https://dl.ubnt.com/firmwares/airfiber5X/v4.1.0/UBNT-MIB.txt
+UBNT_AIROS_URL    := https://dl.ubnt.com/firmwares/airos-ubnt-mib/ubnt-mib.zip
 UBNT_DL_URL       := http://dl.ubnt-ut.com/snmp
 WIENER_URL        := https://file.wiener-d.com/software/net-snmp/WIENER-CRATE-MIB-5704.zip
-RARITAN_URL       := http://cdn.raritan.com/download/PX/v1.5.20/PDU-MIB.txt
-INFRAPOWER_URL    := https://www.austin-hughes.com/support/software/infrapower/IPD-MIB.7z
-LIEBERT_URL       := https://www.vertiv.com/492204/contentassets/b00273585e0a453a9c983523e8a0d6ff/lgpmib-unix_rev16.tar
 
 .DEFAULT: all
 
@@ -81,33 +81,33 @@ docker-tag-latest:
 
 .PHONY: mibs
 mibs: mib-dir \
+  $(MIBDIR)/.cisco_v2 \
+  $(MIBDIR)/.kemp-lm \
+  $(MIBDIR)/.net-snmp \
+  $(MIBDIR)/.paloalto_panos \
+  $(MIBDIR)/.synology \
   $(MIBDIR)/apc-powernet-mib \
   $(MIBDIR)/ARISTA-ENTITY-SENSOR-MIB \
   $(MIBDIR)/ARISTA-SMI-MIB \
   $(MIBDIR)/ARISTA-SW-IP-FORWARDING-MIB \
-  $(MIBDIR)/.cisco_v2 \
   $(MIBDIR)/IANA-CHARSET-MIB.txt \
   $(MIBDIR)/IANA-IFTYPE-MIB.txt \
   $(MIBDIR)/IANA-PRINTER-MIB.txt \
+  $(MIBDIR)/IPD-MIB_Q419V9.mib \
   $(MIBDIR)/KEEPALIVED-MIB \
-  $(MIBDIR)/.kemp-lm \
+  $(MIBDIR)/LIEBERT_GP_PDU.MIB \
   $(MIBDIR)/MIKROTIK-MIB \
-  $(MIBDIR)/.net-snmp \
-  $(MIBDIR)/.paloalto_panos \
+  $(MIBDIR)/PDU-MIB.txt \
   $(MIBDIR)/PICO-IPSEC-FLOW-MONITOR-MIB.txt \
   $(MIBDIR)/PICO-SMI-ID-MIB.txt \
   $(MIBDIR)/PICO-SMI-MIB.txt \
   $(MIBDIR)/PRINTER-MIB-V2.txt \
   $(MIBDIR)/servertech-sentry3-mib \
   $(MIBDIR)/servertech-sentry4-mib \
-  $(MIBDIR)/.synology \
-  $(MIBDIR)/UBNT-UniFi-MIB \
   $(MIBDIR)/UBNT-AirFiber-MIB \
   $(MIBDIR)/UBNT-AirMAX-MIB.txt \
-  $(MIBDIR)/WIENER-CRATE-MIB-5704.txt \
-  $(MIBDIR)/PDU-MIB.txt \
-  $(MIBDIR)/IPD-MIB_Q419V9.mib \
-  $(MIBDIR)/LIEBERT_GP_PDU.MIB
+  $(MIBDIR)/UBNT-UniFi-MIB \
+  $(MIBDIR)/WIENER-CRATE-MIB-5704.txt
 
 mib-dir:
 	@mkdir -p -v $(MIBDIR)
@@ -156,9 +156,23 @@ $(MIBDIR)/IANA-PRINTER-MIB.txt:
 	@echo ">> Downloading IANA printer MIB"
 	@curl $(CURL_OPTS) -o $(MIBDIR)/IANA-PRINTER-MIB.txt $(IANA_PRINTER_URL)
 
+$(MIBDIR)/IPD-MIB_Q419V9.mib:
+	$(eval TMP := $(shell mktemp))
+	@echo ">> Downloading IPD-MIB_Q419V9 to $(TMP)"
+	@curl $(CURL_OPTS) -L -o $(TMP) $(INFRAPOWER_URL)
+	@7z e -o$(MIBDIR) $(TMP)
+	@rm -v $(TMP)
+
 $(MIBDIR)/KEEPALIVED-MIB:
 	@echo ">> Downloading KEEPALIVED-MIB"
 	@curl $(CURL_OPTS) -o $(MIBDIR)/KEEPALIVED-MIB $(KEEPALIVED_URL)
+
+$(MIBDIR)/LIEBERT_GP_PDU.MIB:
+	$(eval TMP := $(shell mktemp))
+	@echo ">> Downloading LIEBERT_GP_PDU.MIB to $(TMP)"
+	@curl $(CURL_OPTS) -o $(TMP) $(LIEBERT_URL)
+	@tar --no-same-owner -C $(MIBDIR) -xvf $(TMP)
+	@rm -v $(TMP)
 
 $(MIBDIR)/.kemp-lm:
 	$(eval TMP := $(shell mktemp))
@@ -191,6 +205,14 @@ $(MIBDIR)/.net-snmp:
 	@curl $(CURL_OPTS) -o $(MIBDIR)/UCD-SNMP-MIB $(NET_SNMP_URL)/UCD-SNMP-MIB.txt
 	@touch $(MIBDIR)/.net-snmp
 
+$(MIBDIR)/.paloalto_panos:
+	$(eval TMP := $(shell mktemp))
+	@echo ">> Downloading paloalto_pano to $(TMP)"
+	@curl $(CURL_OPTS) -o $(TMP) $(PALOALTO_URL)
+	@unzip -j -d $(MIBDIR) $(TMP)
+	@rm -v $(TMP)
+	@touch $(MIBDIR)/.paloalto_panos
+
 $(MIBDIR)/PICO-IPSEC-FLOW-MONITOR-MIB.txt:
 	@echo ">> Downloading PICO-IPSEC-FLOW-MONITOR-MIB.txt"
 	@curl $(CURL_OPTS) -o $(MIBDIR)/PICO-IPSEC-FLOW-MONITOR-MIB.txt "$(NEC_URL)/PICO-IPSEC-FLOW-MONITOR-MIB.txt"
@@ -203,17 +225,14 @@ $(MIBDIR)/PICO-SMI-ID-MIB.txt:
 	@echo ">> Downloading PICO-SMI-ID-MIB.txt"
 	@curl $(CURL_OPTS) -o $(MIBDIR)/PICO-SMI-ID-MIB.txt "$(NEC_URL)/PICO-SMI-ID-MIB.txt"
 
-$(MIBDIR)/.paloalto_panos:
-	$(eval TMP := $(shell mktemp))
-	@echo ">> Downloading paloalto_pano to $(TMP)"
-	@curl $(CURL_OPTS) -o $(TMP) $(PALOALTO_URL)
-	@unzip -j -d $(MIBDIR) $(TMP)
-	@rm -v $(TMP)
-	@touch $(MIBDIR)/.paloalto_panos
-
 $(MIBDIR)/PRINTER-MIB-V2.txt:
 	@echo ">> Downloading Printer MIB v2"
 	@curl $(CURL_OPTS) -o $(MIBDIR)/PRINTER-MIB-V2.txt $(PRINTER_URL)
+
+# raritan
+$(MIBDIR)/PDU-MIB.txt:
+	@echo ">> Downloading PDU-MIB"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/PDU-MIB.txt "$(RARITAN_URL)"
 
 $(MIBDIR)/servertech-sentry3-mib:
 	@echo ">> Downloading servertech-sentry3-mib"
@@ -231,10 +250,6 @@ $(MIBDIR)/.synology:
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.synology
 
-$(MIBDIR)/UBNT-UniFi-MIB:
-	@echo ">> Downloading UBNT-UniFi-MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/UBNT-UniFi-MIB "$(UBNT_DL_URL)/UBNT-UniFi-MIB"
-
 $(MIBDIR)/UBNT-AirFiber-MIB:
 	@echo ">> Downloading UBNT-AirFiber-MIB"
 	@curl $(CURL_OPTS) -o $(MIBDIR)/UBNT-AirFiber-MIB $(UBNT_AIRFIBER_URL)
@@ -246,27 +261,13 @@ $(MIBDIR)/UBNT-AirMAX-MIB.txt:
 	@unzip -j -d $(MIBDIR) $(TMP) UBNT-AirMAX-MIB.txt
 	@rm -v $(TMP)
 
+$(MIBDIR)/UBNT-UniFi-MIB:
+	@echo ">> Downloading UBNT-UniFi-MIB"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/UBNT-UniFi-MIB "$(UBNT_DL_URL)/UBNT-UniFi-MIB"
+
 $(MIBDIR)/WIENER-CRATE-MIB-5704.txt:
 	$(eval TMP := $(shell mktemp))
 	@echo ">> Downloading WIENER-CRATE-MIB to $(TMP)"
 	@curl $(CURL_OPTS) -o $(TMP) $(WIENER_URL)
 	@unzip -j -d $(MIBDIR) $(TMP)
-	@rm -v $(TMP)
-
-$(MIBDIR)/PDU-MIB.txt:
-	@echo ">> Downloading PDU-MIB"
-	@curl $(CURL_OPTS) -o $(MIBDIR)/PDU-MIB.txt "$(RARITAN_URL)"
-
-$(MIBDIR)/IPD-MIB_Q419V9.mib:
-	$(eval TMP := $(shell mktemp))
-	@echo ">> Downloading IPD-MIB_Q419V9 to $(TMP)"
-	@curl $(CURL_OPTS) -L -o $(TMP) $(INFRAPOWER_URL)
-	@7z e -o$(MIBDIR) $(TMP)
-	@rm -v $(TMP)
-
-$(MIBDIR)/LIEBERT_GP_PDU.MIB:
-	$(eval TMP := $(shell mktemp))
-	@echo ">> Downloading LIEBERT_GP_PDU.MIB to $(TMP)"
-	@curl $(CURL_OPTS) -o $(TMP) $(LIEBERT_URL)
-	@tar --no-same-owner -C $(MIBDIR) -xvf $(TMP)
 	@rm -v $(TMP)

--- a/generator/README.md
+++ b/generator/README.md
@@ -37,12 +37,10 @@ If you would like to run the generator in docker to generate your `snmp.yml` con
 The Docker image expects a directory containing the `generator.yml` and a directory called `mibs` that contains all MIBs you wish to use.
 
 This example will generate the example `snmp.yml` which is included in the top level of the snmp_exporter repo:
+
 ```sh
 make mibs
-docker build -t snmp-generator .
-docker run -ti \
-  -v "${PWD}:/opt/" \
-  snmp-generator generate
+docker docker-generate
 ```
 
 ## File Format

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -646,3 +646,31 @@ modules:
         ignore: true # Lookup metric
       ifType:
         type: EnumAsInfo
+
+  # Vertiv Geist PDU
+  #
+  # https://www.vertiv.com/en-us/support/software-download/power-distribution/geist-r-series-v5-firmware/
+  # https://www.vertiv.com/4ae12a/globalassets/documents/firmware/geist/geist-r05-5_7_0-11112020.zip
+  vertiv_geist_pdu:
+    walk:
+      - sysUpTime
+      - deviceCount
+      - productAlarmCount
+      - productWarnCount
+      - pduMainTable
+      - pduPhaseTable
+      - pduBreakerTable
+      - pduLineTable
+      - pduOutletMeterTable
+
+    lookups:
+      - source_indexes: [pduMainIndex]
+        lookup: pduMainName
+      - source_indexes: [pduPhaseIndex]
+        lookup: pduPhaseName
+      - source_indexes: [pduBreakerIndex]
+        lookup: pduBreakerName
+      - source_indexes: [pduLineIndex]
+        lookup: pduLineName
+      - source_indexes: [pduOutletMeterIndex]
+        lookup: pduOutletMeterName

--- a/snmp.yml
+++ b/snmp.yml
@@ -31139,6 +31139,583 @@ ubiquiti_unifi:
     oid: 1.3.6.1.4.1.41112.1.6.3.6
     type: DisplayString
     help: ' - 1.3.6.1.4.1.41112.1.6.3.6'
+vertiv_geist_pdu:
+  walk:
+  - 1.3.6.1.4.1.21239.5.2.3.1
+  - 1.3.6.1.4.1.21239.5.2.3.2
+  - 1.3.6.1.4.1.21239.5.2.3.3
+  - 1.3.6.1.4.1.21239.5.2.3.4
+  - 1.3.6.1.4.1.21239.6.1.99.8
+  get:
+  - 1.3.6.1.2.1.1.3.0
+  - 1.3.6.1.4.1.21239.5.2.1.13.0
+  - 1.3.6.1.4.1.21239.5.2.1.14.0
+  - 1.3.6.1.4.1.21239.5.2.1.6.0
+  metrics:
+  - name: sysUpTime
+    oid: 1.3.6.1.2.1.1.3
+    type: gauge
+    help: The time (in hundredths of a second) since the network management portion
+      of the system was last re-initialized. - 1.3.6.1.2.1.1.3
+  - name: productAlarmCount
+    oid: 1.3.6.1.4.1.21239.5.2.1.13
+    type: gauge
+    help: Number of alarms currently tripped - 1.3.6.1.4.1.21239.5.2.1.13
+  - name: productWarnCount
+    oid: 1.3.6.1.4.1.21239.5.2.1.14
+    type: gauge
+    help: Number of warnings currently tripped - 1.3.6.1.4.1.21239.5.2.1.14
+  - name: deviceCount
+    oid: 1.3.6.1.4.1.21239.5.2.1.6
+    type: gauge
+    help: Total number of devices on unit - 1.3.6.1.4.1.21239.5.2.1.6
+  - name: pduMainIndex
+    oid: 1.3.6.1.4.1.21239.5.2.3.1.1.1
+    type: gauge
+    help: Table entry index value - 1.3.6.1.4.1.21239.5.2.3.1.1.1
+    indexes:
+    - labelname: pduMainIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduMainIndex
+      labelname: pduMainName
+      oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+      type: DisplayString
+  - name: pduMainSerial
+    oid: 1.3.6.1.4.1.21239.5.2.3.1.1.2
+    type: DisplayString
+    help: Serial number - 1.3.6.1.4.1.21239.5.2.3.1.1.2
+    indexes:
+    - labelname: pduMainIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduMainIndex
+      labelname: pduMainName
+      oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+      type: DisplayString
+  - name: pduMainName
+    oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+    type: DisplayString
+    help: PDU name (factory-assigned) - 1.3.6.1.4.1.21239.5.2.3.1.1.3
+    indexes:
+    - labelname: pduMainIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduMainIndex
+      labelname: pduMainName
+      oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+      type: DisplayString
+  - name: pduMainLabel
+    oid: 1.3.6.1.4.1.21239.5.2.3.1.1.4
+    type: DisplayString
+    help: PDU label (user-defined) - 1.3.6.1.4.1.21239.5.2.3.1.1.4
+    indexes:
+    - labelname: pduMainIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduMainIndex
+      labelname: pduMainName
+      oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+      type: DisplayString
+  - name: pduMainAvail
+    oid: 1.3.6.1.4.1.21239.5.2.3.1.1.5
+    type: gauge
+    help: 'Device availability: 0 = Unavailable 1 = Available 2 = Partially Unavailable
+      - 1.3.6.1.4.1.21239.5.2.3.1.1.5'
+    indexes:
+    - labelname: pduMainIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduMainIndex
+      labelname: pduMainName
+      oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+      type: DisplayString
+  - name: pduMeterType
+    oid: 1.3.6.1.4.1.21239.5.2.3.1.1.6
+    type: gauge
+    help: 'Current meter type: 0 = Wye 1 = Delta - 1.3.6.1.4.1.21239.5.2.3.1.1.6'
+    indexes:
+    - labelname: pduMainIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduMainIndex
+      labelname: pduMainName
+      oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+      type: DisplayString
+    enum_values:
+      0: wye
+      1: delta
+  - name: pduTotalName
+    oid: 1.3.6.1.4.1.21239.5.2.3.1.1.7
+    type: DisplayString
+    help: Total name (factory-assigned) - 1.3.6.1.4.1.21239.5.2.3.1.1.7
+    indexes:
+    - labelname: pduMainIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduMainIndex
+      labelname: pduMainName
+      oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+      type: DisplayString
+  - name: pduTotalLabel
+    oid: 1.3.6.1.4.1.21239.5.2.3.1.1.8
+    type: DisplayString
+    help: Total label (user-defined) - 1.3.6.1.4.1.21239.5.2.3.1.1.8
+    indexes:
+    - labelname: pduMainIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduMainIndex
+      labelname: pduMainName
+      oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+      type: DisplayString
+  - name: pduTotalRealPower
+    oid: 1.3.6.1.4.1.21239.5.2.3.1.1.9
+    type: gauge
+    help: PDU total real power - 1.3.6.1.4.1.21239.5.2.3.1.1.9
+    indexes:
+    - labelname: pduMainIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduMainIndex
+      labelname: pduMainName
+      oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+      type: DisplayString
+  - name: pduTotalApparentPower
+    oid: 1.3.6.1.4.1.21239.5.2.3.1.1.10
+    type: gauge
+    help: PDU total apparent power - 1.3.6.1.4.1.21239.5.2.3.1.1.10
+    indexes:
+    - labelname: pduMainIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduMainIndex
+      labelname: pduMainName
+      oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+      type: DisplayString
+  - name: pduTotalPowerFactor
+    oid: 1.3.6.1.4.1.21239.5.2.3.1.1.11
+    type: gauge
+    help: PDU total power factor - 1.3.6.1.4.1.21239.5.2.3.1.1.11
+    indexes:
+    - labelname: pduMainIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduMainIndex
+      labelname: pduMainName
+      oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+      type: DisplayString
+  - name: pduTotalEnergy
+    oid: 1.3.6.1.4.1.21239.5.2.3.1.1.12
+    type: gauge
+    help: PDU total accumulated energy in watt-hours - 1.3.6.1.4.1.21239.5.2.3.1.1.12
+    indexes:
+    - labelname: pduMainIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduMainIndex
+      labelname: pduMainName
+      oid: 1.3.6.1.4.1.21239.5.2.3.1.1.3
+      type: DisplayString
+  - name: pduPhaseIndex
+    oid: 1.3.6.1.4.1.21239.5.2.3.2.1.1
+    type: gauge
+    help: Table entry index value - 1.3.6.1.4.1.21239.5.2.3.2.1.1
+    indexes:
+    - labelname: pduPhaseIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduPhaseIndex
+      labelname: pduPhaseName
+      oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+      type: DisplayString
+  - name: pduPhaseName
+    oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+    type: DisplayString
+    help: PDU phase name (factory-assigned) - 1.3.6.1.4.1.21239.5.2.3.2.1.2
+    indexes:
+    - labelname: pduPhaseIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduPhaseIndex
+      labelname: pduPhaseName
+      oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+      type: DisplayString
+  - name: pduPhaseLabel
+    oid: 1.3.6.1.4.1.21239.5.2.3.2.1.3
+    type: DisplayString
+    help: PDU phase label (user-defined) - 1.3.6.1.4.1.21239.5.2.3.2.1.3
+    indexes:
+    - labelname: pduPhaseIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduPhaseIndex
+      labelname: pduPhaseName
+      oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+      type: DisplayString
+  - name: pduPhaseVoltage
+    oid: 1.3.6.1.4.1.21239.5.2.3.2.1.4
+    type: gauge
+    help: PDU phase voltage in tenths of a volt - 1.3.6.1.4.1.21239.5.2.3.2.1.4
+    indexes:
+    - labelname: pduPhaseIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduPhaseIndex
+      labelname: pduPhaseName
+      oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+      type: DisplayString
+  - name: pduPhaseCurrent
+    oid: 1.3.6.1.4.1.21239.5.2.3.2.1.8
+    type: gauge
+    help: PDU phase current reading in hundredths of an amp - 1.3.6.1.4.1.21239.5.2.3.2.1.8
+    indexes:
+    - labelname: pduPhaseIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduPhaseIndex
+      labelname: pduPhaseName
+      oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+      type: DisplayString
+  - name: pduPhaseRealPower
+    oid: 1.3.6.1.4.1.21239.5.2.3.2.1.12
+    type: gauge
+    help: Real power for phase in watts - 1.3.6.1.4.1.21239.5.2.3.2.1.12
+    indexes:
+    - labelname: pduPhaseIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduPhaseIndex
+      labelname: pduPhaseName
+      oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+      type: DisplayString
+  - name: pduPhaseApparentPower
+    oid: 1.3.6.1.4.1.21239.5.2.3.2.1.13
+    type: gauge
+    help: Apparent power for phase in volt-amps - 1.3.6.1.4.1.21239.5.2.3.2.1.13
+    indexes:
+    - labelname: pduPhaseIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduPhaseIndex
+      labelname: pduPhaseName
+      oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+      type: DisplayString
+  - name: pduPhasePowerFactor
+    oid: 1.3.6.1.4.1.21239.5.2.3.2.1.14
+    type: gauge
+    help: Power factor for phase - 1.3.6.1.4.1.21239.5.2.3.2.1.14
+    indexes:
+    - labelname: pduPhaseIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduPhaseIndex
+      labelname: pduPhaseName
+      oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+      type: DisplayString
+  - name: pduPhaseEnergy
+    oid: 1.3.6.1.4.1.21239.5.2.3.2.1.15
+    type: gauge
+    help: Accumulated energy for phase in watt-hours - 1.3.6.1.4.1.21239.5.2.3.2.1.15
+    indexes:
+    - labelname: pduPhaseIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduPhaseIndex
+      labelname: pduPhaseName
+      oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+      type: DisplayString
+  - name: pduPhaseBalance
+    oid: 1.3.6.1.4.1.21239.5.2.3.2.1.17
+    type: gauge
+    help: Phase balance as percent - 1.3.6.1.4.1.21239.5.2.3.2.1.17
+    indexes:
+    - labelname: pduPhaseIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduPhaseIndex
+      labelname: pduPhaseName
+      oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+      type: DisplayString
+  - name: pduPhaseCurrentCrestFactor
+    oid: 1.3.6.1.4.1.21239.5.2.3.2.1.19
+    type: gauge
+    help: Current crest factor for phase, in hundredths - 1.3.6.1.4.1.21239.5.2.3.2.1.19
+    indexes:
+    - labelname: pduPhaseIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduPhaseIndex
+      labelname: pduPhaseName
+      oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+      type: DisplayString
+  - name: pduPhaseResCurrentDetected
+    oid: 1.3.6.1.4.1.21239.5.2.3.2.1.20
+    type: gauge
+    help: Tells if residual current was detected - 1.3.6.1.4.1.21239.5.2.3.2.1.20
+    indexes:
+    - labelname: pduPhaseIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduPhaseIndex
+      labelname: pduPhaseName
+      oid: 1.3.6.1.4.1.21239.5.2.3.2.1.2
+      type: DisplayString
+    enum_values:
+      1: "true"
+      2: "false"
+  - name: pduBreakerIndex
+    oid: 1.3.6.1.4.1.21239.5.2.3.3.1.1
+    type: gauge
+    help: Table entry index value - 1.3.6.1.4.1.21239.5.2.3.3.1.1
+    indexes:
+    - labelname: pduBreakerIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduBreakerIndex
+      labelname: pduBreakerName
+      oid: 1.3.6.1.4.1.21239.5.2.3.3.1.2
+      type: DisplayString
+  - name: pduBreakerName
+    oid: 1.3.6.1.4.1.21239.5.2.3.3.1.2
+    type: DisplayString
+    help: PDU breaker name (factory-assigned) - 1.3.6.1.4.1.21239.5.2.3.3.1.2
+    indexes:
+    - labelname: pduBreakerIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduBreakerIndex
+      labelname: pduBreakerName
+      oid: 1.3.6.1.4.1.21239.5.2.3.3.1.2
+      type: DisplayString
+  - name: pduBreakerLabel
+    oid: 1.3.6.1.4.1.21239.5.2.3.3.1.3
+    type: DisplayString
+    help: PDU breaker label (user-defined) - 1.3.6.1.4.1.21239.5.2.3.3.1.3
+    indexes:
+    - labelname: pduBreakerIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduBreakerIndex
+      labelname: pduBreakerName
+      oid: 1.3.6.1.4.1.21239.5.2.3.3.1.2
+      type: DisplayString
+  - name: pduBreakerCurrent
+    oid: 1.3.6.1.4.1.21239.5.2.3.3.1.4
+    type: gauge
+    help: PDU breaker current reading in hundredths of an amp - 1.3.6.1.4.1.21239.5.2.3.3.1.4
+    indexes:
+    - labelname: pduBreakerIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduBreakerIndex
+      labelname: pduBreakerName
+      oid: 1.3.6.1.4.1.21239.5.2.3.3.1.2
+      type: DisplayString
+  - name: pduBreakerVoltage
+    oid: 1.3.6.1.4.1.21239.5.2.3.3.1.8
+    type: gauge
+    help: PDU breaker voltage in tenths of a volt - 1.3.6.1.4.1.21239.5.2.3.3.1.8
+    indexes:
+    - labelname: pduBreakerIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduBreakerIndex
+      labelname: pduBreakerName
+      oid: 1.3.6.1.4.1.21239.5.2.3.3.1.2
+      type: DisplayString
+  - name: pduBreakerRealPower
+    oid: 1.3.6.1.4.1.21239.5.2.3.3.1.12
+    type: gauge
+    help: Real power for breaker in watts - 1.3.6.1.4.1.21239.5.2.3.3.1.12
+    indexes:
+    - labelname: pduBreakerIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduBreakerIndex
+      labelname: pduBreakerName
+      oid: 1.3.6.1.4.1.21239.5.2.3.3.1.2
+      type: DisplayString
+  - name: pduBreakerApparentPower
+    oid: 1.3.6.1.4.1.21239.5.2.3.3.1.13
+    type: gauge
+    help: Apparent power for breaker in volt-amps - 1.3.6.1.4.1.21239.5.2.3.3.1.13
+    indexes:
+    - labelname: pduBreakerIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduBreakerIndex
+      labelname: pduBreakerName
+      oid: 1.3.6.1.4.1.21239.5.2.3.3.1.2
+      type: DisplayString
+  - name: pduBreakerPowerFactor
+    oid: 1.3.6.1.4.1.21239.5.2.3.3.1.14
+    type: gauge
+    help: Power factor for breaker - 1.3.6.1.4.1.21239.5.2.3.3.1.14
+    indexes:
+    - labelname: pduBreakerIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduBreakerIndex
+      labelname: pduBreakerName
+      oid: 1.3.6.1.4.1.21239.5.2.3.3.1.2
+      type: DisplayString
+  - name: pduBreakerEnergy
+    oid: 1.3.6.1.4.1.21239.5.2.3.3.1.15
+    type: gauge
+    help: Accumulated energy for breaker in watt-hours - 1.3.6.1.4.1.21239.5.2.3.3.1.15
+    indexes:
+    - labelname: pduBreakerIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduBreakerIndex
+      labelname: pduBreakerName
+      oid: 1.3.6.1.4.1.21239.5.2.3.3.1.2
+      type: DisplayString
+  - name: pduBreakerResCurrentDetected
+    oid: 1.3.6.1.4.1.21239.5.2.3.3.1.20
+    type: gauge
+    help: Tells if residual current was detected - 1.3.6.1.4.1.21239.5.2.3.3.1.20
+    indexes:
+    - labelname: pduBreakerIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduBreakerIndex
+      labelname: pduBreakerName
+      oid: 1.3.6.1.4.1.21239.5.2.3.3.1.2
+      type: DisplayString
+    enum_values:
+      1: "true"
+      2: "false"
+  - name: pduBreakerLossOfLoadDetected
+    oid: 1.3.6.1.4.1.21239.5.2.3.3.1.21
+    type: gauge
+    help: Tells if a loss of load was detected - 1.3.6.1.4.1.21239.5.2.3.3.1.21
+    indexes:
+    - labelname: pduBreakerIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduBreakerIndex
+      labelname: pduBreakerName
+      oid: 1.3.6.1.4.1.21239.5.2.3.3.1.2
+      type: DisplayString
+    enum_values:
+      1: "true"
+      2: "false"
+  - name: pduLineIndex
+    oid: 1.3.6.1.4.1.21239.5.2.3.4.1.1
+    type: gauge
+    help: Table entry index value - 1.3.6.1.4.1.21239.5.2.3.4.1.1
+    indexes:
+    - labelname: pduLineIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduLineIndex
+      labelname: pduLineName
+      oid: 1.3.6.1.4.1.21239.5.2.3.4.1.2
+      type: DisplayString
+  - name: pduLineName
+    oid: 1.3.6.1.4.1.21239.5.2.3.4.1.2
+    type: DisplayString
+    help: PDU line name (factory-assigned) - 1.3.6.1.4.1.21239.5.2.3.4.1.2
+    indexes:
+    - labelname: pduLineIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduLineIndex
+      labelname: pduLineName
+      oid: 1.3.6.1.4.1.21239.5.2.3.4.1.2
+      type: DisplayString
+  - name: pduLineLabel
+    oid: 1.3.6.1.4.1.21239.5.2.3.4.1.3
+    type: DisplayString
+    help: PDU line label (user-defined) - 1.3.6.1.4.1.21239.5.2.3.4.1.3
+    indexes:
+    - labelname: pduLineIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduLineIndex
+      labelname: pduLineName
+      oid: 1.3.6.1.4.1.21239.5.2.3.4.1.2
+      type: DisplayString
+  - name: pduLineCurrent
+    oid: 1.3.6.1.4.1.21239.5.2.3.4.1.4
+    type: gauge
+    help: PDU line current reading in hundredths of an amp - 1.3.6.1.4.1.21239.5.2.3.4.1.4
+    indexes:
+    - labelname: pduLineIndex
+      type: gauge
+    lookups:
+    - labels:
+      - pduLineIndex
+      labelname: pduLineName
+      oid: 1.3.6.1.4.1.21239.5.2.3.4.1.2
+      type: DisplayString
+  - name: pduOutletMeterKWattHrs
+    oid: 1.3.6.1.4.1.21239.6.1.99.8.1.1
+    type: gauge
+    help: Kilowatt hours for outlet - 1.3.6.1.4.1.21239.6.1.99.8.1.1
+    indexes:
+    - labelname: pduOutletMainIndex
+      type: gauge
+    - labelname: pduOutletMainID
+      type: gauge
+  - name: pduOutletMeterAmps
+    oid: 1.3.6.1.4.1.21239.6.1.99.8.1.2
+    type: gauge
+    help: Current reading for outlet - 1.3.6.1.4.1.21239.6.1.99.8.1.2
+    indexes:
+    - labelname: pduOutletMainIndex
+      type: gauge
+    - labelname: pduOutletMainID
+      type: gauge
+  - name: pduOutletMeterPower
+    oid: 1.3.6.1.4.1.21239.6.1.99.8.1.3
+    type: gauge
+    help: Power measurement for outlet - 1.3.6.1.4.1.21239.6.1.99.8.1.3
+    indexes:
+    - labelname: pduOutletMainIndex
+      type: gauge
+    - labelname: pduOutletMainID
+      type: gauge
 wiener_mpod:
   walk:
   - 1.3.6.1.4.1.19947.1.3.2.1.10


### PR DESCRIPTION
This adds Vertiv Geist PDU support.

I also tweaked the following. I can split these out into a different PR if that's preferred, but they are separate commits in here.

* pinned golang 1.15 in the generator Dockerfile since 1.16 changes repo fetching and it was failing
* sorted the makefile tasks/URLs
* added docker-generate task to simplify running generate in docker if you have the repo