### PR TITLE
collector: pass Context

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -208,8 +208,8 @@ type collector struct {
 	logger log.Logger
 }
 
-func New(target string, module *config.Module, logger log.Logger) *collector {
-	return &collector{target: target, module: module, logger: logger}
+func New(ctx context.Context, target string, module *config.Module, logger log.Logger) *collector {
+	return &collector{ctx: ctx, target: target, module: module, logger: logger}
 }
 
 // Describe implements Prometheus.Collector.

--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func handler(w http.ResponseWriter, r *http.Request, logger log.Logger) {
 
 	start := time.Now()
 	registry := prometheus.NewRegistry()
-	c := collector.New(target, module, logger)
+	c := collector.New(r.Context(), target, module, logger)
 	registry.MustRegister(c)
 	// Delegate http serving to Prometheus client library, which will call collector.Collect.
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})


### PR DESCRIPTION
This diff adds an ability to pass custom Context to the collector.  This is inline with some other exporter's like the [mysqld_exporter](https://github.com/prometheus/mysqld_exporter/blob/3381d9c187b54115e89764de20f5c43bad948ad0/collector/exporter.go#L87).