### PR TITLE
Fix generator docker release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,13 @@ jobs:
           make -C generator docker-tag-latest DOCKER_IMAGE_TAG="$CIRCLE_TAG"
           make -C generator docker-tag-latest DOCKER_IMAGE_TAG="$CIRCLE_TAG" DOCKER_REPO=quay.io/prometheus
         fi
-    - run: make -C generator docker-publish
-    - run: make -C generator docker-publish DOCKER_REPO=quay.io/prometheus
+    - run: make -C generator docker-publish DOCKER_IMAGE_TAG=$CIRCLE_TAG
+    - run: make -C generator docker-publish DOCKER_IMAGE_TAG=$CIRCLE_TAG DOCKER_REPO=quay.io/prometheus
+    - run: |
+        if [[ "$CIRCLE_TAG" =~ ^v[0-9]+(\.[0-9]+){2}$ ]]; then
+          make -C generator docker-publish DOCKER_IMAGE_TAG="latest"
+          make -C generator docker-publish DOCKER_IMAGE_TAG="latest" DOCKER_REPO=quay.io/prometheus
+        fi
 
   mixin:
     executor: golang


### PR DESCRIPTION
Add correct image tags to generator docker-publish CI steps.

Fixes: https://github.com/prometheus/snmp_exporter/issues/944