### PR TITLE
Update generator for net-snmp 5.9

### DIFF
--- a/generator/net_snmp.go
+++ b/generator/net_snmp.go
@@ -20,8 +20,7 @@ package main
 #include <net-snmp/mib_api.h>
 #include <unistd.h>
 // From parse.c
-#define MAXTC   4096
-  struct tc {
+struct tc {
   int             type;
   int             modid;
   char           *descriptor;
@@ -29,11 +28,12 @@ package main
   struct enum_list *enums;
   struct range_list *ranges;
   char           *description;
-} tclist[MAXTC];
+} *tclist;
+int tc_alloc;
 
 // Return the size of a fixed, or 0 if it is not fixed.
 int get_tc_fixed_size(int tc_index) {
-	if (tc_index < 0 || tc_index >= MAXTC) {
+	if (tc_index < 0 || tc_index >= tc_alloc) {
     return 0;
   }
   struct range_list *ranges;


### PR DESCRIPTION
At some point in the past few months, CircleCI updated the
circleci/golang:1.16 image from being based on Debian 10 (buster) to
Debian 11 (bullseye). With this, net-snmp (libsnmp-dev) was updated from
5.7.3 to 5.9.

In net-snmp 5.9, the definition of `tclist` (copied into the generator's
net_snmp.go) changed from

    #define MAXTC   4096
    struct tc {                     /* textual conventions */
        int             type;
        int             modid;
        char           *descriptor;
        char           *hint;
        struct enum_list *enums;
        struct range_list *ranges;
        char           *description;
    } tclist[MAXTC];

to

    #define TC_INCR 100
    struct tc {                     /* textual conventions */
        int             type;
        int             modid;
        char           *descriptor;
        char           *hint;
        struct enum_list *enums;
        struct range_list *ranges;
        char           *description;
    } *tclist;
    int tc_alloc;

The mismatch between the definitions used by net-snmp and snmp_exporter
caused the removal of all `fixed_size` fields in the generated snmp.yml,
which in turn caused CI runs for recent PRs to fail (some examples of
such PRs are 702, 700, 681).

This commit adapts net_snmp.go to the new definition of `tclist`.
