### PR TITLE
Add MIBOPTS flag to the generator

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -35,6 +35,23 @@ by the snmp_exporter executable to collect data from the snmp enabled devices.
 
 Additional command are available for debugging, use the `help` command to see them.
 
+### MIB Parsing options
+
+The parsing of MIBs can be controlled using the `--snmp.mibopts` flag. The available values depend on the net-snmp version used to build the generator.
+
+Example from net-snmp 5.9.1:
+
+```
+Toggle various defaults controlling MIB parsing:
+  u:  allow the use of underlines in MIB symbols
+  c:  disallow the use of "--" to terminate comments
+  d:  save the DESCRIPTIONs of the MIB objects
+  e:  disable errors when MIB symbols conflict
+  w:  enable warnings when MIB symbols conflict
+  W:  enable detailed warnings when MIB symbols conflict
+  R:  replace MIB symbols from latest module
+```
+
 ## Docker Users
 
 If you would like to run the generator in docker to generate your `snmp.yml` config run the following commands.

--- a/generator/main.go
+++ b/generator/main.go
@@ -94,6 +94,7 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node, logger log.Logger)
 
 var (
 	failOnParseErrors  = kingpin.Flag("fail-on-parse-errors", "Exit with a non-zero status if there are MIB parsing errors").Default("false").Bool()
+	snmpMIBOpts        = kingpin.Flag("snmp.mibopts", "Toggle various defaults controlling MIB parsing, see snmpwalk --help").String()
 	generateCommand    = kingpin.Command("generate", "Generate snmp.yml from generator.yml")
 	outputPath         = generateCommand.Flag("output-path", "Path to to write resulting config file").Default("snmp.yml").Short('o').String()
 	parseErrorsCommand = kingpin.Command("parse_errors", "Debug: Print the parse errors output by NetSNMP")

--- a/generator/net_snmp.go
+++ b/generator/net_snmp.go
@@ -20,6 +20,7 @@ package main
 #include <net-snmp/mib_api.h>
 #include <net-snmp/agent/agent_callbacks.h>
 #include <net-snmp/library/default_store.h>
+#include <net-snmp/library/parse.h>
 #include <unistd.h>
 // From parse.c
 // Hacky workarounds to detect which version of net-snmp this
@@ -159,6 +160,9 @@ func initSNMP(logger log.Logger) (string, error) {
 	os.Setenv("MIBS", "ALL")
 	// Help the user find their MIB directories.
 	level.Info(logger).Log("msg", "Loading MIBs", "from", C.GoString(C.netsnmp_get_mib_directory()))
+	if *snmpMIBOpts != "" {
+		C.snmp_mib_toggle_options(C.CString(*snmpMIBOpts))
+	}
 	// We want the descriptions.
 	C.snmp_set_save_descriptions(1)
 


### PR DESCRIPTION
Allow passing net-snmp MIBOPTS for controlling MIB parsing.

Fixes: https://github.com/prometheus/snmp_exporter/issues/715