### PR TITLE
Enable environment variable expansion during config file load

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -29,7 +29,8 @@ func LoadFile(filename string) (*Config, error) {
 		return nil, err
 	}
 	cfg := &Config{}
-	err = yaml.UnmarshalStrict(content, cfg)
+	expanded := os.ExpandEnv(string(content))
+	err = yaml.UnmarshalStrict([]byte(expanded), cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/config_test.go
+++ b/config_test.go
@@ -14,6 +14,7 @@
 package main
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -44,6 +45,30 @@ func TestLoadConfigWithOverrides(t *testing.T) {
 	err := sc.ReloadConfig("testdata/snmp-with-overrides.yml")
 	if err != nil {
 		t.Errorf("Error loading config %v: %v", "testdata/snmp-with-overrides.yml", err)
+	}
+	sc.RLock()
+	_, err = yaml.Marshal(sc.C)
+	sc.RUnlock()
+	if err != nil {
+		t.Errorf("Error marshaling config: %v", err)
+	}
+}
+
+func TestLoadConfigExpandEnv(t *testing.T) {
+	community := "test-community"
+	os.Setenv("COMMUNITY", community)
+	sc := &SafeConfig{}
+	err := sc.ReloadConfig("testdata/snmp-with-env.yml")
+	if err != nil {
+		t.Errorf("Error loading config %v: %v", "testdata/snmp-with-env.yml", err)
+	}
+	module, ok := (*(sc.C))["default"]
+	if !ok {
+		t.Errorf("Error loading config %v: default key not found.", "testdata/snmp-with-env.yml")
+	}
+	actual := string(module.WalkParams.Auth.Community)
+	if actual != community {
+		t.Errorf("The environment variable was not expanded. Expected %v, but got %v", community, actual)
 	}
 	sc.RLock()
 	_, err = yaml.Marshal(sc.C)

--- a/testdata/snmp-with-env.yml
+++ b/testdata/snmp-with-env.yml
@@ -1,0 +1,5 @@
+default:
+  auth:
+    community: $COMMUNITY
+  walk:
+  - 1.1.1.1.1.1


### PR DESCRIPTION
Hi. I wanted to hide community information in managing snmp.yml, so I made it available from environment variables.

Please let me know if there is anything I am missing.