### PR TITLE
Updated Mikrotik neighbor indexes make them unique

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -569,7 +569,12 @@ modules:
         lookup: mtxrGaugeName
         drop_source_indexes: true
       - source_indexes: [mtxrNeighborIndex]
-        lookup: mtxrNeighborIpAddress
+        lookup: mtxrNeighborMacAddress
+        drop_source_indexes: true
+      - source_indexes: [mtxrNeighborIndex]
+        lookup: mtxrNeighborInterfaceID
+      - source_indexes: [mtxrNeighborInterfaceID]
+        lookup: ifName
         drop_source_indexes: true
       - source_indexes: [mtxrOpticalIndex]
         lookup: mtxrOpticalName

--- a/snmp.yml
+++ b/snmp.yml
@@ -14735,14 +14735,28 @@ modules:
       indexes:
       - labelname: mtxrNeighborIndex
         type: gauge
+      - labelname: mtxrNeighborInterfaceID
+        type: gauge
       lookups:
       - labels:
         - mtxrNeighborIndex
-        labelname: mtxrNeighborIpAddress
-        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.2
-        type: InetAddressIPv4
+        labelname: mtxrNeighborMacAddress
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.3
+        type: PhysAddress48
+      - labels:
+        - mtxrNeighborIndex
+        labelname: mtxrNeighborInterfaceID
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.8
+        type: gauge
+      - labels:
+        - mtxrNeighborInterfaceID
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
       - labels: []
         labelname: mtxrNeighborIndex
+      - labels: []
+        labelname: mtxrNeighborInterfaceID
     - name: mtxrNeighborIpAddress
       oid: 1.3.6.1.4.1.14988.1.1.11.1.1.2
       type: InetAddressIPv4
@@ -14750,14 +14764,28 @@ modules:
       indexes:
       - labelname: mtxrNeighborIndex
         type: gauge
+      - labelname: mtxrNeighborInterfaceID
+        type: gauge
       lookups:
       - labels:
         - mtxrNeighborIndex
-        labelname: mtxrNeighborIpAddress
-        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.2
-        type: InetAddressIPv4
+        labelname: mtxrNeighborMacAddress
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.3
+        type: PhysAddress48
+      - labels:
+        - mtxrNeighborIndex
+        labelname: mtxrNeighborInterfaceID
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.8
+        type: gauge
+      - labels:
+        - mtxrNeighborInterfaceID
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
       - labels: []
         labelname: mtxrNeighborIndex
+      - labels: []
+        labelname: mtxrNeighborInterfaceID
     - name: mtxrNeighborMacAddress
       oid: 1.3.6.1.4.1.14988.1.1.11.1.1.3
       type: PhysAddress48
@@ -14765,14 +14793,28 @@ modules:
       indexes:
       - labelname: mtxrNeighborIndex
         type: gauge
+      - labelname: mtxrNeighborInterfaceID
+        type: gauge
       lookups:
       - labels:
         - mtxrNeighborIndex
-        labelname: mtxrNeighborIpAddress
-        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.2
-        type: InetAddressIPv4
+        labelname: mtxrNeighborMacAddress
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.3
+        type: PhysAddress48
+      - labels:
+        - mtxrNeighborIndex
+        labelname: mtxrNeighborInterfaceID
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.8
+        type: gauge
+      - labels:
+        - mtxrNeighborInterfaceID
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
       - labels: []
         labelname: mtxrNeighborIndex
+      - labels: []
+        labelname: mtxrNeighborInterfaceID
     - name: mtxrNeighborVersion
       oid: 1.3.6.1.4.1.14988.1.1.11.1.1.4
       type: DisplayString
@@ -14780,14 +14822,28 @@ modules:
       indexes:
       - labelname: mtxrNeighborIndex
         type: gauge
+      - labelname: mtxrNeighborInterfaceID
+        type: gauge
       lookups:
       - labels:
         - mtxrNeighborIndex
-        labelname: mtxrNeighborIpAddress
-        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.2
-        type: InetAddressIPv4
+        labelname: mtxrNeighborMacAddress
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.3
+        type: PhysAddress48
+      - labels:
+        - mtxrNeighborIndex
+        labelname: mtxrNeighborInterfaceID
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.8
+        type: gauge
+      - labels:
+        - mtxrNeighborInterfaceID
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
       - labels: []
         labelname: mtxrNeighborIndex
+      - labels: []
+        labelname: mtxrNeighborInterfaceID
     - name: mtxrNeighborPlatform
       oid: 1.3.6.1.4.1.14988.1.1.11.1.1.5
       type: DisplayString
@@ -14795,14 +14851,28 @@ modules:
       indexes:
       - labelname: mtxrNeighborIndex
         type: gauge
+      - labelname: mtxrNeighborInterfaceID
+        type: gauge
       lookups:
       - labels:
         - mtxrNeighborIndex
-        labelname: mtxrNeighborIpAddress
-        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.2
-        type: InetAddressIPv4
+        labelname: mtxrNeighborMacAddress
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.3
+        type: PhysAddress48
+      - labels:
+        - mtxrNeighborIndex
+        labelname: mtxrNeighborInterfaceID
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.8
+        type: gauge
+      - labels:
+        - mtxrNeighborInterfaceID
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
       - labels: []
         labelname: mtxrNeighborIndex
+      - labels: []
+        labelname: mtxrNeighborInterfaceID
     - name: mtxrNeighborIdentity
       oid: 1.3.6.1.4.1.14988.1.1.11.1.1.6
       type: DisplayString
@@ -14810,14 +14880,28 @@ modules:
       indexes:
       - labelname: mtxrNeighborIndex
         type: gauge
+      - labelname: mtxrNeighborInterfaceID
+        type: gauge
       lookups:
       - labels:
         - mtxrNeighborIndex
-        labelname: mtxrNeighborIpAddress
-        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.2
-        type: InetAddressIPv4
+        labelname: mtxrNeighborMacAddress
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.3
+        type: PhysAddress48
+      - labels:
+        - mtxrNeighborIndex
+        labelname: mtxrNeighborInterfaceID
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.8
+        type: gauge
+      - labels:
+        - mtxrNeighborInterfaceID
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
       - labels: []
         labelname: mtxrNeighborIndex
+      - labels: []
+        labelname: mtxrNeighborInterfaceID
     - name: mtxrNeighborSoftwareID
       oid: 1.3.6.1.4.1.14988.1.1.11.1.1.7
       type: DisplayString
@@ -14825,14 +14909,28 @@ modules:
       indexes:
       - labelname: mtxrNeighborIndex
         type: gauge
+      - labelname: mtxrNeighborInterfaceID
+        type: gauge
       lookups:
       - labels:
         - mtxrNeighborIndex
-        labelname: mtxrNeighborIpAddress
-        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.2
-        type: InetAddressIPv4
+        labelname: mtxrNeighborMacAddress
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.3
+        type: PhysAddress48
+      - labels:
+        - mtxrNeighborIndex
+        labelname: mtxrNeighborInterfaceID
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.8
+        type: gauge
+      - labels:
+        - mtxrNeighborInterfaceID
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
       - labels: []
         labelname: mtxrNeighborIndex
+      - labels: []
+        labelname: mtxrNeighborInterfaceID
     - name: mtxrNeighborInterfaceID
       oid: 1.3.6.1.4.1.14988.1.1.11.1.1.8
       type: gauge
@@ -14840,14 +14938,28 @@ modules:
       indexes:
       - labelname: mtxrNeighborIndex
         type: gauge
+      - labelname: mtxrNeighborInterfaceID
+        type: gauge
       lookups:
       - labels:
         - mtxrNeighborIndex
-        labelname: mtxrNeighborIpAddress
-        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.2
-        type: InetAddressIPv4
+        labelname: mtxrNeighborMacAddress
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.3
+        type: PhysAddress48
+      - labels:
+        - mtxrNeighborIndex
+        labelname: mtxrNeighborInterfaceID
+        oid: 1.3.6.1.4.1.14988.1.1.11.1.1.8
+        type: gauge
+      - labels:
+        - mtxrNeighborInterfaceID
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
       - labels: []
         labelname: mtxrNeighborIndex
+      - labels: []
+        labelname: mtxrNeighborInterfaceID
     - name: mtxrDate
       oid: 1.3.6.1.4.1.14988.1.1.12.1
       type: gauge


### PR DESCRIPTION
In response to PR #915, this change will update the keys of mtxrNeighborTable to unique label combinations. The current release will return http 500 replies on request with variations on following errors:

`* collected metric "mtxrNeighborInterfaceID" { label:{name:"mtxrNeighborIpAddress" value:"0.0.0.0"} gauge:{value:1}} was collected before with the same name and label values`

This PR will change the index from mtxrNeighborIpAddress to a combination of mtxrNeighborMacAddress and ifName.

The choice for mtxrNeighborIpAddress as unique index is not suitable for two reasons:
- Mikrotik allows for entries in the neighbor list without an IP adress, or only an IPv6 address.
- Same IP addresses can be assigned to neighbors, making them not unique.

The obvious solution would be to make the MAC address the unique key, but this is also not sufficient because a neighbour can be detected on multiple interfaces (which is useful information and should not be filtered out).

A combination of mac address and interface is unique enough and will benefit in having a more consistent set of data after device reboots.

Examples:

Change from IpAddress to ifName
```diff
-mtxrNeighborMacAddress{mtxrNeighborIpAddress="10.0.0.1",mtxrNeighborMacAddress="48:A9:82:00:00:01"} 1
-mtxrNeighborMacAddress{mtxrNeighborIpAddress="10.0.0.2",mtxrNeighborMacAddress="48:A9:82:00:00:02"} 1
+mtxrNeighborMacAddress{ifName="ether1",mtxrNeighborMacAddress="48:A9:82:00:00:01"} 1
+mtxrNeighborMacAddress{ifName="ether1",mtxrNeighborMacAddress="48:A9:82:00:00:02"} 1
```

Previously impossible:
```diff
-mtxrNeighborIpAddress{mtxrNeighborIpAddress="10.0.0.1",mtxrNeighborMacAddress="48:A9:82:00:00:01"} 1
-mtxrNeighborIpAddress{mtxrNeighborIpAddress="10.0.0.2",mtxrNeighborMacAddress="48:A9:82:00:00:02"} 1
+mtxrNeighborIpAddress{ifName="ether1",mtxrNeighborMacAddress="48:A9:82:00:00:01",mtxrNeighborIpAddress="0.0.0.0"} 1
+mtxrNeighborIpAddress{ifName="vlan14-test",mtxrNeighborMacAddress="48:A9:82:00:00:01",mtxrNeighborIpAddress="10.0.0.1"} 1
+mtxrNeighborIpAddress{ifName="vlan14-test",mtxrNeighborMacAddress="48:A9:82:00:00:02",mtxrNeighborIpAddress="10.0.0.2"} 1
```
Example Mikrotik Neighbor table in Winbox interface
![image](https://github.com/prometheus/snmp_exporter/assets/1188258/50f68884-a562-4287-a820-e72e0485bacb)

@SuperQ @RichiH