### PR TITLE
Improved Lookup process for label information to utilize TypeMapping

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1006,6 +1006,25 @@ func TestIndexesToLabels(t *testing.T) {
 			},
 			result: map[string]string{"a": "1", "chainable_id": "42", "targetlabel": "targetvalue"},
 		},
+		{
+			oid: []int{1, 8, 1},
+			metric: config.Metric{
+				Indexes: []*config.Index{
+					{Labelname: "lldpRemTimeMark", Type: "gauge"},
+					{Labelname: "lldpRemLocalPortNum", Type: "gauge"},
+					{Labelname: "lldpRemIndex", Type: "gauge"},
+				},
+				Lookups: []*config.Lookup{
+					{Labels: []string{"lldpRemLocalPortNum"}, Labelname: "lldpLocPortId", Oid: "1.1.3", Type: "LldpPortId"},
+				},
+			},
+			oidToPdu: map[string]gosnmp.SnmpPDU{
+				"1.1.9.1.8.1": gosnmp.SnmpPDU{Value: "hostname"},
+				"1.1.2.8":     gosnmp.SnmpPDU{Value: 3},
+				"1.1.3.8":     gosnmp.SnmpPDU{Value: []byte{4, 5, 6, 7, 8, 9}},
+			},
+			result: map[string]string{"lldpRemTimeMark": "1", "lldpRemLocalPortNum": "8", "lldpRemIndex": "1", "lldpLocPortId": "04:05:06:07:08:09"},
+		},
 	}
 	for _, c := range cases {
 		got := indexesToLabels(c.oid, &c.metric, c.oidToPdu, internalMetrics{})


### PR DESCRIPTION
We've made improvements to the Metric Lookup process. 
Previously, the byte representation of labels was output as-is under certain circumstances. With this update, it now references the processing of TypeMapping for output.

generator.yml
```
modules:
  default:
    walk:
    - lldpRemPortIdSubtype
    - lldpLocPortIdSubtype
    - lldpRemPortId
    - lldpLocPortId
    - lldpRemSysName
    lookups:
    - source_indexes:
      - lldpRemTimeMark
      - lldpRemLocalPortNum
      - lldpRemIndex
      lookup: "lldpRemPortId"
    - source_indexes: ['lldpRemLocalPortNum']
      lookup: "lldpLocPortId"
    overrides:
      lldpRemPortIdSubtype:
        ignore: true
      lldpLocPortIdSubtype:
        ignore: true
```

before
```
lldpLocPortId{lldpLocPortId="Management1",lldpLocPortNum="245"} 1
# HELP lldpRemPortId The string value used to identify the port component associated with the remote system. - 1.0.8802.1.1.2.1.4.1.1.7
# TYPE lldpRemPortId gauge
lldpRemPortId{lldpLocPortId="0x4D616E6167656D656E743100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",lldpRemIndex="2",lldpRemLocalPortNum="245",lldpRemPortId="0x4769312F31340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",lldpRemTimeMark="0"} 1
# HELP lldpRemSysName The string value used to identify the system name of the remote system. - 1.0.8802.1.1.2.1.4.1.1.9
# TYPE lldpRemSysName gauge
lldpRemSysName{lldpLocPortId="0x4D616E6167656D656E743100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",lldpRemIndex="14",lldpRemLocalPortNum="245",lldpRemPortId="0x4769312F31340000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",lldpRemSysName="hostname",lldpRemTimeMark="0"} 1
```

after
```
lldpLocPortId{lldpLocPortId="Management1",lldpLocPortNum="245"} 1
# HELP lldpRemPortId The string value used to identify the port component associated with the remote system. - 1.0.8802.1.1.2.1.4.1.1.7
# TYPE lldpRemPortId gauge
lldpRemPortId{lldpLocPortId="Management1",lldpRemIndex="2",lldpRemLocalPortNum="245",lldpRemPortId="Gi1/14",lldpRemTimeMark="0"} 1
# HELP lldpRemSysName The string value used to identify the system name of the remote system. - 1.0.8802.1.1.2.1.4.1.1.9
# TYPE lldpRemSysName gauge
lldpRemSysName{lldpLocPortId="Management1",lldpRemIndex="2",lldpRemLocalPortNum="245",lldpRemPortId="Gi1/14",lldpRemSysName="hostname",lldpRemTimeMark="0"} 1
```