### PR TITLE
generator: add a --config-file= option

### DIFF
--- a/generator/main.go
+++ b/generator/main.go
@@ -37,7 +37,12 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node, logger log.Logger)
 		return fmt.Errorf("unable to determine absolute path for output")
 	}
 
-	content, err := ioutil.ReadFile("generator.yml")
+	configPath, err := filepath.Abs(*configPath)
+	if err != nil {
+		return fmt.Errorf("unable to determine absolute path for configuration file")
+	}
+
+	content, err := ioutil.ReadFile(configPath)
 	if err != nil {
 		return fmt.Errorf("error reading yml config: %s", err)
 	}
@@ -95,6 +100,7 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node, logger log.Logger)
 
 var (
 	failOnParseErrors  = kingpin.Flag("fail-on-parse-errors", "Exit with a non-zero status if there are MIB parsing errors").Default("false").Bool()
+	configPath         = kingpin.Flag("config-file", "Path to configuration file").Default("generator.yml").Short('c').String()
 	generateCommand    = kingpin.Command("generate", "Generate snmp.yml from generator.yml")
 	outputPath         = generateCommand.Flag("output-path", "Path to to write resulting config file").Default("snmp.yml").Short('o').String()
 	parseErrorsCommand = kingpin.Command("parse_errors", "Debug: Print the parse errors output by NetSNMP")


### PR DESCRIPTION
This allows easier use of multiple generator config files, for example
for different sets of authentication credentials or to break up the
giant snmp.yml file into smaller chunks that fit better in a Kubernetes
ConfigMap.