### PR TITLE
Support fetching multiple modules in one scrape

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,25 @@ Note that [URL encoding](https://en.wikipedia.org/wiki/URL_encoding) should be u
 to the `:` and `/` characters. Prometheus encodes query parameters automatically and manual encoding
 is not necessary within the Prometheus configuration file.
 
+## Multi-Module Handling
+The multi-module functionality allows you to specify multiple modules, enabling the retrieval of information from several modules in a single scrape.
+The concurrency can be specified using the snmp-exporter option --concurrency (the default is 1).
+
+Note: This implementation does not perform any de-duplication of walks between different modules.
+
+There are two ways to specify multiple modules. You can either separate them with a comma or define multiple params_module.
+The URLs would look like this:
+
+For comma separation:
+```
+http://localhost:9116/snmp?module=if_mib,arista_sw&target=192.0.0.8
+```
+
+For multiple params_module:
+```
+http://localhost:9116/snmp?module=if_mib&module=arista_sw&target=192.0.0.8
+```
+
 ## Configuration
 
 The default configuration file name is `snmp.yml` and should not be edited

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ is not necessary within the Prometheus configuration file.
 
 ## Multi-Module Handling
 The multi-module functionality allows you to specify multiple modules, enabling the retrieval of information from several modules in a single scrape.
-The concurrency can be specified using the snmp-exporter option --concurrency (the default is 1).
+The concurrency can be specified using the snmp-exporter option `--snmp.module-concurrency` (the default is 1).
 
 Note: This implementation does not perform any de-duplication of walks between different modules.
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -44,8 +44,8 @@ var (
 	wrapCounters           = kingpin.Flag("snmp.wrap-large-counters", "Wrap 64-bit counters to avoid floating point rounding.").Default("true").Bool()
 	srcAddress             = kingpin.Flag("snmp.source-address", "Source address to send snmp from in the format 'address:port' to use when connecting targets. If the port parameter is empty or '0', as in '127.0.0.1:' or '[::1]:0', a source port number is automatically (random) chosen.").Default("").String()
 
-	SnmpDuration = promauto.NewSummaryVec(
-		prometheus.SummaryOpts{
+	SnmpDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
 			Name: "snmp_collection_duration_seconds",
 			Help: "Duration of collections by the SNMP exporter",
 		},

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -89,8 +89,12 @@ func listToOid(l []int) string {
 	return strings.Join(result, ".")
 }
 
-func InitModuleMetrics(auth, module string) {
-	snmpDuration.WithLabelValues(auth, module)
+func InitModuleMetrics(auths map[string]*config.Auth, modules map[string]*config.Module) {
+	for auth := range auths {
+		for module := range modules {
+			snmpDuration.WithLabelValues(auth, module)
+		}
+	}
 }
 
 type ScrapeResults struct {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -527,12 +527,10 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 		}()
 	}
 
-	go func() {
-		for _, module := range c.modules {
-			workerChan <- module
-		}
-		close(workerChan)
-	}()
+	for _, module := range c.modules {
+		workerChan <- module
+	}
+	close(workerChan)
 	wg.Wait()
 }
 

--- a/main.go
+++ b/main.go
@@ -160,11 +160,7 @@ func (sc *SafeConfig) ReloadConfig(configFile string) (err error) {
 	sc.Lock()
 	sc.C = conf
 	// Initialize metrics.
-	for auth := range sc.C.Auths {
-		for module := range sc.C.Modules {
-			collector.InitModuleMetrics(auth, module)
-		}
-	}
+	collector.InitModuleMetrics(sc.C.Auths, sc.C.Modules)
 	sc.Unlock()
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -21,7 +21,6 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
-	"time"
 
 	"github.com/alecthomas/kingpin/v2"
 	"github.com/go-kit/log"
@@ -43,6 +42,7 @@ import (
 var (
 	configFile  = kingpin.Flag("config.file", "Path to configuration file.").Default("snmp.yml").String()
 	dryRun      = kingpin.Flag("dry-run", "Only verify configuration is valid and exit.").Default("false").Bool()
+	concurrency = kingpin.Flag("concurrency", "Specify the number of modules to fetch concurrently").Default("1").Int()
 	metricsPath = kingpin.Flag(
 		"web.telemetry-path",
 		"Path under which to expose metrics.",
@@ -50,13 +50,6 @@ var (
 	toolkitFlags = webflag.AddFlags(kingpin.CommandLine, ":9116")
 
 	// Metrics about the SNMP exporter itself.
-	snmpDuration = promauto.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Name: "snmp_collection_duration_seconds",
-			Help: "Duration of collections by the SNMP exporter",
-		},
-		[]string{"auth", "module"},
-	)
 	snmpRequestErrors = promauto.NewCounter(
 		prometheus.CounterOpts{
 			Name: "snmp_request_errors_total",
@@ -94,44 +87,37 @@ func handler(w http.ResponseWriter, r *http.Request, logger log.Logger) {
 		authName = "public_v2"
 	}
 
-	moduleName := query.Get("module")
-	if len(query["module"]) > 1 {
-		http.Error(w, "'module' parameter must only be specified once", http.StatusBadRequest)
-		snmpRequestErrors.Inc()
-		return
+	queryModule := query["module"]
+	if len(queryModule) == 0 {
+		queryModule = append(queryModule, "if_mib")
 	}
-	if moduleName == "" {
-		moduleName = "if_mib"
-	}
-
 	sc.RLock()
 	auth, authOk := sc.C.Auths[authName]
-	module, moduleOk := sc.C.Modules[moduleName]
-	sc.RUnlock()
 	if !authOk {
+		sc.RUnlock()
 		http.Error(w, fmt.Sprintf("Unknown auth '%s'", authName), http.StatusBadRequest)
 		snmpRequestErrors.Inc()
 		return
 	}
-	if !moduleOk {
-		http.Error(w, fmt.Sprintf("Unknown module '%s'", moduleName), http.StatusBadRequest)
-		snmpRequestErrors.Inc()
-		return
+	modules := make(map[string]*config.Module)
+	for _, m := range queryModule {
+		module, moduleOk := sc.C.Modules[m]
+		if !moduleOk {
+			sc.RUnlock()
+			http.Error(w, fmt.Sprintf("Unknown module '%s'", m), http.StatusBadRequest)
+			snmpRequestErrors.Inc()
+			return
+		}
+		modules[m] = module
 	}
-
-	logger = log.With(logger, "auth", authName, "module", moduleName, "target", target)
-	level.Debug(logger).Log("msg", "Starting scrape")
-
-	start := time.Now()
+	sc.RUnlock()
+	logger = log.With(logger, "auth", authName, "target", target)
 	registry := prometheus.NewRegistry()
-	c := collector.New(r.Context(), target, auth, module, logger, registry)
+	c := collector.New(r.Context(), target, authName, auth, modules, logger, registry, *concurrency)
 	registry.MustRegister(c)
 	// Delegate http serving to Prometheus client library, which will call collector.Collect.
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})
 	h.ServeHTTP(w, r)
-	duration := time.Since(start).Seconds()
-	snmpDuration.WithLabelValues(authName, moduleName).Observe(duration)
-	level.Debug(logger).Log("msg", "Finished scrape", "duration_seconds", duration)
 }
 
 func updateConfiguration(w http.ResponseWriter, r *http.Request) {
@@ -162,7 +148,7 @@ func (sc *SafeConfig) ReloadConfig(configFile string) (err error) {
 	// Initialize metrics.
 	for auth := range sc.C.Auths {
 		for module := range sc.C.Modules {
-			snmpDuration.WithLabelValues(auth, module)
+			collector.SnmpDuration.WithLabelValues(auth, module)
 		}
 	}
 	sc.Unlock()
@@ -176,8 +162,11 @@ func main() {
 	kingpin.HelpFlag.Short('h')
 	kingpin.Parse()
 	logger := promlog.New(promlogConfig)
+	if *concurrency < 1 {
+		*concurrency = 1
+	}
 
-	level.Info(logger).Log("msg", "Starting snmp_exporter", "version", version.Info())
+	level.Info(logger).Log("msg", "Starting snmp_exporter", "version", version.Info(), "concurrency", concurrency)
 	level.Info(logger).Log("build_context", version.BuildContext())
 
 	prometheus.MustRegister(version.NewCollector("snmp_exporter"))

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ import (
 var (
 	configFile  = kingpin.Flag("config.file", "Path to configuration file.").Default("snmp.yml").String()
 	dryRun      = kingpin.Flag("dry-run", "Only verify configuration is valid and exit.").Default("false").Bool()
-	concurrency = kingpin.Flag("concurrency", "Specify the number of modules to fetch concurrently").Default("1").Int()
+	concurrency = kingpin.Flag("snmp.module-concurrency", "The number of modules to fetch concurrently per scrape").Default("1").Int()
 	metricsPath = kingpin.Flag(
 		"web.telemetry-path",
 		"Path under which to expose metrics.",


### PR DESCRIPTION
I implemented the ability to scrape in multiple modules. 
Parallel processing depends on user requirements, so I made it possible to specify the number of parallels. #731 

```
> ./snmp_exporter -h
usage: snmp_exporter [<flags>]

Flags:
  -h, --[no-]help               Show context-sensitive help (also try --help-long and --help-man).
...
      --[no-]dry-run            Only verify configuration is valid and exit.
      --concurrency=1           Specify the number of modules to fetch concurrently <- Added
```

## test
generator.yml
```
modules:
  sysUpTime:
    walk:
    - sysUpTime
  sysDescr:
    walk:
    - sysDescr
```

output
```
curl 'http://localhost:9116/snmp?target=cumulus&module=sysUpTime&module=sysDescr'
# HELP snmp_packet_duration_seconds A histogram of latencies for SNMP packets.
# TYPE snmp_packet_duration_seconds histogram
snmp_packet_duration_seconds_bucket{le="0.0001"} 0
snmp_packet_duration_seconds_bucket{le="0.0002"} 0
snmp_packet_duration_seconds_bucket{le="0.0004"} 0
snmp_packet_duration_seconds_bucket{le="0.0008"} 0
snmp_packet_duration_seconds_bucket{le="0.0016"} 0
snmp_packet_duration_seconds_bucket{le="0.0032"} 0
snmp_packet_duration_seconds_bucket{le="0.0064"} 0
snmp_packet_duration_seconds_bucket{le="0.0128"} 0
snmp_packet_duration_seconds_bucket{le="0.0256"} 0
snmp_packet_duration_seconds_bucket{le="0.0512"} 0
snmp_packet_duration_seconds_bucket{le="0.1024"} 0
snmp_packet_duration_seconds_bucket{le="0.2048"} 0
snmp_packet_duration_seconds_bucket{le="0.4096"} 0
snmp_packet_duration_seconds_bucket{le="0.8192"} 0
snmp_packet_duration_seconds_bucket{le="1.6384"} 0
snmp_packet_duration_seconds_bucket{le="+Inf"} 0
snmp_packet_duration_seconds_sum 0
snmp_packet_duration_seconds_count 0
# HELP snmp_packet_retries_total Number of SNMP packet retries.
# TYPE snmp_packet_retries_total counter
snmp_packet_retries_total 0
# HELP snmp_packets_total Number of SNMP packet sent, including retries.
# TYPE snmp_packets_total counter
snmp_packets_total 0
# HELP snmp_scrape_duration_seconds Total SNMP time scrape took (walk and processing).
# TYPE snmp_scrape_duration_seconds gauge
snmp_scrape_duration_seconds{module="sysDescr"} 0.081744083
snmp_scrape_duration_seconds{module="sysUpTime"} 0.0794535
# HELP snmp_scrape_packets_retried Packets retried for get, bulkget, and walk.
# TYPE snmp_scrape_packets_retried gauge
snmp_scrape_packets_retried{module="sysDescr"} 0
snmp_scrape_packets_retried{module="sysUpTime"} 0
# HELP snmp_scrape_packets_sent Packets sent for get, bulkget, and walk; including retries.
# TYPE snmp_scrape_packets_sent gauge
snmp_scrape_packets_sent{module="sysDescr"} 1
snmp_scrape_packets_sent{module="sysUpTime"} 1
# HELP snmp_scrape_pdus_returned PDUs returned from get, bulkget, and walk.
# TYPE snmp_scrape_pdus_returned gauge
snmp_scrape_pdus_returned{module="sysDescr"} 1
snmp_scrape_pdus_returned{module="sysUpTime"} 1
# HELP snmp_scrape_walk_duration_seconds Time SNMP walk/bulkwalk took.
# TYPE snmp_scrape_walk_duration_seconds gauge
snmp_scrape_walk_duration_seconds{module="sysDescr"} 0.081711667
snmp_scrape_walk_duration_seconds{module="sysUpTime"} 0.079426875
# HELP snmp_unexpected_pdu_type_total Unexpected Go types in a PDU.
# TYPE snmp_unexpected_pdu_type_total counter
snmp_unexpected_pdu_type_total 0
# HELP sysDescr A textual description of the entity - 1.3.6.1.2.1.1.1
# TYPE sysDescr gauge
sysDescr{sysDescr="Cumulus-Linux **********"} 1
# HELP sysUpTime The time (in hundredths of a second) since the network management portion of the system was last re-initialized. - 1.3.6.1.2.1.1.3
# TYPE sysUpTime gauge
sysUpTime 1.387417375e+09
```

## Confirmation of Significant Changes
Since the change will add module information to the metrics output by snmp_exporter as standard, could you please confirm that this is the right direction for the change?