### PR TITLE
Add Eaton EPDU G3 SNMP support to snmp_exporter

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -45,7 +45,7 @@ WIENER_URL        := https://file.wiener-d.com/software/net-snmp/WIENER-CRATE-MI
 RARITAN_URL       := https://cdn.raritan.com/download/PX/v1.5.20/PDU-MIB.txt
 INFRAPOWER_URL    := https://www.austin-hughes.com/support/software/infrapower/IPD-MIB.7z
 LIEBERT_URL       := https://www.vertiv.com/globalassets/documents/software/monitoring/lgpmib-win_rev16_299461_0.zip
-EATON_URL         := https://www.eaton.com/content/dam/eaton/products/backup-power-ups-surge-it-power-distribution/Firmware/eaton-pdu-g3-firmware-mib.zip
+EATON_URL         := https://powerquality.eaton.com/Support/Software-Drivers/Downloads/ePDU/EATON-EPDU-MIB.zip
 
 .DEFAULT: all
 
@@ -293,9 +293,7 @@ $(MIBDIR)/LIEBERT_GP_PDU.MIB:
 $(MIBDIR)/EATON-EPDU-MIB.txt $(MIBDIR)/EATON-SENSOR-MIB.txt:
 	$(eval TMP := $(shell mktemp))
 	@echo ">> Downloading EATON-EPDU-MIB.txt to $(TMP)"
-	@curl -A "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/81.0" $(CURL_OPTS) -o $(TMP) $(EATON_URL)
-	$(eval TMP2 := $(shell mktemp -d))
-	@unzip  -j -d $(TMP2)  $(TMP) EATON-EPDU-MIB.zip
-	@unzip -j -d $(MIBDIR) $(TMP2)/EATON-EPDU-MIB.zip EATON-EPDU-MIB.txt EATON-SENSOR-MIB.txt
+	@curl $(CURL_OPTS) -o $(TMP) $(EATON_URL)
+	@unzip -j -d $(MIBDIR) $(TMP) EATON-EPDU-MIB.txt EATON-SENSOR-MIB.txt
 	@rm -v $(TMP)
 

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -45,6 +45,7 @@ WIENER_URL        := https://file.wiener-d.com/software/net-snmp/WIENER-CRATE-MI
 RARITAN_URL       := https://cdn.raritan.com/download/PX/v1.5.20/PDU-MIB.txt
 INFRAPOWER_URL    := https://www.austin-hughes.com/support/software/infrapower/IPD-MIB.7z
 LIEBERT_URL       := https://www.vertiv.com/globalassets/documents/software/monitoring/lgpmib-win_rev16_299461_0.zip
+EATON_URL         := https://www.eaton.com/content/dam/eaton/products/backup-power-ups-surge-it-power-distribution/Firmware/eaton-pdu-g3-firmware-mib.zip
 
 .DEFAULT: all
 
@@ -115,7 +116,9 @@ mibs: mib-dir \
   $(MIBDIR)/WIENER-CRATE-MIB-5704.txt \
   $(MIBDIR)/PDU-MIB.txt \
   $(MIBDIR)/IPD-MIB_Q419V9.mib \
-  $(MIBDIR)/LIEBERT_GP_PDU.MIB
+  $(MIBDIR)/LIEBERT_GP_PDU.MIB \
+  $(MIBDIR)/EATON-EPDU-MIB.txt \
+  $(MIBDIR)/EATON-SENSOR-MIB.txt
 
 mib-dir:
 	@mkdir -p -v $(MIBDIR)
@@ -286,3 +289,13 @@ $(MIBDIR)/LIEBERT_GP_PDU.MIB:
 	@curl $(CURL_OPTS) -o $(TMP) $(LIEBERT_URL)
 	@unzip -j -d $(MIBDIR) $(TMP) LIEBERT_GP_PDU.MIB LIEBERT_GP_REG.MIB
 	@rm -v $(TMP)
+
+$(MIBDIR)/EATON-EPDU-MIB.txt $(MIBDIR)/EATON-SENSOR-MIB.txt:
+	$(eval TMP := $(shell mktemp))
+	@echo ">> Downloading EATON-EPDU-MIB.txt to $(TMP)"
+	@curl -A "Mozilla/5.0 (X11; Linux x86_64; rv:60.0) Gecko/20100101 Firefox/81.0" $(CURL_OPTS) -o $(TMP) $(EATON_URL)
+	$(eval TMP2 := $(shell mktemp -d))
+	@unzip  -j -d $(TMP2)  $(TMP) EATON-EPDU-MIB.zip
+	@unzip -j -d $(MIBDIR) $(TMP2)/EATON-EPDU-MIB.zip EATON-EPDU-MIB.txt EATON-SENSOR-MIB.txt
+	@rm -v $(TMP)
+

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -46,6 +46,7 @@ RARITAN_URL       := https://cdn.raritan.com/download/PX/v1.5.20/PDU-MIB.txt
 INFRAPOWER_URL    := https://www.austin-hughes.com/support/software/infrapower/IPD-MIB.7z
 LIEBERT_URL       := https://www.vertiv.com/globalassets/documents/software/monitoring/lgpmib-win_rev16_299461_0.zip
 EATON_URL         := https://powerquality.eaton.com/Support/Software-Drivers/Downloads/ePDU/EATON-EPDU-MIB.zip
+EATON_OIDS_URL    := https://raw.githubusercontent.com/librenms/librenms/master/mibs/eaton/EATON-OIDS
 
 .DEFAULT: all
 
@@ -118,7 +119,8 @@ mibs: mib-dir \
   $(MIBDIR)/IPD-MIB_Q419V9.mib \
   $(MIBDIR)/LIEBERT_GP_PDU.MIB \
   $(MIBDIR)/EATON-EPDU-MIB.txt \
-  $(MIBDIR)/EATON-SENSOR-MIB.txt
+  $(MIBDIR)/EATON-SENSOR-MIB.txt \
+  $(MIBDIR)/EATON-OIDS.txt
 
 mib-dir:
 	@mkdir -p -v $(MIBDIR)
@@ -296,4 +298,8 @@ $(MIBDIR)/EATON-EPDU-MIB.txt $(MIBDIR)/EATON-SENSOR-MIB.txt:
 	@curl $(CURL_OPTS) -o $(TMP) $(EATON_URL)
 	@unzip -j -d $(MIBDIR) $(TMP) EATON-EPDU-MIB.txt EATON-SENSOR-MIB.txt
 	@rm -v $(TMP)
+
+$(MIBDIR)/EATON-OIDS.txt:
+	@echo ">> Downloading EATON-OIDS.txt to $@"
+	@curl $(CURL_OPTS) -o $@ $(EATON_OIDS_URL)
 

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -684,9 +684,6 @@ modules:
       - inputVA
       - inputWatts
       - inputPowerCapacity
-      #- outletID
-      - outletName
-      #- outletDesignator
       - outletCurrentCapacity
       - outletCurrent
       - outletCurrentThStatus
@@ -699,10 +696,8 @@ modules:
     lookups:
       - source_indexes: [strappingIndex, outletIndex]
         lookup: 1.3.6.1.4.1.534.6.6.7.6.1.1.2 # outletID
-        #drop_source_indexes: true
       - source_indexes: [strappingIndex, outletIndex]
         lookup: 1.3.6.1.4.1.534.6.6.7.6.1.1.3 # outletName
-        #drop_source_indexes: true
       - source_indexes: [strappingIndex, outletIndex]
         lookup: 1.3.6.1.4.1.534.6.6.7.6.1.1.6 # outletDesignator
         drop_source_indexes: true

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -693,6 +693,10 @@ modules:
       - outletWatts
       - outletPowerFactor
       - outletControlStatus
+      - humidityAlarm
+      - humidityValue
+      - temperatureAlarm
+      - temperatureValue
     lookups:
       - source_indexes: [strappingIndex, outletIndex]
         lookup: 1.3.6.1.4.1.534.6.6.7.6.1.1.2 # outletID

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -657,3 +657,57 @@ modules:
         ignore: true # Lookup metric
       ifType:
         type: EnumAsInfo
+
+# Eaton ePDU
+#
+# https://www.eaton.com/us/en-us/catalog/backup-power-ups-surge-it-power-distribution/eaton-metered-outlet-rack-pdu.resources.html
+  eaton_epdu:
+    version: 1
+    walk:
+      - interfaces
+      - ifXTable
+      - communicationStatus
+      - internalStatus
+      - inputFrequency
+      - inputFrequencyStatus
+      - inputVoltageCount
+      - inputCurrentCount
+      - inputPowerCount
+      - inputFeedName
+      - inputVoltage
+      - inputVoltageThStatus
+      - inputCurrentCapacity
+      - inputCurrent
+      - inputCurrentThStatus
+      - inputCurrentCrestFactor
+      - inputCurrentPercentLoad
+      - inputVA
+      - inputWatts
+      - inputPowerCapacity
+      #- outletID
+      - outletName
+      #- outletDesignator
+      - outletCurrentCapacity
+      - outletCurrent
+      - outletCurrentThStatus
+      - outletCurrentCrestFactor
+      - outletCurrentPercentLoad
+      - outletVA
+      - outletWatts
+      - outletPowerFactor
+      - outletControlStatus
+    lookups:
+      - source_indexes: [strappingIndex, outletIndex]
+        lookup: 1.3.6.1.4.1.534.6.6.7.6.1.1.2 # outletID
+        #drop_source_indexes: true
+      - source_indexes: [strappingIndex, outletIndex]
+        lookup: 1.3.6.1.4.1.534.6.6.7.6.1.1.3 # outletName
+        #drop_source_indexes: true
+      - source_indexes: [strappingIndex, outletIndex]
+        lookup: 1.3.6.1.4.1.534.6.6.7.6.1.1.6 # outletDesignator
+        drop_source_indexes: true
+    overrides:
+      ifType:
+        type: EnumAsInfo
+      "1.3.6.1.4.1.534.6.6.7.6.1.1.3":
+        type: DisplayString

--- a/snmp.yml
+++ b/snmp.yml
@@ -6559,6 +6559,1148 @@ ddwrt:
     type: DisplayString
     help: Describes whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
       is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.101
+eaton_epdu:
+  walk:
+  - 1.3.6.1.2.1.2
+  - 1.3.6.1.2.1.31.1.1
+  - 1.3.6.1.4.1.13742.4.1.2.2.1.4
+  - 1.3.6.1.4.1.13742.4.1.2.2.1.9
+  - 1.3.6.1.4.1.534.6.6.7.1.2.1.30
+  - 1.3.6.1.4.1.534.6.6.7.1.2.1.31
+  - 1.3.6.1.4.1.534.6.6.7.3.1.1.10
+  - 1.3.6.1.4.1.534.6.6.7.3.1.1.3
+  - 1.3.6.1.4.1.534.6.6.7.3.1.1.4
+  - 1.3.6.1.4.1.534.6.6.7.3.1.1.5
+  - 1.3.6.1.4.1.534.6.6.7.3.1.1.6
+  - 1.3.6.1.4.1.534.6.6.7.3.1.1.7
+  - 1.3.6.1.4.1.534.6.6.7.3.2.1.3
+  - 1.3.6.1.4.1.534.6.6.7.3.2.1.4
+  - 1.3.6.1.4.1.534.6.6.7.3.3.1.10
+  - 1.3.6.1.4.1.534.6.6.7.3.3.1.11
+  - 1.3.6.1.4.1.534.6.6.7.3.3.1.3
+  - 1.3.6.1.4.1.534.6.6.7.3.3.1.4
+  - 1.3.6.1.4.1.534.6.6.7.3.3.1.5
+  - 1.3.6.1.4.1.534.6.6.7.3.4.1.3
+  - 1.3.6.1.4.1.534.6.6.7.3.4.1.4
+  - 1.3.6.1.4.1.534.6.6.7.3.5.1.9
+  - 1.3.6.1.4.1.534.6.6.7.6.1.1.2
+  - 1.3.6.1.4.1.534.6.6.7.6.1.1.3
+  - 1.3.6.1.4.1.534.6.6.7.6.1.1.6
+  - 1.3.6.1.4.1.534.6.6.7.6.4.1.10
+  - 1.3.6.1.4.1.534.6.6.7.6.4.1.2
+  - 1.3.6.1.4.1.534.6.6.7.6.4.1.4
+  - 1.3.6.1.4.1.534.6.6.7.6.4.1.9
+  - 1.3.6.1.4.1.534.6.6.7.6.5.1.2
+  - 1.3.6.1.4.1.534.6.6.7.6.5.1.3
+  - 1.3.6.1.4.1.534.6.6.7.6.6.1.2
+  metrics:
+  - name: ifNumber
+    oid: 1.3.6.1.2.1.2.1
+    type: gauge
+    help: The number of network interfaces (regardless of their current state) present
+      on this system. - 1.3.6.1.2.1.2.1
+  - name: ifIndex
+    oid: 1.3.6.1.2.1.2.2.1.1
+    type: gauge
+    help: A unique value, greater than zero, for each interface - 1.3.6.1.2.1.2.2.1.1
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifDescr
+    oid: 1.3.6.1.2.1.2.2.1.2
+    type: DisplayString
+    help: A textual string containing information about the interface - 1.3.6.1.2.1.2.2.1.2
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifType
+    oid: 1.3.6.1.2.1.2.2.1.3
+    type: EnumAsInfo
+    help: The type of interface - 1.3.6.1.2.1.2.2.1.3
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    enum_values:
+      1: other
+      2: regular1822
+      3: hdh1822
+      4: ddnX25
+      5: rfc877x25
+      6: ethernetCsmacd
+      7: iso88023Csmacd
+      8: iso88024TokenBus
+      9: iso88025TokenRing
+      10: iso88026Man
+      11: starLan
+      12: proteon10Mbit
+      13: proteon80Mbit
+      14: hyperchannel
+      15: fddi
+      16: lapb
+      17: sdlc
+      18: ds1
+      19: e1
+      20: basicISDN
+      21: primaryISDN
+      22: propPointToPointSerial
+      23: ppp
+      24: softwareLoopback
+      25: eon
+      26: ethernet3Mbit
+      27: nsip
+      28: slip
+      29: ultra
+      30: ds3
+      31: sip
+      32: frameRelay
+      33: rs232
+      34: para
+      35: arcnet
+      36: arcnetPlus
+      37: atm
+      38: miox25
+      39: sonet
+      40: x25ple
+      41: iso88022llc
+      42: localTalk
+      43: smdsDxi
+      44: frameRelayService
+      45: v35
+      46: hssi
+      47: hippi
+      48: modem
+      49: aal5
+      50: sonetPath
+      51: sonetVT
+      52: smdsIcip
+      53: propVirtual
+      54: propMultiplexor
+      55: ieee80212
+      56: fibreChannel
+      57: hippiInterface
+      58: frameRelayInterconnect
+      59: aflane8023
+      60: aflane8025
+      61: cctEmul
+      62: fastEther
+      63: isdn
+      64: v11
+      65: v36
+      66: g703at64k
+      67: g703at2mb
+      68: qllc
+      69: fastEtherFX
+      70: channel
+      71: ieee80211
+      72: ibm370parChan
+      73: escon
+      74: dlsw
+      75: isdns
+      76: isdnu
+      77: lapd
+      78: ipSwitch
+      79: rsrb
+      80: atmLogical
+      81: ds0
+      82: ds0Bundle
+      83: bsc
+      84: async
+      85: cnr
+      86: iso88025Dtr
+      87: eplrs
+      88: arap
+      89: propCnls
+      90: hostPad
+      91: termPad
+      92: frameRelayMPI
+      93: x213
+      94: adsl
+      95: radsl
+      96: sdsl
+      97: vdsl
+      98: iso88025CRFPInt
+      99: myrinet
+      100: voiceEM
+      101: voiceFXO
+      102: voiceFXS
+      103: voiceEncap
+      104: voiceOverIp
+      105: atmDxi
+      106: atmFuni
+      107: atmIma
+      108: pppMultilinkBundle
+      109: ipOverCdlc
+      110: ipOverClaw
+      111: stackToStack
+      112: virtualIpAddress
+      113: mpc
+      114: ipOverAtm
+      115: iso88025Fiber
+      116: tdlc
+      117: gigabitEthernet
+      118: hdlc
+      119: lapf
+      120: v37
+      121: x25mlp
+      122: x25huntGroup
+      123: transpHdlc
+      124: interleave
+      125: fast
+      126: ip
+      127: docsCableMaclayer
+      128: docsCableDownstream
+      129: docsCableUpstream
+      130: a12MppSwitch
+      131: tunnel
+      132: coffee
+      133: ces
+      134: atmSubInterface
+      135: l2vlan
+      136: l3ipvlan
+      137: l3ipxvlan
+      138: digitalPowerline
+      139: mediaMailOverIp
+      140: dtm
+      141: dcn
+      142: ipForward
+      143: msdsl
+      144: ieee1394
+      145: if-gsn
+      146: dvbRccMacLayer
+      147: dvbRccDownstream
+      148: dvbRccUpstream
+      149: atmVirtual
+      150: mplsTunnel
+      151: srp
+      152: voiceOverAtm
+      153: voiceOverFrameRelay
+      154: idsl
+      155: compositeLink
+      156: ss7SigLink
+      157: propWirelessP2P
+      158: frForward
+      159: rfc1483
+      160: usb
+      161: ieee8023adLag
+      162: bgppolicyaccounting
+      163: frf16MfrBundle
+      164: h323Gatekeeper
+      165: h323Proxy
+      166: mpls
+      167: mfSigLink
+      168: hdsl2
+      169: shdsl
+      170: ds1FDL
+      171: pos
+      172: dvbAsiIn
+      173: dvbAsiOut
+      174: plc
+      175: nfas
+      176: tr008
+      177: gr303RDT
+      178: gr303IDT
+      179: isup
+      180: propDocsWirelessMaclayer
+      181: propDocsWirelessDownstream
+      182: propDocsWirelessUpstream
+      183: hiperlan2
+      184: propBWAp2Mp
+      185: sonetOverheadChannel
+      186: digitalWrapperOverheadChannel
+      187: aal2
+      188: radioMAC
+      189: atmRadio
+      190: imt
+      191: mvl
+      192: reachDSL
+      193: frDlciEndPt
+      194: atmVciEndPt
+      195: opticalChannel
+      196: opticalTransport
+      197: propAtm
+      198: voiceOverCable
+      199: infiniband
+      200: teLink
+      201: q2931
+      202: virtualTg
+      203: sipTg
+      204: sipSig
+      205: docsCableUpstreamChannel
+      206: econet
+      207: pon155
+      208: pon622
+      209: bridge
+      210: linegroup
+      211: voiceEMFGD
+      212: voiceFGDEANA
+      213: voiceDID
+      214: mpegTransport
+      215: sixToFour
+      216: gtp
+      217: pdnEtherLoop1
+      218: pdnEtherLoop2
+      219: opticalChannelGroup
+      220: homepna
+      221: gfp
+      222: ciscoISLvlan
+      223: actelisMetaLOOP
+      224: fcipLink
+      225: rpr
+      226: qam
+      227: lmp
+      228: cblVectaStar
+      229: docsCableMCmtsDownstream
+      230: adsl2
+      231: macSecControlledIF
+      232: macSecUncontrolledIF
+      233: aviciOpticalEther
+      234: atmbond
+      235: voiceFGDOS
+      236: mocaVersion1
+      237: ieee80216WMAN
+      238: adsl2plus
+      239: dvbRcsMacLayer
+      240: dvbTdm
+      241: dvbRcsTdma
+      242: x86Laps
+      243: wwanPP
+      244: wwanPP2
+      245: voiceEBS
+      246: ifPwType
+      247: ilan
+      248: pip
+      249: aluELP
+      250: gpon
+      251: vdsl2
+      252: capwapDot11Profile
+      253: capwapDot11Bss
+      254: capwapWtpVirtualRadio
+      255: bits
+      256: docsCableUpstreamRfPort
+      257: cableDownstreamRfPort
+      258: vmwareVirtualNic
+      259: ieee802154
+      260: otnOdu
+      261: otnOtu
+      262: ifVfiType
+      263: g9981
+      264: g9982
+      265: g9983
+      266: aluEpon
+      267: aluEponOnu
+      268: aluEponPhysicalUni
+      269: aluEponLogicalLink
+      270: aluGponOnu
+      271: aluGponPhysicalUni
+      272: vmwareNicTeam
+      277: docsOfdmDownstream
+      278: docsOfdmaUpstream
+      279: gfast
+      280: sdci
+      281: xboxWireless
+      282: fastdsl
+      283: docsCableScte55d1FwdOob
+      284: docsCableScte55d1RetOob
+      285: docsCableScte55d2DsOob
+      286: docsCableScte55d2UsOob
+      287: docsCableNdf
+      288: docsCableNdr
+      289: ptm
+      290: ghn
+      291: otnOtsi
+      292: otnOtuc
+      293: otnOduc
+      294: otnOtsig
+      295: microwaveCarrierTermination
+      296: microwaveRadioLinkTerminal
+      297: ieee8021axDrni
+      298: ax25
+      299: ieee19061nanocom
+      300: cpri
+      301: omni
+      302: roe
+      303: p2pOverLan
+  - name: ifMtu
+    oid: 1.3.6.1.2.1.2.2.1.4
+    type: gauge
+    help: The size of the largest packet which can be sent/received on the interface,
+      specified in octets - 1.3.6.1.2.1.2.2.1.4
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifSpeed
+    oid: 1.3.6.1.2.1.2.2.1.5
+    type: gauge
+    help: An estimate of the interface's current bandwidth in bits per second - 1.3.6.1.2.1.2.2.1.5
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifPhysAddress
+    oid: 1.3.6.1.2.1.2.2.1.6
+    type: PhysAddress48
+    help: The interface's address at its protocol sub-layer - 1.3.6.1.2.1.2.2.1.6
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifAdminStatus
+    oid: 1.3.6.1.2.1.2.2.1.7
+    type: gauge
+    help: The desired state of the interface - 1.3.6.1.2.1.2.2.1.7
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    enum_values:
+      1: up
+      2: down
+      3: testing
+  - name: ifOperStatus
+    oid: 1.3.6.1.2.1.2.2.1.8
+    type: gauge
+    help: The current operational state of the interface - 1.3.6.1.2.1.2.2.1.8
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    enum_values:
+      1: up
+      2: down
+      3: testing
+      4: unknown
+      5: dormant
+      6: notPresent
+      7: lowerLayerDown
+  - name: ifLastChange
+    oid: 1.3.6.1.2.1.2.2.1.9
+    type: gauge
+    help: The value of sysUpTime at the time the interface entered its current operational
+      state - 1.3.6.1.2.1.2.2.1.9
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifInOctets
+    oid: 1.3.6.1.2.1.2.2.1.10
+    type: counter
+    help: The total number of octets received on the interface, including framing
+      characters - 1.3.6.1.2.1.2.2.1.10
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifInUcastPkts
+    oid: 1.3.6.1.2.1.2.2.1.11
+    type: counter
+    help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+      which were not addressed to a multicast or broadcast address at this sub-layer
+      - 1.3.6.1.2.1.2.2.1.11
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifInNUcastPkts
+    oid: 1.3.6.1.2.1.2.2.1.12
+    type: counter
+    help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+      which were addressed to a multicast or broadcast address at this sub-layer -
+      1.3.6.1.2.1.2.2.1.12
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifInDiscards
+    oid: 1.3.6.1.2.1.2.2.1.13
+    type: counter
+    help: The number of inbound packets which were chosen to be discarded even though
+      no errors had been detected to prevent their being deliverable to a higher-layer
+      protocol - 1.3.6.1.2.1.2.2.1.13
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifInErrors
+    oid: 1.3.6.1.2.1.2.2.1.14
+    type: counter
+    help: For packet-oriented interfaces, the number of inbound packets that contained
+      errors preventing them from being deliverable to a higher-layer protocol - 1.3.6.1.2.1.2.2.1.14
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifInUnknownProtos
+    oid: 1.3.6.1.2.1.2.2.1.15
+    type: counter
+    help: For packet-oriented interfaces, the number of packets received via the interface
+      which were discarded because of an unknown or unsupported protocol - 1.3.6.1.2.1.2.2.1.15
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifOutOctets
+    oid: 1.3.6.1.2.1.2.2.1.16
+    type: counter
+    help: The total number of octets transmitted out of the interface, including framing
+      characters - 1.3.6.1.2.1.2.2.1.16
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifOutUcastPkts
+    oid: 1.3.6.1.2.1.2.2.1.17
+    type: counter
+    help: The total number of packets that higher-level protocols requested be transmitted,
+      and which were not addressed to a multicast or broadcast address at this sub-layer,
+      including those that were discarded or not sent - 1.3.6.1.2.1.2.2.1.17
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifOutNUcastPkts
+    oid: 1.3.6.1.2.1.2.2.1.18
+    type: counter
+    help: The total number of packets that higher-level protocols requested be transmitted,
+      and which were addressed to a multicast or broadcast address at this sub-layer,
+      including those that were discarded or not sent - 1.3.6.1.2.1.2.2.1.18
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifOutDiscards
+    oid: 1.3.6.1.2.1.2.2.1.19
+    type: counter
+    help: The number of outbound packets which were chosen to be discarded even though
+      no errors had been detected to prevent their being transmitted - 1.3.6.1.2.1.2.2.1.19
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifOutErrors
+    oid: 1.3.6.1.2.1.2.2.1.20
+    type: counter
+    help: For packet-oriented interfaces, the number of outbound packets that could
+      not be transmitted because of errors - 1.3.6.1.2.1.2.2.1.20
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifOutQLen
+    oid: 1.3.6.1.2.1.2.2.1.21
+    type: gauge
+    help: The length of the output packet queue (in packets). - 1.3.6.1.2.1.2.2.1.21
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifSpecific
+    oid: 1.3.6.1.2.1.2.2.1.22
+    type: OctetString
+    help: A reference to MIB definitions specific to the particular media being used
+      to realize the interface - 1.3.6.1.2.1.2.2.1.22
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifName
+    oid: 1.3.6.1.2.1.31.1.1.1.1
+    type: DisplayString
+    help: The textual name of the interface - 1.3.6.1.2.1.31.1.1.1.1
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifInMulticastPkts
+    oid: 1.3.6.1.2.1.31.1.1.1.2
+    type: counter
+    help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+      which were addressed to a multicast address at this sub-layer - 1.3.6.1.2.1.31.1.1.1.2
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifInBroadcastPkts
+    oid: 1.3.6.1.2.1.31.1.1.1.3
+    type: counter
+    help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+      which were addressed to a broadcast address at this sub-layer - 1.3.6.1.2.1.31.1.1.1.3
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifOutMulticastPkts
+    oid: 1.3.6.1.2.1.31.1.1.1.4
+    type: counter
+    help: The total number of packets that higher-level protocols requested be transmitted,
+      and which were addressed to a multicast address at this sub-layer, including
+      those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.4
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifOutBroadcastPkts
+    oid: 1.3.6.1.2.1.31.1.1.1.5
+    type: counter
+    help: The total number of packets that higher-level protocols requested be transmitted,
+      and which were addressed to a broadcast address at this sub-layer, including
+      those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.5
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifHCInOctets
+    oid: 1.3.6.1.2.1.31.1.1.1.6
+    type: counter
+    help: The total number of octets received on the interface, including framing
+      characters - 1.3.6.1.2.1.31.1.1.1.6
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifHCInUcastPkts
+    oid: 1.3.6.1.2.1.31.1.1.1.7
+    type: counter
+    help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+      which were not addressed to a multicast or broadcast address at this sub-layer
+      - 1.3.6.1.2.1.31.1.1.1.7
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifHCInMulticastPkts
+    oid: 1.3.6.1.2.1.31.1.1.1.8
+    type: counter
+    help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+      which were addressed to a multicast address at this sub-layer - 1.3.6.1.2.1.31.1.1.1.8
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifHCInBroadcastPkts
+    oid: 1.3.6.1.2.1.31.1.1.1.9
+    type: counter
+    help: The number of packets, delivered by this sub-layer to a higher (sub-)layer,
+      which were addressed to a broadcast address at this sub-layer - 1.3.6.1.2.1.31.1.1.1.9
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifHCOutOctets
+    oid: 1.3.6.1.2.1.31.1.1.1.10
+    type: counter
+    help: The total number of octets transmitted out of the interface, including framing
+      characters - 1.3.6.1.2.1.31.1.1.1.10
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifHCOutUcastPkts
+    oid: 1.3.6.1.2.1.31.1.1.1.11
+    type: counter
+    help: The total number of packets that higher-level protocols requested be transmitted,
+      and which were not addressed to a multicast or broadcast address at this sub-layer,
+      including those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.11
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifHCOutMulticastPkts
+    oid: 1.3.6.1.2.1.31.1.1.1.12
+    type: counter
+    help: The total number of packets that higher-level protocols requested be transmitted,
+      and which were addressed to a multicast address at this sub-layer, including
+      those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.12
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifHCOutBroadcastPkts
+    oid: 1.3.6.1.2.1.31.1.1.1.13
+    type: counter
+    help: The total number of packets that higher-level protocols requested be transmitted,
+      and which were addressed to a broadcast address at this sub-layer, including
+      those that were discarded or not sent - 1.3.6.1.2.1.31.1.1.1.13
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifLinkUpDownTrapEnable
+    oid: 1.3.6.1.2.1.31.1.1.1.14
+    type: gauge
+    help: Indicates whether linkUp/linkDown traps should be generated for this interface
+      - 1.3.6.1.2.1.31.1.1.1.14
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    enum_values:
+      1: enabled
+      2: disabled
+  - name: ifHighSpeed
+    oid: 1.3.6.1.2.1.31.1.1.1.15
+    type: gauge
+    help: An estimate of the interface's current bandwidth in units of 1,000,000 bits
+      per second - 1.3.6.1.2.1.31.1.1.1.15
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifPromiscuousMode
+    oid: 1.3.6.1.2.1.31.1.1.1.16
+    type: gauge
+    help: This object has a value of false(2) if this interface only accepts packets/frames
+      that are addressed to this station - 1.3.6.1.2.1.31.1.1.1.16
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    enum_values:
+      1: "true"
+      2: "false"
+  - name: ifConnectorPresent
+    oid: 1.3.6.1.2.1.31.1.1.1.17
+    type: gauge
+    help: This object has the value 'true(1)' if the interface sublayer has a physical
+      connector and the value 'false(2)' otherwise. - 1.3.6.1.2.1.31.1.1.1.17
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+    enum_values:
+      1: "true"
+      2: "false"
+  - name: ifAlias
+    oid: 1.3.6.1.2.1.31.1.1.1.18
+    type: DisplayString
+    help: This object is an 'alias' name for the interface as specified by a network
+      manager, and provides a non-volatile 'handle' for the interface - 1.3.6.1.2.1.31.1.1.1.18
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: ifCounterDiscontinuityTime
+    oid: 1.3.6.1.2.1.31.1.1.1.19
+    type: gauge
+    help: The value of sysUpTime on the most recent occasion at which any one or more
+      of this interface's counters suffered a discontinuity - 1.3.6.1.2.1.31.1.1.1.19
+    indexes:
+    - labelname: ifIndex
+      type: gauge
+  - name: outletCurrent
+    oid: 1.3.6.1.4.1.13742.4.1.2.2.1.4
+    type: gauge
+    help: A unique value for the current sensor attached to the outlet - 1.3.6.1.4.1.13742.4.1.2.2.1.4
+    indexes:
+    - labelname: outletIndex
+      type: gauge
+  - name: outletPowerFactor
+    oid: 1.3.6.1.4.1.13742.4.1.2.2.1.9
+    type: gauge
+    help: A unique value for the power factor of the outlet - 1.3.6.1.4.1.13742.4.1.2.2.1.9
+    indexes:
+    - labelname: outletIndex
+      type: gauge
+  - name: communicationStatus
+    oid: 1.3.6.1.4.1.534.6.6.7.1.2.1.30
+    type: gauge
+    help: Status of the internal communication with the PDU. - 1.3.6.1.4.1.534.6.6.7.1.2.1.30
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    enum_values:
+      0: good
+      1: communicationLost
+  - name: internalStatus
+    oid: 1.3.6.1.4.1.534.6.6.7.1.2.1.31
+    type: gauge
+    help: Status of the internal failure inside the PDU. - 1.3.6.1.4.1.534.6.6.7.1.2.1.31
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    enum_values:
+      0: good
+      1: internalFailure
+  - name: inputFeedName
+    oid: 1.3.6.1.4.1.534.6.6.7.3.1.1.10
+    type: OctetString
+    help: A descriptive name for the input. - 1.3.6.1.4.1.534.6.6.7.3.1.1.10
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+  - name: inputFrequency
+    oid: 1.3.6.1.4.1.534.6.6.7.3.1.1.3
+    type: gauge
+    help: Units are 0.1 Hz; divide by ten to get Hz. - 1.3.6.1.4.1.534.6.6.7.3.1.1.3
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+  - name: inputFrequencyStatus
+    oid: 1.3.6.1.4.1.534.6.6.7.3.1.1.4
+    type: gauge
+    help: Status of the measured input frequency relative to the nominal frequency
+      and the admitted tolerance. - 1.3.6.1.4.1.534.6.6.7.3.1.1.4
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+    enum_values:
+      0: good
+      1: outOfRange
+  - name: inputVoltageCount
+    oid: 1.3.6.1.4.1.534.6.6.7.3.1.1.5
+    type: gauge
+    help: Number of input voltage measurements on this ePDU. - 1.3.6.1.4.1.534.6.6.7.3.1.1.5
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+  - name: inputCurrentCount
+    oid: 1.3.6.1.4.1.534.6.6.7.3.1.1.6
+    type: gauge
+    help: Number of input current measurements on this ePDU. - 1.3.6.1.4.1.534.6.6.7.3.1.1.6
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+  - name: inputPowerCount
+    oid: 1.3.6.1.4.1.534.6.6.7.3.1.1.7
+    type: gauge
+    help: Number of rows in the inputPowerTable. - 1.3.6.1.4.1.534.6.6.7.3.1.1.7
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+  - name: inputVoltage
+    oid: 1.3.6.1.4.1.534.6.6.7.3.2.1.3
+    type: gauge
+    help: An input voltage measurement value - 1.3.6.1.4.1.534.6.6.7.3.2.1.3
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+    - labelname: inputVoltageIndex
+      type: gauge
+  - name: inputVoltageThStatus
+    oid: 1.3.6.1.4.1.534.6.6.7.3.2.1.4
+    type: gauge
+    help: Status of the measured input voltage relative to the configured thresholds.
+      - 1.3.6.1.4.1.534.6.6.7.3.2.1.4
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+    - labelname: inputVoltageIndex
+      type: gauge
+    enum_values:
+      0: good
+      1: lowWarning
+      2: lowCritical
+      3: highWarning
+      4: highCritical
+  - name: inputCurrentCrestFactor
+    oid: 1.3.6.1.4.1.534.6.6.7.3.3.1.10
+    type: gauge
+    help: Current crest factor - 1.3.6.1.4.1.534.6.6.7.3.3.1.10
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+    - labelname: inputCurrentIndex
+      type: gauge
+  - name: inputCurrentPercentLoad
+    oid: 1.3.6.1.4.1.534.6.6.7.3.3.1.11
+    type: gauge
+    help: Current percent load, based on the rated current capacity - 1.3.6.1.4.1.534.6.6.7.3.3.1.11
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+    - labelname: inputCurrentIndex
+      type: gauge
+  - name: inputCurrentCapacity
+    oid: 1.3.6.1.4.1.534.6.6.7.3.3.1.3
+    type: gauge
+    help: Rated current capacity of the input - 1.3.6.1.4.1.534.6.6.7.3.3.1.3
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+    - labelname: inputCurrentIndex
+      type: gauge
+  - name: inputCurrent
+    oid: 1.3.6.1.4.1.534.6.6.7.3.3.1.4
+    type: gauge
+    help: An input current measurement value - 1.3.6.1.4.1.534.6.6.7.3.3.1.4
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+    - labelname: inputCurrentIndex
+      type: gauge
+  - name: inputCurrentThStatus
+    oid: 1.3.6.1.4.1.534.6.6.7.3.3.1.5
+    type: gauge
+    help: Status of the measured input current relative to the configured thresholds.
+      - 1.3.6.1.4.1.534.6.6.7.3.3.1.5
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+    - labelname: inputCurrentIndex
+      type: gauge
+    enum_values:
+      0: good
+      1: lowWarning
+      2: lowCritical
+      3: highWarning
+      4: highCritical
+  - name: inputVA
+    oid: 1.3.6.1.4.1.534.6.6.7.3.4.1.3
+    type: gauge
+    help: An input VA value - 1.3.6.1.4.1.534.6.6.7.3.4.1.3
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+    - labelname: inputPowerIndex
+      type: gauge
+  - name: inputWatts
+    oid: 1.3.6.1.4.1.534.6.6.7.3.4.1.4
+    type: gauge
+    help: An input Watts value - 1.3.6.1.4.1.534.6.6.7.3.4.1.4
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+    - labelname: inputPowerIndex
+      type: gauge
+  - name: inputPowerCapacity
+    oid: 1.3.6.1.4.1.534.6.6.7.3.5.1.9
+    type: gauge
+    help: Typical power capacity of the input - 1.3.6.1.4.1.534.6.6.7.3.5.1.9
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: inputIndex
+      type: gauge
+  - name: outletCurrentPercentLoad
+    oid: 1.3.6.1.4.1.534.6.6.7.6.4.1.10
+    type: gauge
+    help: Current percent load, based on the rated current capacity - 1.3.6.1.4.1.534.6.6.7.6.4.1.10
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletID
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.2
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletName
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.3
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletDesignator
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.6
+      type: DisplayString
+    - labels: []
+      labelname: strappingIndex
+    - labels: []
+      labelname: outletIndex
+  - name: outletCurrentCapacity
+    oid: 1.3.6.1.4.1.534.6.6.7.6.4.1.2
+    type: gauge
+    help: Rated current capacity of the outlet - 1.3.6.1.4.1.534.6.6.7.6.4.1.2
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletID
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.2
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletName
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.3
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletDesignator
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.6
+      type: DisplayString
+    - labels: []
+      labelname: strappingIndex
+    - labels: []
+      labelname: outletIndex
+  - name: outletCurrentThStatus
+    oid: 1.3.6.1.4.1.534.6.6.7.6.4.1.4
+    type: gauge
+    help: Status of the measured outlet current relative to the configured thresholds
+      - 1.3.6.1.4.1.534.6.6.7.6.4.1.4
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletID
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.2
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletName
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.3
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletDesignator
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.6
+      type: DisplayString
+    - labels: []
+      labelname: strappingIndex
+    - labels: []
+      labelname: outletIndex
+    enum_values:
+      0: good
+      1: lowWarning
+      2: lowCritical
+      3: highWarning
+      4: highCritical
+  - name: outletCurrentCrestFactor
+    oid: 1.3.6.1.4.1.534.6.6.7.6.4.1.9
+    type: gauge
+    help: Current crest factor - 1.3.6.1.4.1.534.6.6.7.6.4.1.9
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletID
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.2
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletName
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.3
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletDesignator
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.6
+      type: DisplayString
+    - labels: []
+      labelname: strappingIndex
+    - labels: []
+      labelname: outletIndex
+  - name: outletVA
+    oid: 1.3.6.1.4.1.534.6.6.7.6.5.1.2
+    type: gauge
+    help: An outlet VA value - 1.3.6.1.4.1.534.6.6.7.6.5.1.2
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletID
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.2
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletName
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.3
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletDesignator
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.6
+      type: DisplayString
+    - labels: []
+      labelname: strappingIndex
+    - labels: []
+      labelname: outletIndex
+  - name: outletWatts
+    oid: 1.3.6.1.4.1.534.6.6.7.6.5.1.3
+    type: gauge
+    help: An outlet Watts value - 1.3.6.1.4.1.534.6.6.7.6.5.1.3
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletID
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.2
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletName
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.3
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletDesignator
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.6
+      type: DisplayString
+    - labels: []
+      labelname: strappingIndex
+    - labels: []
+      labelname: outletIndex
+  - name: outletControlStatus
+    oid: 1.3.6.1.4.1.534.6.6.7.6.6.1.2
+    type: gauge
+    help: Current state of a controlled outlet. - 1.3.6.1.4.1.534.6.6.7.6.6.1.2
+    indexes:
+    - labelname: strappingIndex
+      type: gauge
+    - labelname: outletIndex
+      type: gauge
+    lookups:
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletID
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.2
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletName
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.3
+      type: DisplayString
+    - labels:
+      - strappingIndex
+      - outletIndex
+      labelname: outletDesignator
+      oid: 1.3.6.1.4.1.534.6.6.7.6.1.1.6
+      type: DisplayString
+    - labels: []
+      labelname: strappingIndex
+    - labels: []
+      labelname: outletIndex
+    enum_values:
+      0: "off"
+      1: "on"
+      2: pendingOff
+      3: pendingOn
+  version: 1
 if_mib:
   walk:
   - 1.3.6.1.2.1.2

--- a/snmp.yml
+++ b/snmp.yml
@@ -6593,6 +6593,10 @@ eaton_epdu:
   - 1.3.6.1.4.1.534.6.6.7.6.5.1.2
   - 1.3.6.1.4.1.534.6.6.7.6.5.1.3
   - 1.3.6.1.4.1.534.6.6.7.6.6.1.2
+  - 1.3.6.1.4.1.534.6.8.1.2.3.1.1
+  - 1.3.6.1.4.1.534.6.8.1.2.3.1.3
+  - 1.3.6.1.4.1.534.6.8.1.3.3.1.1
+  - 1.3.6.1.4.1.534.6.8.1.3.3.1.3
   metrics:
   - name: ifNumber
     oid: 1.3.6.1.2.1.2.1
@@ -7700,6 +7704,92 @@ eaton_epdu:
       1: "on"
       2: pendingOff
       3: pendingOn
+  - name: temperatureAlarm
+    oid: 1.3.6.1.4.1.534.6.8.1.2.3.1.1
+    type: gauge
+    help: Alarm set according to the realtime measure compared to the thresholds.
+      - 1.3.6.1.4.1.534.6.8.1.2.3.1.1
+    indexes:
+    - labelname: sensorIndex
+      type: gauge
+      enum_values:
+        1: temp1
+        2: temp2
+        3: temp3
+        4: temp4
+        5: temp5
+        6: temp6
+        7: temp7
+        8: temp8
+    - labelname: temperatureIndex
+      type: gauge
+    enum_values:
+      0: good
+      1: lowWarning
+      2: lowCritical
+      3: highWarning
+      4: highCritical
+  - name: temperatureValue
+    oid: 1.3.6.1.4.1.534.6.8.1.2.3.1.3
+    type: gauge
+    help: Realtime measured value after correction with the offset - 1.3.6.1.4.1.534.6.8.1.2.3.1.3
+    indexes:
+    - labelname: sensorIndex
+      type: gauge
+      enum_values:
+        1: temp1
+        2: temp2
+        3: temp3
+        4: temp4
+        5: temp5
+        6: temp6
+        7: temp7
+        8: temp8
+    - labelname: temperatureIndex
+      type: gauge
+  - name: humidityAlarm
+    oid: 1.3.6.1.4.1.534.6.8.1.3.3.1.1
+    type: gauge
+    help: Alarm set according to the realtime measure compared to the thresholds.
+      - 1.3.6.1.4.1.534.6.8.1.3.3.1.1
+    indexes:
+    - labelname: sensorIndex
+      type: gauge
+      enum_values:
+        1: temp1
+        2: temp2
+        3: temp3
+        4: temp4
+        5: temp5
+        6: temp6
+        7: temp7
+        8: temp8
+    - labelname: humidityIndex
+      type: gauge
+    enum_values:
+      0: good
+      1: lowWarning
+      2: lowCritical
+      3: highWarning
+      4: highCritical
+  - name: humidityValue
+    oid: 1.3.6.1.4.1.534.6.8.1.3.3.1.3
+    type: gauge
+    help: Realtime measured value after correction with the offset - 1.3.6.1.4.1.534.6.8.1.3.3.1.3
+    indexes:
+    - labelname: sensorIndex
+      type: gauge
+      enum_values:
+        1: temp1
+        2: temp2
+        3: temp3
+        4: temp4
+        5: temp5
+        6: temp6
+        7: temp7
+        8: temp8
+    - labelname: humidityIndex
+      type: gauge
   version: 1
 if_mib:
   walk:


### PR DESCRIPTION
This adds support for Eaton EPDU G3 PDUs, including per-outlet power monitoring.

@SuperQ 