### PR TITLE
Override `bsnAPName` to DisplayString

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -48,6 +48,9 @@ modules:
       - source_indexes: [bsnAPDot3MacAddress]
         lookup: bsnAPName
         drop_source_indexes: true
+    overrides:
+      bsnAPName:
+        type: DisplayString
 
 # APC/Schneider UPS Network Management Cards
 #

--- a/snmp.yml
+++ b/snmp.yml
@@ -2988,7 +2988,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDBNoisePower
@@ -3009,7 +3009,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnApIfNoOfUsers
@@ -3027,7 +3027,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfType
@@ -3045,7 +3045,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
       enum_values:
@@ -3067,7 +3067,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
       enum_values:
@@ -3138,7 +3138,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11MulticastTransmittedFrameCount
@@ -3157,7 +3157,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11RetryCount
@@ -3176,7 +3176,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11MultipleRetryCount
@@ -3195,7 +3195,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11FrameDuplicateCount
@@ -3214,7 +3214,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11RTSSuccessCount
@@ -3233,7 +3233,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11RTSFailureCount
@@ -3252,7 +3252,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11ACKFailureCount
@@ -3271,7 +3271,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11ReceivedFragmentCount
@@ -3290,7 +3290,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11MulticastReceivedFrameCount
@@ -3309,7 +3309,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11FCSErrorCount
@@ -3328,7 +3328,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11TransmittedFrameCount
@@ -3347,7 +3347,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11WEPUndecryptableCount
@@ -3369,7 +3369,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
     - name: bsnAPIfDot11FailedCount
@@ -3389,7 +3389,7 @@ modules:
         - bsnAPDot3MacAddress
         labelname: bsnAPName
         oid: 1.3.6.1.4.1.14179.2.2.1.1.3
-        type: OctetString
+        type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
   cyberpower:


### PR DESCRIPTION
This PR overrides `bsnAPName` to DisplayString in the `cisco_wlc` module.

Before:
```
bsnApIfNoOfUsers{bsnAPIfSlotId="0",bsnAPName="0xABCDEF"} 0
```

After:
```
bsnApIfNoOfUsers{bsnAPIfSlotId="0",bsnAPName="AP-NAME"} 0
```