### PR TITLE
Update Dockerfile for Go 1.16

### DIFF
--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -2,10 +2,7 @@ FROM golang:latest
 
 RUN apt-get update && \
     apt-get install -y libsnmp-dev p7zip-full unzip && \
-    go get github.com/prometheus/snmp_exporter/generator && \
-    cd /go/src/github.com/prometheus/snmp_exporter/generator && \
-    go get -v . && \
-    go install
+    go install github.com/prometheus/snmp_exporter/generator@latest
 
 WORKDIR "/opt"
 

--- a/snmp.yml
+++ b/snmp.yml
@@ -25195,6 +25195,10 @@ synology:
     type: gauge
     help: This oid is for checking whether there is a latest DSM can be upgraded -
       1.3.6.1.4.1.6574.1.5.4
+  - name: controllerNumber
+    oid: 1.3.6.1.4.1.6574.1.6
+    type: gauge
+    help: Synology system controller number Controller A(0) Controller B(1) - 1.3.6.1.4.1.6574.1.6
   - name: storageIOIndex
     oid: 1.3.6.1.4.1.6574.101.1.1.1
     type: gauge
@@ -25375,6 +25379,21 @@ synology:
       type: DisplayString
     - labels: []
       labelname: storageIOIndex
+  - name: storageIODeviceSerial
+    oid: 1.3.6.1.4.1.6574.101.1.1.14
+    type: DisplayString
+    help: The name of the device we are counting/checking. - 1.3.6.1.4.1.6574.101.1.1.14
+    indexes:
+    - labelname: storageIOIndex
+      type: gauge
+    lookups:
+    - labels:
+      - storageIOIndex
+      labelname: storageIODevice
+      oid: 1.3.6.1.4.1.6574.101.1.1.2
+      type: DisplayString
+    - labels: []
+      labelname: storageIOIndex
   - name: spaceIOIndex
     oid: 1.3.6.1.4.1.6574.102.1.1.1
     type: gauge
@@ -25544,6 +25563,21 @@ synology:
     oid: 1.3.6.1.4.1.6574.102.1.1.13
     type: counter
     help: The number of bytes written to this device since boot. - 1.3.6.1.4.1.6574.102.1.1.13
+    indexes:
+    - labelname: spaceIOIndex
+      type: gauge
+    lookups:
+    - labels:
+      - spaceIOIndex
+      labelname: spaceIODevice
+      oid: 1.3.6.1.4.1.6574.102.1.1.2
+      type: DisplayString
+    - labels: []
+      labelname: spaceIOIndex
+  - name: spaceUUID
+    oid: 1.3.6.1.4.1.6574.102.1.1.14
+    type: DisplayString
+    help: The uuid of space. - 1.3.6.1.4.1.6574.102.1.1.14
     indexes:
     - labelname: spaceIOIndex
       type: gauge


### PR DESCRIPTION
Use go install to build the generator.

Fixes: https://github.com/prometheus/snmp_exporter/issues/635

Signed-off-by: Ben Kochie <superq@gmail.com>