### PR TITLE
Allow snmp_context to be passed as optional parameter to override the snmp.ContextName

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -55,7 +55,7 @@ ifneq ($(shell which gotestsum),)
 endif
 endif
 
-PROMU_VERSION ?= 0.13.0
+PROMU_VERSION ?= 0.14.0
 PROMU_URL     := https://github.com/prometheus/promu/releases/download/v$(PROMU_VERSION)/promu-$(PROMU_VERSION).$(GO_BUILD_PLATFORM).tar.gz
 
 SKIP_GOLANGCI_LINT :=

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -125,6 +125,7 @@ func ScrapeTarget(ctx context.Context, target string, snmp_context string, confi
 	snmp.Timeout = config.WalkParams.Timeout
 	snmp.UseUnconnectedUDPSocket = config.WalkParams.UseUnconnectedUDPSocket
 	snmp.LocalAddr = *srcAddress
+
 	// Allow a set of OIDs that aren't in a strictly increasing order
 	if config.WalkParams.AllowNonIncreasingOIDs {
 		snmp.AppOpts = make(map[string]interface{})

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -158,7 +158,7 @@ func ScrapeTarget(ctx context.Context, target string, snmp_context string, confi
 	}
 
 	// Configure auth.
-	config.WalkParams.ConfigureSNMP(&snmp,snmp_context)
+	config.WalkParams.ConfigureSNMP(&snmp, snmp_context)
 
 	// Do the actual walk.
 	err := snmp.Connect()
@@ -259,11 +259,11 @@ func buildMetricTree(metrics []*config.Metric) *MetricNode {
 }
 
 type collector struct {
-	ctx    context.Context
-	target string
-        snmp_context string
-	module *config.Module
-	logger log.Logger
+	ctx          context.Context
+	target       string
+	snmp_context string
+	module       *config.Module
+	logger       log.Logger
 }
 
 func New(ctx context.Context, target string, snmp_context string, module *config.Module, logger log.Logger) *collector {

--- a/config/config.go
+++ b/config/config.go
@@ -125,7 +125,7 @@ func (c *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // ConfigureSNMP sets the various version and auth settings.
-func (c WalkParams) ConfigureSNMP(g *gosnmp.GoSNMP,snmp_context string) {
+func (c WalkParams) ConfigureSNMP(g *gosnmp.GoSNMP, snmp_context string) {
 	switch c.Version {
 	case 1:
 		g.Version = gosnmp.Version1
@@ -135,11 +135,11 @@ func (c WalkParams) ConfigureSNMP(g *gosnmp.GoSNMP,snmp_context string) {
 		g.Version = gosnmp.Version3
 	}
 	g.Community = string(c.Auth.Community)
-        if snmp_context == ""{
-	        g.ContextName = c.Auth.ContextName
-        } else{
-                g.ContextName = snmp_context
-        }
+	if snmp_context == "" {
+		g.ContextName = c.Auth.ContextName
+	} else {
+		g.ContextName = snmp_context
+	}
 	// v3 security settings.
 	g.SecurityModel = gosnmp.UserSecurityModel
 	usm := &gosnmp.UsmSecurityParameters{

--- a/config/config.go
+++ b/config/config.go
@@ -125,7 +125,7 @@ func (c *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // ConfigureSNMP sets the various version and auth settings.
-func (c WalkParams) ConfigureSNMP(g *gosnmp.GoSNMP) {
+func (c WalkParams) ConfigureSNMP(g *gosnmp.GoSNMP,snmp_context string) {
 	switch c.Version {
 	case 1:
 		g.Version = gosnmp.Version1
@@ -135,8 +135,11 @@ func (c WalkParams) ConfigureSNMP(g *gosnmp.GoSNMP) {
 		g.Version = gosnmp.Version3
 	}
 	g.Community = string(c.Auth.Community)
-	g.ContextName = c.Auth.ContextName
-
+        if snmp_context == ""{
+	        g.ContextName = c.Auth.ContextName
+        } else{
+                g.ContextName = snmp_context
+        }
 	// v3 security settings.
 	g.SecurityModel = gosnmp.UserSecurityModel
 	usm := &gosnmp.UsmSecurityParameters{

--- a/main.go
+++ b/main.go
@@ -85,13 +85,12 @@ func handler(w http.ResponseWriter, r *http.Request, logger log.Logger) {
 		moduleName = "if_mib"
 	}
 
-
-        snmp_context := query.Get("snmp_context")
-        if len(query["snmp_context"]) > 1 {
-                http.Error(w, "'snmp_context' parameter must only be specified once", 400)
-                snmpRequestErrors.Inc()
-                return
-        }
+	snmp_context := query.Get("snmp_context")
+	if len(query["snmp_context"]) > 1 {
+		http.Error(w, "'snmp_context' parameter must only be specified once", 400)
+		snmpRequestErrors.Inc()
+		return
+	}
 
 	sc.RLock()
 	module, ok := (*(sc.C))[moduleName]

--- a/main.go
+++ b/main.go
@@ -103,7 +103,7 @@ func handler(w http.ResponseWriter, r *http.Request, logger log.Logger) {
 	}
 
 	logger = log.With(logger, "module", moduleName, "target", target)
-	level.Debug(logger).Log("msg", "Starting scrape","snmp_context",snmp_context)
+	level.Debug(logger).Log("msg", "Starting scrape")
 
 	start := time.Now()
 	registry := prometheus.NewRegistry()


### PR DESCRIPTION
snmp?target=hostname&module=module will use existing c.Auth.ContextName from snmp.yml as g.ContextName if defined (same as previous behavior)

snmp?target=hostname&module=module&snmp_context=context_name allows for adding or overriding this value by passing it as a job param similar to target and module values.

this allows for simple automated configuration of jobs to scrape individual contexts without needing to define a new entry in snmp.yml for each

@SuperQ  @RichiH 