### PR TITLE
Fix default snmp.yaml

### DIFF
--- a/snmp.yml
+++ b/snmp.yml
@@ -346,6 +346,7 @@ apcups:
       300: cpri
       301: omni
       302: roe
+      303: p2pOverLan
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -3044,6 +3045,7 @@ arista_sw:
       300: cpri
       301: omni
       302: roe
+      303: p2pOverLan
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -4281,6 +4283,7 @@ cisco_wlc:
       300: cpri
       301: omni
       302: roe
+      303: p2pOverLan
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -5411,6 +5414,7 @@ ddwrt:
       300: cpri
       301: omni
       302: roe
+      303: p2pOverLan
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -6832,6 +6836,7 @@ if_mib:
       300: cpri
       301: omni
       302: roe
+      303: p2pOverLan
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -9637,6 +9642,7 @@ kemp_loadmaster:
       300: cpri
       301: omni
       302: roe
+      303: p2pOverLan
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -13424,6 +13430,7 @@ mikrotik:
       300: cpri
       301: omni
       302: roe
+      303: p2pOverLan
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -20044,6 +20051,7 @@ paloalto_fw:
       300: cpri
       301: omni
       302: roe
+      303: p2pOverLan
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -21199,28 +21207,36 @@ paloalto_fw:
     type: DisplayString
     help: Zone name for the interface - 1.3.6.1.4.1.25461.2.1.2.3.10.1.1
     indexes:
-    - labelname: ifIndex
+    - labelname: panZoneName
+      type: DisplayString
+    - labelname: panVsysId
       type: gauge
   - name: panZoneActiveTcpCps
     oid: 1.3.6.1.4.1.25461.2.1.2.3.10.1.2
     type: gauge
     help: Number of active TCP connections per second for this zone. - 1.3.6.1.4.1.25461.2.1.2.3.10.1.2
     indexes:
-    - labelname: ifIndex
+    - labelname: panZoneName
+      type: DisplayString
+    - labelname: panVsysId
       type: gauge
   - name: panZoneActiveUdpCps
     oid: 1.3.6.1.4.1.25461.2.1.2.3.10.1.3
     type: gauge
     help: Number of active UDP connections per second for this zone. - 1.3.6.1.4.1.25461.2.1.2.3.10.1.3
     indexes:
-    - labelname: ifIndex
+    - labelname: panZoneName
+      type: DisplayString
+    - labelname: panVsysId
       type: gauge
   - name: panZoneActiveOtherIpCps
     oid: 1.3.6.1.4.1.25461.2.1.2.3.10.1.4
     type: gauge
     help: Number of active Other IP connections per second for this zone. - 1.3.6.1.4.1.25461.2.1.2.3.10.1.4
     indexes:
-    - labelname: ifIndex
+    - labelname: panZoneName
+      type: DisplayString
+    - labelname: panVsysId
       type: gauge
   - name: ifIndex
     oid: 1.3.6.1.4.1.25461.2.1.2.3.11.1.1
@@ -21257,6 +21273,10 @@ paloalto_fw:
     indexes:
     - labelname: ifIndex
       type: gauge
+  - name: panSessionCps
+    oid: 1.3.6.1.4.1.25461.2.1.2.3.12
+    type: gauge
+    help: Total number of active TCP connections per second. - 1.3.6.1.4.1.25461.2.1.2.3.12
   - name: panGPGWUtilizationPct
     oid: 1.3.6.1.4.1.25461.2.1.2.5.1.1
     type: gauge
@@ -24611,6 +24631,7 @@ synology:
       300: cpri
       301: omni
       302: roe
+      303: p2pOverLan
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -27198,6 +27219,7 @@ ubiquiti_airfiber:
       300: cpri
       301: omni
       302: roe
+      303: p2pOverLan
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -29048,6 +29070,7 @@ ubiquiti_airmax:
       300: cpri
       301: omni
       302: roe
+      303: p2pOverLan
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge
@@ -30375,6 +30398,7 @@ ubiquiti_unifi:
       300: cpri
       301: omni
       302: roe
+      303: p2pOverLan
   - name: ifMtu
     oid: 1.3.6.1.2.1.2.2.1.4
     type: gauge


### PR DESCRIPTION
Circle is failing because of the update in mibs that change the default snmp file

Signed-off-by: Sébastien Coavoux <sebastien.coavoux@azoplee.com>