### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ scrape_configs:
         - switch.local # SNMP device.
     metrics_path: /snmp
     params:
-      module: [if_mib]
+      module: [if_mib]  # can't be used as multiple module option. Onle ne module per job allowed
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target


### PR DESCRIPTION
fix prometheus#718
    Signed-off-by: Vyacheslav Vershinin <vershinin.vyacheslav@gmail.com>](https://github.com/prometheus/snmp_exporter/issues/718

In documentation https://github.com/prometheus/snmp_exporter#prometheus-configuration `module` variable is a list, but you can't use it like real list.

Working ok:

```yaml
- job_name: 'working ok'
  params:
      module: [if_mib]
```

Failed:

```yaml
- job_name: 'failed 400 error'
  params:
    module: [if_mib,cisco_wlc]
```

Actual error in prometheus `server returned HTTP status 400 Bad Request`
)