### PR TITLE
Fix metrics path not using command-line argument value

### DIFF
--- a/main.go
+++ b/main.go
@@ -220,7 +220,7 @@ func main() {
 		}
 	}()
 
-	http.Handle("/metrics", promhttp.Handler()) // Normal metrics endpoint for SNMP exporter itself.
+	http.Handle(*metricsPath, promhttp.Handler()) // Normal metrics endpoint for SNMP exporter itself.
 	// Endpoint to do SNMP scrapes.
 	http.HandleFunc(proberPath, func(w http.ResponseWriter, r *http.Request) {
 		handler(w, r, logger)


### PR DESCRIPTION
Hello,
I casually discovered this bug while looking at the source code of the SNMP exporter.
The exporter currently hard codes `/metrics` instead of using the `--web.telemetry-path` command-line argument value.

The fix here aligns with the current approach in the Node Exporter:
https://github.com/prometheus/node_exporter/blob/c31ebb43590cb0055acd4bc00a432f6a2dafdd08/node_exporter.go#L188