### PR TITLE
Update snmp_exporter.service

### DIFF
--- a/examples/systemd/snmp_exporter.service
+++ b/examples/systemd/snmp_exporter.service
@@ -7,7 +7,7 @@ After=network-online.target
 [Service]
 User=prometheus
 Restart=on-failure
-ExecStart=/home/prometheus/snmp_exporter/snmp_exporter --config.file='/home/prometheus/snmp_exporter/snmp.yml'
+ExecStart=/home/prometheus/snmp_exporter/snmp_exporter --config.file=/home/prometheus/snmp_exporter/snmp.yml
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Fix service start failed issue in CentOS 7.9.

Error message below

```
Aug 26 09:43:16 Prometheus_SNMP systemd[1]: Unit snmp_exporter.service entered failed state.                                    
Aug 26 09:43:16 Prometheus_SNMP systemd[1]: snmp_exporter.service failed.                                                       
Aug 26 09:43:16 Prometheus_SNMP systemd[1]: snmp_exporter.service holdoff time over, scheduling restart.                        
Aug 26 09:43:16 Prometheus_SNMP systemd[1]: Stopped SNMP Exporter.                                                              
Aug 26 09:43:16 Prometheus_SNMP systemd[1]: start request repeated too quickly for snmp_exporter.service                        
Aug 26 09:43:16 Prometheus_SNMP systemd[1]: Failed to start SNMP Exporter.                                                      
Aug 26 09:43:16 Prometheus_SNMP systemd[1]: Unit snmp_exporter.service entered failed state.                                    
Aug 26 09:43:16 Prometheus_SNMP systemd[1]: snmp_exporter.service failed.
```

Signed-off-by: xxzk <eric24831684@gmail.com>