### PR TITLE
fix mib parse error

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -46,7 +46,7 @@ RARITAN_URL       := https://cdn.raritan.com/download/PX/v1.5.20/PDU-MIB.txt
 INFRAPOWER_URL    := https://www.austin-hughes.com/wp-content/uploads/2021/05/IPD-03-S-MIB.zip
 LIEBERT_URL       := https://www.vertiv.com/globalassets/documents/software/monitoring/lgpmib-win_rev16_299461_0.zip
 
-CYBERPOWER_VERSION := 2.10
+CYBERPOWER_VERSION := 2.11
 CYBERPOWER_URL     := https://dl4jz3rbrsfum.cloudfront.net/software/CyberPower_MIB_v$(CYBERPOWER_VERSION).MIB.zip
 
 .DEFAULT: all

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -660,7 +660,7 @@ modules:
 
 # CyberPower
 #
-# https://www.cyberpowersystems.com/product/software/mib-files/mib-v29/
+# https://www.cyberpowersystems.com/product/software/mib-files/mib-v211/
   cyberpower:
     version: 1
     walk:


### PR DESCRIPTION
Update Cyberpower MIB Version to 2.11 as there is an error in 2.10 which leads to parse error by net-snmp

```
generator git:(bastischubert/add-geist-mib) ✗ ./generator parse_errors
ts=2023-04-06T14:31:42.610Z caller=net_snmp.go:161 level=info msg="Loading MIBs" from=mibs
ts=2023-04-06T14:31:42.911Z caller=main.go:119 level=warn msg="NetSNMP reported parse error(s)" errors=2
No log handling enabled - using stderr logging
Did not find 'DisplayString' in module #-1 (mibs/CyberPower.MIB)
```