### PR TITLE
Fix retries in generator

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -121,7 +121,7 @@ func ScrapeTarget(ctx context.Context, target string, config *config.Module, log
 	snmp := gosnmp.GoSNMP{}
 	snmp.Context = ctx
 	snmp.MaxRepetitions = config.WalkParams.MaxRepetitions
-	snmp.Retries = config.WalkParams.Retries
+	snmp.Retries = *config.WalkParams.Retries
 	snmp.Timeout = config.WalkParams.Timeout
 	snmp.UseUnconnectedUDPSocket = config.WalkParams.UseUnconnectedUDPSocket
 	snmp.LocalAddr = *srcAddress

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,8 @@ func LoadFile(filename string) (*Config, error) {
 }
 
 var (
+	defaultRetries int = 3
+
 	DefaultAuth = Auth{
 		Community:     "public",
 		SecurityLevel: "noAuthNoPriv",
@@ -46,7 +48,7 @@ var (
 	DefaultWalkParams = WalkParams{
 		Version:                 2,
 		MaxRepetitions:          25,
-		Retries:                 3,
+		Retries:                 &defaultRetries,
 		Timeout:                 time.Second * 5,
 		Auth:                    DefaultAuth,
 		UseUnconnectedUDPSocket: false,
@@ -66,7 +68,7 @@ type Config map[string]*Module
 type WalkParams struct {
 	Version                 int           `yaml:"version,omitempty"`
 	MaxRepetitions          uint32        `yaml:"max_repetitions,omitempty"`
-	Retries                 int           `yaml:"retries,omitempty"`
+	Retries                 *int          `yaml:"retries,omitempty"`
 	Timeout                 time.Duration `yaml:"timeout,omitempty"`
 	Auth                    Auth          `yaml:"auth,omitempty"`
 	UseUnconnectedUDPSocket bool          `yaml:"use_unconnected_udp_socket,omitempty"`


### PR DESCRIPTION
Fix parsing of `0` in retries in the generator config by making the
struct value a pointer[0].

Fixes: https://github.com/prometheus/snmp_exporter/issues/785

[0]: https://www.sohamkamani.com/golang/omitempty/#the-difference-between-0--and-nil

Signed-off-by: SuperQ <superq@gmail.com>