### PR TITLE
added support for aes192c and aes256c privacy protocol

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -95,7 +95,7 @@ func (c *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			if wp.Auth.PrivPassword == "" {
 				return fmt.Errorf("priv password is missing, required for SNMPv3 with priv")
 			}
-			if wp.Auth.PrivProtocol != "DES" && wp.Auth.PrivProtocol != "AES" && wp.Auth.PrivProtocol != "AES192" && wp.Auth.PrivProtocol != "AES256" {
+			if wp.Auth.PrivProtocol != "DES" && wp.Auth.PrivProtocol != "AES" && wp.Auth.PrivProtocol != "AES192" && wp.Auth.PrivProtocol != "AES192C" && wp.Auth.PrivProtocol != "AES256" && wp.Auth.PrivProtocol != "AES256C" {
 				return fmt.Errorf("priv protocol must be DES or AES")
 			}
 			fallthrough
@@ -174,8 +174,12 @@ func (c WalkParams) ConfigureSNMP(g *gosnmp.GoSNMP) {
 			usm.PrivacyProtocol = gosnmp.AES
 		case "AES192":
 			usm.PrivacyProtocol = gosnmp.AES192
+		case "AES192C":
+			usm.PrivacyProtocol = gosnmp.AES192C
 		case "AES256":
 			usm.PrivacyProtocol = gosnmp.AES256
+		case "AES256C":
+			usm.PrivacyProtocol = gosnmp.AES256C
 		}
 	}
 	g.SecurityParameters = usm


### PR DESCRIPTION
Signed-off-by: Theunis Botha <theunisb@jurumani.com>

Hi @SuperQ 

Following #595, I added support for Cisco's AES192 and AES256 PrivacyProtocol encryptions that was available in the GoSNMP package. We ran into some issues where we weren't able to walk some Cisco devices, and realised it was using their own implementation, AES256C, instead of AES256. 