### PR TITLE
Ignore version in config files

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -65,6 +65,7 @@ var (
 type Config struct {
 	Auths   map[string]*Auth   `yaml:"auths,omitempty"`
 	Modules map[string]*Module `yaml:"modules,omitempty"`
+	Version int                `yaml:"version,omitempty"`
 }
 
 type WalkParams struct {

--- a/generator/config.go
+++ b/generator/config.go
@@ -23,6 +23,7 @@ import (
 type Config struct {
 	Auths   map[string]*config.Auth  `yaml:"auths"`
 	Modules map[string]*ModuleConfig `yaml:"modules"`
+	Version int                      `yaml:"version,omitempty"`
 }
 
 type MetricOverrides struct {


### PR DESCRIPTION
Re-add the version key, but omitempty so it is simply ignored for now.