### PR TITLE
Support chained lookups in the generator

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -99,6 +99,17 @@ modules:
         drop_source_indexes: false  # If true, delete source index labels for this lookup.
                                     # This avoids label clutter when the new index is unique.
 
+      # It is also possible to chain lookups or use multiple labels to gather label values.
+      # This might be helpful to resolve multiple index labels to a proper human readable label.
+      # Please be aware that ordering matters here.
+
+      # In this example, we first do a lookup to get the `cbQosConfigIndex` as another label.
+      - source_indexes: [cbQosPolicyIndex, cbQosObjectsIndex]
+        lookup: cbQosConfigIndex
+      # Using the newly added label, we have another lookup to fetch the `cbQosCMName` based on `cbQosConfigIndex`.
+      - source_indexes: [cbQosConfigIndex]
+        lookup: cbQosCMName
+
      overrides: # Allows for per-module overrides of bits of MIBs
        metricName:
          ignore: true # Drops the metric from the output.


### PR DESCRIPTION
This PR fixes the generator tree code to add lookups as index if the lookup label is used for another lookup. Example configuration to use it for Cisco's Class based QOS (CISCO-CLASS-BASED-QOS-MIB)

```
modules:
  cisco:
    auth:
      community: public
    walk:
      - interfaces
      - ifXTable
      - 1.3.6.1.4.1.9.9.42
      - 1.3.6.1.4.1.9.9.166
    lookups:
      - source_indexes: [cbQosPolicyIndex, cbQosObjectsIndex]
        lookup: cbQosConfigIndex
      - source_indexes: [cbQosConfigIndex]
        lookup: cbQosCMName
      - source_indexes: [cbQosPolicyIndex]
        lookup: cbQosIfIndex
      - source_indexes: [cbQosIfIndex]
        lookup: ifName
    overrides:
      cbQosConfigIndex:
        ignore: true
      cbQosPolicyIndex:
        ignore: true
      cbQosObjectsIndex:
        ignore: true
      cbQosIfIndex:
        ignore: true
``` 

Fixes: #678 