### PR TITLE
Add makefile target to generate in docker

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -14,7 +14,7 @@
 MIBDIR   := mibs
 MIB_PATH := 'mibs'
 
-CURL_OPTS ?= -s --retry 3 --retry-delay 3 --fail
+CURL_OPTS ?= -L -s --retry 3 --retry-delay 3 --fail
 
 DOCKER_IMAGE_NAME ?= snmp-generator
 DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
@@ -71,6 +71,10 @@ parse_errors: generator mibs
 .PHONY: docker
 docker:
 	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" .
+
+.PHONY: docker-generate
+docker-generate: docker mibs
+	docker run -ti -v "${PWD}:/opt/" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)" generate
 
 .PHONY: docker-publish
 docker-publish:

--- a/generator/README.md
+++ b/generator/README.md
@@ -37,12 +37,9 @@ If you would like to run the generator in docker to generate your `snmp.yml` con
 The Docker image expects a directory containing the `generator.yml` and a directory called `mibs` that contains all MIBs you wish to use.
 
 This example will generate the example `snmp.yml` which is included in the top level of the snmp_exporter repo:
+
 ```sh
-make mibs
-docker build -t snmp-generator .
-docker run -ti \
-  -v "${PWD}:/opt/" \
-  snmp-generator generate
+make docker-generate
 ```
 
 ## File Format


### PR DESCRIPTION
This PR improve the makefile:

- Clean mibs directory before re-download
- Add parameter for curl to follow redirects
- Improve generator makefile and readme to have a direct target

Signed-off-by: Carlos de Paula <me@carlosedp.com>