### PR TITLE
Implement indices filters

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -174,7 +174,7 @@ func ScrapeTarget(ctx context.Context, target string, config *config.Module, log
 	// evaluate rules
 	newGet := config.Get
 	newWalk := config.Walk
-	for _, filter := range config.Filters{
+	for _, filter := range config.Filters {
 		var pdus []gosnmp.SnmpPDU
 		allowedList := []string{}
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -187,16 +187,16 @@ func ScrapeTarget(ctx context.Context, target string, config *config.Module, log
 			continue
 		}
 
-		allowedList = filterAllowedInstances(logger, filter, pdus, allowedList)
+		allowedList = filterAllowedIndices(logger, filter, pdus, allowedList)
 
-		// Update config to get only instance and not walk them
+		// Update config to get only index and not walk them
 		newWalk = updateWalkConfig(newWalk, filter, logger)
 
-		// Only Keep instance not involved in filters
+		// Only Keep indices not involved in filters
 		newCfg := updateGetConfig(newGet, filter, logger)
 
-		// We now add each instance from filter to the get list
-		newCfg = addAllowedInstances(filter, allowedList, logger, newCfg)
+		// We now add each index from filter to the get list
+		newCfg = addAllowedIndices(filter, allowedList, logger, newCfg)
 
 		newGet = newCfg
 	}
@@ -266,7 +266,7 @@ func ScrapeTarget(ctx context.Context, target string, config *config.Module, log
 	return results, nil
 }
 
-func filterAllowedInstances(logger log.Logger, filter config.DynamicFilter, pdus []gosnmp.SnmpPDU, allowedList []string) []string {
+func filterAllowedIndices(logger log.Logger, filter config.DynamicFilter, pdus []gosnmp.SnmpPDU, allowedList []string) []string {
 	level.Debug(logger).Log("msg", "Evaluating rule for oid", "oid", filter.Oid)
 	for _, pdu := range pdus {
 		found := false
@@ -281,9 +281,9 @@ func filterAllowedInstances(logger log.Logger, filter config.DynamicFilter, pdus
 		}
 		if found {
 			pduArray := strings.Split(pdu.Name, ".")
-			instance := pduArray[len(pduArray)-1]
-			level.Debug(logger).Log("msg", "Caching instance", "instance", instance)
-			allowedList = append(allowedList, instance)
+			index := pduArray[len(pduArray)-1]
+			level.Debug(logger).Log("msg", "Caching index", "index", index)
+			allowedList = append(allowedList, index)
 		}
 	}
 	return allowedList
@@ -329,11 +329,11 @@ func updateGetConfig(getConfig []string, filter config.DynamicFilter, logger log
 	return newCfg
 }
 
-func addAllowedInstances(filter config.DynamicFilter, allowedList []string, logger log.Logger, newCfg []string) []string {
+func addAllowedIndices(filter config.DynamicFilter, allowedList []string, logger log.Logger, newCfg []string) []string {
 	for _, targetOid := range filter.Targets {
-		for _, instance := range allowedList {
-			level.Debug(logger).Log("msg", "Adding get configuration", "oid", targetOid+"."+instance)
-			newCfg = append(newCfg, targetOid+"."+instance)
+		for _, index := range allowedList {
+			level.Debug(logger).Log("msg", "Adding get configuration", "oid", targetOid+"."+index)
+			newCfg = append(newCfg, targetOid+"."+index)
 		}
 	}
 	return newCfg

--- a/config/config.go
+++ b/config/config.go
@@ -77,11 +77,11 @@ type WalkParams struct {
 
 type Module struct {
 	// A list of OIDs.
-	Walk       []string   `yaml:"walk,omitempty"`
-	Get        []string   `yaml:"get,omitempty"`
-	Metrics    []*Metric  `yaml:"metrics"`
-	WalkParams WalkParams `yaml:",inline"`
-	Filters    []DynamicFilter  `yaml:"filters,omitempty"`
+	Walk       []string        `yaml:"walk,omitempty"`
+	Get        []string        `yaml:"get,omitempty"`
+	Metrics    []*Metric       `yaml:"metrics"`
+	WalkParams WalkParams      `yaml:",inline"`
+	Filters    []DynamicFilter `yaml:"filters,omitempty"`
 }
 
 func (c *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -193,18 +193,18 @@ func (c WalkParams) ConfigureSNMP(g *gosnmp.GoSNMP) {
 }
 
 type Filters struct {
-	Static []StaticFilter `yaml:"static,omitempty"`
+	Static  []StaticFilter  `yaml:"static,omitempty"`
 	Dynamic []DynamicFilter `yaml:"dynamic,omitempty"`
 }
 
 type StaticFilter struct {
-	Targets []string `yaml:"targets,omitempty"`
+	Targets   []string `yaml:"targets,omitempty"`
 	Instances []string `yaml:"instances,omitempty"`
 }
 type DynamicFilter struct {
-	Oid string `yaml:"oid"`
+	Oid     string   `yaml:"oid"`
 	Targets []string `yaml:"targets,omitempty"`
-	Values []string `yaml:"values,omitempty"`
+	Values  []string `yaml:"values,omitempty"`
 }
 
 type Metric struct {

--- a/config/config.go
+++ b/config/config.go
@@ -198,8 +198,8 @@ type Filters struct {
 }
 
 type StaticFilter struct {
-	Targets   []string `yaml:"targets,omitempty"`
-	Instances []string `yaml:"instances,omitempty"`
+	Targets []string `yaml:"targets,omitempty"`
+	Indices []string `yaml:"indices,omitempty"`
 }
 type DynamicFilter struct {
 	Oid     string   `yaml:"oid"`

--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,7 @@ type Module struct {
 	Get        []string   `yaml:"get,omitempty"`
 	Metrics    []*Metric  `yaml:"metrics"`
 	WalkParams WalkParams `yaml:",inline"`
+	Filters    []DynamicFilter  `yaml:"filters,omitempty"`
 }
 
 func (c *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {
@@ -189,6 +190,21 @@ func (c WalkParams) ConfigureSNMP(g *gosnmp.GoSNMP) {
 		}
 	}
 	g.SecurityParameters = usm
+}
+
+type Filters struct {
+	Static []StaticFilter `yaml:"static,omitempty"`
+	Dynamic []DynamicFilter `yaml:"dynamic,omitempty"`
+}
+
+type StaticFilter struct {
+	Targets []string `yaml:"targets,omitempty"`
+	Instances []string `yaml:"instances,omitempty"`
+}
+type DynamicFilter struct {
+	Oid string `yaml:"oid"`
+	Targets []string `yaml:"targets,omitempty"`
+	Values []string `yaml:"values,omitempty"`
 }
 
 type Metric struct {

--- a/generator/Dockerfile-local
+++ b/generator/Dockerfile-local
@@ -1,0 +1,14 @@
+FROM golang:latest
+
+RUN apt-get update && \
+    apt-get install -y libsnmp-dev p7zip-full
+
+COPY ./generator  /bin/generator
+
+WORKDIR "/opt"
+
+ENTRYPOINT ["/bin/generator"]
+
+ENV MIBDIRS mibs
+
+CMD ["generate"]

--- a/generator/README.md
+++ b/generator/README.md
@@ -142,23 +142,23 @@ modules:
                              #   EnumAsStateSet: An enum with a time series per state. Good for variable low-cardinality enums.
                              #   Bits: An RFC 2578 BITS construct, which produces a StateSet with a time series per bit.
 
-    filters: # Define filters to collect only a subset of OID table instances
-      static: # static filters are handled in the generator. They will convert walks to multiple gets with the specified instances
+    filters: # Define filters to collect only a subset of OID table indices
+      static: # static filters are handled in the generator. They will convert walks to multiple gets with the specified indices
               # in the resulting snmp.yml output.
-              # the instance filter will reduce a walk of a table to only the defined instances to get
+              # the index filter will reduce a walk of a table to only the defined indices to get
               # If one of the target OIDs is used in a lookup, the filter will apply ALL tables using this lookup
               # For a network switch, this could be used to collect a subset of interfaces such as uplinks
               # For a router, this could be used to collect all real ports but not vlans and other virtual interfaces
               # Specifying ifAlias or ifName if they are used in lookups with ifIndex will apply to the filter to 
               # all the OIDs that depend on the lookup, such as ifSpeed, ifInHcOctets, etc.
-              # This feature applies to any table(s) OIDs using a common instance
+              # This feature applies to any table(s) OIDs using a common index
         - targets:
           - bsnDot11EssSsid
-          instances: ["2","3","4"]  # List of interface instances to get
+          indices: ["2","3","4"]  # List of interface indices to get
 
       dynamic: # dynamic filters are handed by the snmp exporter. The generator will simply pass on the configuration in the snmp.yml.
                # The exporter will do a snmp walk of the oid and will restrict snmp walk made on the targets
-               # to the instance matching the value in the values list.
+               # to the index matching the value in the values list.
                # This would be typically used to specify a filter for interfaces with a certain name in ifAlias, ifSpeed or admin status.
                # For example, only get interfaces that a gig and faster, or get interfaces that are named Up or interfaces that are admin Up
         - oid: 1.3.6.1.2.1.2.2.1.7

--- a/generator/README.md
+++ b/generator/README.md
@@ -17,6 +17,12 @@ git clone https://github.com/prometheus/snmp_exporter.git
 cd snmp_exporter/generator
 make generator mibs
 ```
+## Preparation
+
+It is recommended to have a directory per device family which contains the mibs dir for the device family, 
+a logical link to the generator executable and the generator.yml configuration file. This is to avoid name space collisions
+in the MIB definition. Keep only the required MIBS in the mibs directory for the devices.
+Then merge all the resulting snmp.yml files into one main file that will be used by the snmp_exporter collector.
 
 ## Running
 
@@ -24,7 +30,8 @@ make generator mibs
 make generate
 ```
 
-The generator reads in from `generator.yml` and writes to `snmp.yml`.
+The generator reads in the simplified collection instructions from `generator.yml` and writes to `snmp.yml`. Only the snmp.yml file is used
+by the snmp_exporter executable to collect data from the snmp enabled devices.
 
 Additional command are available for debugging, use the `help` command to see them.
 
@@ -42,7 +49,7 @@ make docker-generate
 
 ## File Format
 
-`generator.yml` provides a list of modules. The simplest module is just a name
+`generator.yml` provides a list of modules. Each module defines what to collect from a device type. The simplest module is just a name
 and a set of OIDs to walk.
 
 ```yaml
@@ -105,19 +112,19 @@ modules:
       - source_indexes: [cbQosConfigIndex]
         lookup: cbQosCMName
 
-     overrides: # Allows for per-module overrides of bits of MIBs
-       metricName:
-         ignore: true # Drops the metric from the output.
-         regex_extracts:
-           Temp: # A new metric will be created appending this to the metricName to become metricNameTemp.
-             - regex: '(.*)' # Regex to extract a value from the returned SNMP walks's value.
-               value: '$1' # The result will be parsed as a float64, defaults to $1.
-           Status:
-             - regex: '.*Example'
-               value: '1' # The first entry whose regex matches and whose value parses wins.
-             - regex: '.*'
-               value: '0'
-         type: DisplayString # Override the metric type, possible types are:
+    overrides: # Allows for per-module overrides of bits of MIBs
+      metricName:
+        ignore: true # Drops the metric from the output.
+        regex_extracts:
+          Temp: # A new metric will be created appending this to the metricName to become metricNameTemp.
+            - regex: '(.*)' # Regex to extract a value from the returned SNMP walks's value.
+              value: '$1' # The result will be parsed as a float64, defaults to $1.
+          Status:
+            - regex: '.*Example'
+              value: '1' # The first entry whose regex matches and whose value parses wins.
+            - regex: '.*'
+              value: '0'
+        type: DisplayString # Override the metric type, possible types are:
                              #   gauge:   An integer with type gauge.
                              #   counter: An integer with type counter.
                              #   OctetString: A bit string, rendered as 0xff34.
@@ -134,6 +141,30 @@ modules:
                              #   EnumAsInfo: An enum for which a single timeseries is created. Good for constant values.
                              #   EnumAsStateSet: An enum with a time series per state. Good for variable low-cardinality enums.
                              #   Bits: An RFC 2578 BITS construct, which produces a StateSet with a time series per bit.
+
+    filters: # Define filters to collect only a subset of OID table instances
+      static: # static filters are handled in the generator. They will convert walks to multiple gets with the specified instances
+              # in the resulting snmp.yml output.
+              # the instance filter will reduce a walk of a table to only the defined instances to get
+              # If one of the target OIDs is used in a lookup, the filter will apply ALL tables using this lookup
+              # For a network switch, this could be used to collect a subset of interfaces such as uplinks
+              # For a router, this could be used to collect all real ports but not vlans and other virtual interfaces
+              # Specifying ifAlias or ifName if they are used in lookups with ifIndex will apply to the filter to 
+              # all the OIDs that depend on the lookup, such as ifSpeed, ifInHcOctets, etc.
+              # This feature applies to any table(s) OIDs using a common instance
+        - targets:
+          - bsnDot11EssSsid
+          instances: ["2","3","4"]  # List of interface instances to get
+
+      dynamic: # dynamic filters are handed by the snmp exporter. The generator will simply pass on the configuration in the snmp.yml.
+               # (Not implemented yet) the exporter will do a snmp get of the oid and will restrict snmp get made on the targets
+               # if the value returned is in the values list.
+               # This would be typically used to specify a filter for interfaces with a certain name in ifAlias, ifSpeed or admin status.
+               # For example, only get interfaces that a gig and faster, or get interfaces that are named Up or interfaces that are admin Up
+        - oid: 1.3.6.1.2.1.2.2.1.7
+          targets:
+            - "1.3.6.1.2.1.2.2.1.4"
+          values: ["1", "2"]
 ```
 
 ### EnumAsInfo and EnumAsStateSet

--- a/generator/README.md
+++ b/generator/README.md
@@ -157,8 +157,8 @@ modules:
           instances: ["2","3","4"]  # List of interface instances to get
 
       dynamic: # dynamic filters are handed by the snmp exporter. The generator will simply pass on the configuration in the snmp.yml.
-               # (Not implemented yet) the exporter will do a snmp get of the oid and will restrict snmp get made on the targets
-               # if the value returned is in the values list.
+               # The exporter will do a snmp walk of the oid and will restrict snmp walk made on the targets
+               # to the instance matching the value in the values list.
                # This would be typically used to specify a filter for interfaces with a certain name in ifAlias, ifSpeed or admin status.
                # For example, only get interfaces that a gig and faster, or get interfaces that are named Up or interfaces that are admin Up
         - oid: 1.3.6.1.2.1.2.2.1.7

--- a/generator/README.md
+++ b/generator/README.md
@@ -59,6 +59,8 @@ modules:
       - 1.3.6.1.2.1.2              # Same as "interfaces"
       - sysUpTime                  # Same as "1.3.6.1.2.1.1.3"
       - 1.3.6.1.2.1.31.1.1.1.6.40  # Instance of "ifHCInOctets" with index "40"
+      - 1.3.6.1.2.1.2.2.1.4        # Same as ifMtu (used for filter example)
+      - bsnDot11EssSsid            # Same as 1.3.6.1.4.1.14179.2.1.1.1.2 (used for filter example)
 
     version: 2  # SNMP version to use. Defaults to 2.
                 # 1 will use GETNEXT, 2 and 3 use GETBULK.

--- a/generator/config.go
+++ b/generator/config.go
@@ -50,6 +50,7 @@ type ModuleConfig struct {
 	Lookups    []*Lookup                  `yaml:"lookups"`
 	WalkParams config.WalkParams          `yaml:",inline"`
 	Overrides  map[string]MetricOverrides `yaml:"overrides"`
+	Filters    config.Filters           `yaml:"filters,omitempty"`
 }
 
 type Lookup struct {

--- a/generator/config.go
+++ b/generator/config.go
@@ -50,7 +50,7 @@ type ModuleConfig struct {
 	Lookups    []*Lookup                  `yaml:"lookups"`
 	WalkParams config.WalkParams          `yaml:",inline"`
 	Overrides  map[string]MetricOverrides `yaml:"overrides"`
-	Filters    config.Filters           `yaml:"filters,omitempty"`
+	Filters    config.Filters             `yaml:"filters,omitempty"`
 }
 
 type Lookup struct {

--- a/generator/config.go
+++ b/generator/config.go
@@ -15,8 +15,8 @@ package main
 
 import (
 	"fmt"
-
 	"github.com/prometheus/snmp_exporter/config"
+	"strconv"
 )
 
 // The generator config.
@@ -51,6 +51,26 @@ type ModuleConfig struct {
 	WalkParams config.WalkParams          `yaml:",inline"`
 	Overrides  map[string]MetricOverrides `yaml:"overrides"`
 	Filters    config.Filters             `yaml:"filters,omitempty"`
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (c *ModuleConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type plain ModuleConfig
+	if err := unmarshal((*plain)(c)); err != nil {
+		return err
+	}
+
+	// Ensure indices in static filters are integer for input validation.
+	for _, filter := range c.Filters.Static {
+		for _, index := range filter.Indices {
+			_, err := strconv.Atoi(index)
+			if err != nil {
+				return fmt.Errorf("invalid index '%s'. Index must be integer", index)
+			}
+		}
+	}
+
+	return nil
 }
 
 type Lookup struct {

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -379,7 +379,7 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 	// Build an map of all oid targeted by a filter to access it easily later
 	filterMap := map[string][]string{}
 
-	for _, filter := range cfg.Filters.Static{
+	for _, filter := range cfg.Filters.Static {
 		for _, oid := range filter.Targets {
 			n, ok := nameToNode[oid]
 			if ok {

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -180,7 +180,7 @@ func metricAccess(a string) bool {
 	case "ACCESS_READONLY", "ACCESS_READWRITE", "ACCESS_CREATE", "ACCESS_NOACCESS":
 		return true
 	default:
-		// the others are inaccessible metrics.
+		// The others are inaccessible metrics.
 		return false
 	}
 }
@@ -376,7 +376,7 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 		})
 	}
 
-	// Build an map of all oid targeted by a filter to access it easily later
+	// Build an map of all oid targeted by a filter to access it easily later.
 	filterMap := map[string][]string{}
 
 	for _, filter := range cfg.Filters.Static {
@@ -446,7 +446,7 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 				} else {
 					needToWalk[indexNode.Oid] = struct{}{}
 				}
-				// we apply the same filter to metric.Oid if the lookup oid is filtered
+				// We apply the same filter to metric.Oid if the lookup oid is filtered.
 				indices, found := filterMap[indexNode.Oid]
 				if found {
 					delete(needToWalk, metric.Oid)
@@ -474,8 +474,8 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 		}
 	}
 
-	// Check that the object before an InetAddress is an InetAddressType,
-	// if not, change it to an OctetString.
+	// Check that the object before an InetAddress is an InetAddressType.
+	// If not, change it to an OctetString.
 	for _, metric := range out.Metrics {
 		if metric.Type == "InetAddress" || metric.Type == "InetAddressMissingSize" {
 			// Get previous oid.
@@ -507,9 +507,9 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 		}
 	}
 
-	// Apply filters
+	// Apply filters.
 	for _, filter := range cfg.Filters.Static {
-		// Delete the oid targeted by the filter, as we won't walk the whole table
+		// Delete the oid targeted by the filter, as we won't walk the whole table.
 		for _, oid := range filter.Targets {
 			n, ok := nameToNode[oid]
 			if ok {

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -385,7 +385,7 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 			if ok {
 				oid = n.Oid
 			}
-			filterMap[oid] = filter.Instances
+			filterMap[oid] = filter.Indices
 		}
 	}
 
@@ -447,11 +447,11 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 					needToWalk[indexNode.Oid] = struct{}{}
 				}
 				// we apply the same filter to metric.Oid if the lookup oid is filtered
-				instances, found := filterMap[indexNode.Oid]
+				indices, found := filterMap[indexNode.Oid]
 				if found {
 					delete(needToWalk, metric.Oid)
-					for _, instance := range instances {
-						needToWalk[metric.Oid+"."+instance+"."] = struct{}{}
+					for _, index := range indices {
+						needToWalk[metric.Oid+"."+index+"."] = struct{}{}
 					}
 				}
 				if lookup.DropSourceIndexes {
@@ -516,8 +516,8 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 				oid = n.Oid
 			}
 			delete(needToWalk, oid)
-			for _, instance := range filter.Instances {
-				needToWalk[oid+"."+instance+"."] = struct{}{}
+			for _, index := range filter.Indices {
+				needToWalk[oid+"."+index+"."] = struct{}{}
 			}
 		}
 	}

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -376,6 +376,19 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 		})
 	}
 
+	// Build an map of all oid targeted by a filter to access it easily later
+	filterMap := map[string][]string{}
+
+	for _, filter := range cfg.Filters.Static{
+		for _, oid := range filter.Targets {
+			n, ok := nameToNode[oid]
+			if ok {
+				oid = n.Oid
+			}
+			filterMap[oid] = filter.Instances
+		}
+	}
+
 	// Apply lookups.
 	for _, metric := range out.Metrics {
 		toDelete := []string{}
@@ -433,6 +446,14 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 				} else {
 					needToWalk[indexNode.Oid] = struct{}{}
 				}
+				// we apply the same filter to metric.Oid if the lookup oid is filtered
+				instances, found := filterMap[indexNode.Oid]
+				if found {
+					delete(needToWalk, metric.Oid)
+					for _, instance := range instances {
+						needToWalk[metric.Oid+"."+instance+"."] = struct{}{}
+					}
+				}
 				if lookup.DropSourceIndexes {
 					// Avoid leaving the old labelname around.
 					toDelete = append(toDelete, lookup.SourceIndexes...)
@@ -485,6 +506,23 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 			}
 		}
 	}
+
+	// Apply filters
+	for _, filter := range cfg.Filters.Static {
+		// Delete the oid targeted by the filter, as we won't walk the whole table
+		for _, oid := range filter.Targets {
+			n, ok := nameToNode[oid]
+			if ok {
+				oid = n.Oid
+			}
+			delete(needToWalk, oid)
+			for _, instance := range filter.Instances {
+				needToWalk[oid+"."+instance+"."] = struct{}{}
+			}
+		}
+	}
+
+	out.Filters = cfg.Filters.Dynamic
 
 	oids := []string{}
 	for k := range needToWalk {


### PR DESCRIPTION
Hi,

This PR adds the feature of instance filtering in both the generator and the exporter. 
Filters in the generator are referred as "static" while filters in the exporter are "dynamic". 
The idea behind this, is to limit the number of oid returned by the monitored device , and in most case reduce the number of snmp get sent. 

Static filters can be seen as an ease of configuration, as it make instance filtering easier to do
Dynamic filters are simple for now in order to keep the exporter stateless between runs. Filter are evaluated when /snmp route is reached by prometheus by http. We could have a /filter route to make 2 separate flows but that would complexify the code. 

Filters are also not made to have multiple levels. Oid are targeted by a single filter, there is no "and / or" logic at all. 

However, Dynamic filter evaluation support regex. Regex matching was as complex as string comparison but with more options for the user. 

Let me know what do you think. I could squash commits / remove some if necessary