### PR TITLE
Remove auth label from collection metric

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -462,7 +462,7 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 				c.collect(ch, m)
 				duration := time.Since(start).Seconds()
 				level.Debug(logger).Log("msg", "Finished scrape", "duration_seconds", duration)
-				c.metrics.SNMPCollectionDuration.WithLabelValues(c.authName, m.name).Observe(duration)
+				c.metrics.SNMPCollectionDuration.WithLabelValues(m.name).Observe(duration)
 			}
 		}()
 	}

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ var (
 			Name:      "collection_duration_seconds",
 			Help:      "Duration of collections by the SNMP exporter",
 		},
-		[]string{"auth", "module"},
+		[]string{"module"},
 	)
 	sc = &SafeConfig{
 		C: &config.Config{},
@@ -173,10 +173,8 @@ func (sc *SafeConfig) ReloadConfig(configFile []string) (err error) {
 	sc.Lock()
 	sc.C = conf
 	// Initialize metrics.
-	for auth := range sc.C.Auths {
-		for module := range sc.C.Modules {
-			snmpCollectionDuration.WithLabelValues(auth, module)
-		}
+	for module := range sc.C.Modules {
+		snmpCollectionDuration.WithLabelValues(module)
 	}
 	sc.Unlock()
 	return nil


### PR DESCRIPTION
Remove the `auth` label from the exporter collection duratoin histogram as it causes too much cardinality.

Fixes: https://github.com/prometheus/snmp_exporter/issues/978