### PR TITLE
report duration in log after which scrape was cancelled

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -162,10 +162,12 @@ func ScrapeTarget(ctx context.Context, target string, config *config.Module, log
 	config.WalkParams.ConfigureSNMP(&snmp)
 
 	// Do the actual walk.
+	getInitialStart := time.Now()
 	err := snmp.Connect()
 	if err != nil {
 		if err == context.Canceled {
-			return results, fmt.Errorf("scrape canceled (possible timeout) connecting to target %s", snmp.Target)
+			return results, fmt.Errorf("scrape cancelled after %s (possible timeout) connecting to target %s",
+				time.Since(getInitialStart), snmp.Target)
 		}
 		return results, fmt.Errorf("error connecting to target %s: %s", target, err)
 	}
@@ -220,7 +222,8 @@ func ScrapeTarget(ctx context.Context, target string, config *config.Module, log
 		packet, err := snmp.Get(getOids[:oids])
 		if err != nil {
 			if err == context.Canceled {
-				return results, fmt.Errorf("scrape canceled (possible timeout) getting target %s", snmp.Target)
+				return results, fmt.Errorf("scrape cancelled after %s (possible timeout) getting target %s",
+					time.Since(getInitialStart), snmp.Target)
 			}
 			return results, fmt.Errorf("error getting target %s: %s", snmp.Target, err)
 		}
@@ -257,7 +260,8 @@ func ScrapeTarget(ctx context.Context, target string, config *config.Module, log
 		}
 		if err != nil {
 			if err == context.Canceled {
-				return results, fmt.Errorf("scrape canceled (possible timeout) walking target %s", snmp.Target)
+				return results, fmt.Errorf("scrape canceled after %s (possible timeout) walking target %s",
+					time.Since(getInitialStart), snmp.Target)
 			}
 			return results, fmt.Errorf("error walking target %s: %s", snmp.Target, err)
 		}


### PR DESCRIPTION
This change adds duration to log message about cancelled scrape. The motivation for this is the ability tune Prometheus scrape timeout values when SNMP exporter is running in default mode (with log level being info).

This is how it looks like:
```
ts=2023-05-16T15:45:34.828Z caller=main.go:157 level=info msg="Starting snmp_exporter" version="(version=, branch=, revision=9999e5901866ca87e8c0415f464d1d9faf7091a4-modified)"
ts=2023-05-16T15:45:34.829Z caller=main.go:158 level=info build_context="(go=go1.18.1, platform=linux/amd64, user=, date=, tags=unknown)"
ts=2023-05-16T15:45:34.834Z caller=tls_config.go:274 level=info msg="Listening on" address=[::]:9116
ts=2023-05-16T15:45:34.835Z caller=tls_config.go:277 level=info msg="TLS is disabled." http2=false address=[::]:9116
ts=2023-05-16T15:45:42.545Z caller=collector.go:390 level=info module=labtemp target=example.com msg="Error scraping target" err="scrape canceled after 4.845361532s (possible timeout) walking target example.com"
```