### PR TITLE
Remove ioutil

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,7 +15,7 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"time"
 
@@ -24,7 +24,7 @@ import (
 )
 
 func LoadFile(filename string) (*Config, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/generator/main.go
+++ b/generator/main.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -37,7 +36,7 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node, logger log.Logger)
 		return fmt.Errorf("unable to determine absolute path for output")
 	}
 
-	content, err := ioutil.ReadFile("generator.yml")
+	content, err := os.ReadFile("generator.yml")
 	if err != nil {
 		return fmt.Errorf("error reading yml config: %s", err)
 	}

--- a/generator/net_snmp.go
+++ b/generator/net_snmp.go
@@ -67,7 +67,7 @@ import "C"
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"sort"
 
@@ -177,7 +177,7 @@ func initSNMP(logger log.Logger) (string, error) {
 	ch := make(chan string)
 	errch := make(chan error)
 	go func() {
-		data, err := ioutil.ReadAll(r)
+		data, err := io.ReadAll(r)
 		if err != nil {
 			errch <- fmt.Errorf("error reading from pipe: %s", err)
 			return


### PR DESCRIPTION
`ioutil` is deprecated from go1.16 (ref: https://go.dev/doc/go1.16#ioutil).
So removed them.

Signed-off-by: inosato <si17_21@yahoo.co.jp>