### PR TITLE
Optimizing timeouts and packet fragmentation in SNMP scrape jobs

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1352,7 +1352,7 @@ func TestAddAllowedIndices(t *testing.T) {
 
 func TestFragmentMaxRepetitions(t *testing.T) {
 	cases := []struct {
-		maxRetries     int
+		maxRetries     uint32
 		maxRepetitions uint32
 		result         []uint32
 	}{

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1349,3 +1349,53 @@ func TestAddAllowedIndices(t *testing.T) {
 		}
 	}
 }
+
+func TestFragmentMaxRepetitions(t *testing.T) {
+	cases := []struct {
+		maxRetries     int
+		maxRepetitions uint32
+		result         []uint32
+	}{
+		{
+			maxRetries:     1,
+			maxRepetitions: 5,
+			result: []uint32{
+				0,
+			},
+		},
+		{
+			maxRetries:     10,
+			maxRepetitions: 1,
+			result: []uint32{
+				0,
+			},
+		},
+		{
+			maxRetries:     5,
+			maxRepetitions: 5,
+			result: []uint32{
+				4, 3, 2, 1, 0,
+			},
+		},
+		{
+			maxRetries:     10,
+			maxRepetitions: 30,
+			result: []uint32{
+				27, 24, 21, 18, 15, 12, 9, 6, 3, 0,
+			},
+		},
+		{
+			maxRetries:     10,
+			maxRepetitions: 1400,
+			result: []uint32{
+				1260, 1120, 980, 840, 700, 560, 420, 280, 140, 0,
+			},
+		},
+	}
+	for _, c := range cases {
+		got := fragmentMaxRepetitions(c.maxRepetitions, c.maxRetries)
+		if !reflect.DeepEqual(got, c.result) {
+			t.Errorf("fragmentMaxRepetitions(%d, %d): got %v, want %v", c.maxRepetitions, c.maxRetries, got, c.result)
+		}
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -85,14 +85,19 @@ type WalkParams struct {
 	AllowNonIncreasingOIDs  bool          `yaml:"allow_nonincreasing_oids,omitempty"`
 }
 
+type WalkRetry struct {
+	Enabled    bool   `yaml:"enabled,omitempty"`
+	MaxRetires uint32 `yaml:"max_retires,omitempty"`
+}
+
 type Module struct {
 	// A list of OIDs.
-	Walk             []string        `yaml:"walk,omitempty"`
-	Get              []string        `yaml:"get,omitempty"`
-	Metrics          []*Metric       `yaml:"metrics"`
-	WalkParams       WalkParams      `yaml:",inline"`
-	Filters          []DynamicFilter `yaml:"filters,omitempty"`
-	WalkRetryEnabled bool            `yaml:"walk_retry_enabled,omitempty"`
+	Walk       []string        `yaml:"walk,omitempty"`
+	Get        []string        `yaml:"get,omitempty"`
+	Metrics    []*Metric       `yaml:"metrics"`
+	WalkParams WalkParams      `yaml:",inline"`
+	Filters    []DynamicFilter `yaml:"filters,omitempty"`
+	WalkRetry  WalkRetry       `yaml:"walk_retry"`
 }
 
 func (c *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/config/config.go
+++ b/config/config.go
@@ -87,11 +87,13 @@ type WalkParams struct {
 
 type Module struct {
 	// A list of OIDs.
-	Walk       []string        `yaml:"walk,omitempty"`
-	Get        []string        `yaml:"get,omitempty"`
-	Metrics    []*Metric       `yaml:"metrics"`
-	WalkParams WalkParams      `yaml:",inline"`
-	Filters    []DynamicFilter `yaml:"filters,omitempty"`
+	Walk                  []string        `yaml:"walk,omitempty"`
+	Get                   []string        `yaml:"get,omitempty"`
+	Metrics               []*Metric       `yaml:"metrics"`
+	WalkParams            WalkParams      `yaml:",inline"`
+	Filters               []DynamicFilter `yaml:"filters,omitempty"`
+	WalkRetryEnabled      bool            `yaml:"walk_retry_enabled,omitempty"`
+	WalkRetryDelaySeconds int             `yaml:"walk_retry_delay_seconds,omitempty"`
 }
 
 func (c *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/config/config.go
+++ b/config/config.go
@@ -87,13 +87,12 @@ type WalkParams struct {
 
 type Module struct {
 	// A list of OIDs.
-	Walk                  []string        `yaml:"walk,omitempty"`
-	Get                   []string        `yaml:"get,omitempty"`
-	Metrics               []*Metric       `yaml:"metrics"`
-	WalkParams            WalkParams      `yaml:",inline"`
-	Filters               []DynamicFilter `yaml:"filters,omitempty"`
-	WalkRetryEnabled      bool            `yaml:"walk_retry_enabled,omitempty"`
-	WalkRetryDelaySeconds int             `yaml:"walk_retry_delay_seconds,omitempty"`
+	Walk             []string        `yaml:"walk,omitempty"`
+	Get              []string        `yaml:"get,omitempty"`
+	Metrics          []*Metric       `yaml:"metrics"`
+	WalkParams       WalkParams      `yaml:",inline"`
+	Filters          []DynamicFilter `yaml:"filters,omitempty"`
+	WalkRetryEnabled bool            `yaml:"walk_retry_enabled,omitempty"`
 }
 
 func (c *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/snmp.yml
+++ b/snmp.yml
@@ -2371,6 +2371,8 @@ modules:
       indexes:
       - labelname: rPDU2BankStatusIndex
         type: gauge
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   arista_sw:
     walk:
     - 1.3.6.1.2.1.25.2.3.1.6
@@ -2946,6 +2948,8 @@ modules:
           0: unknown
           1: ipv4
           2: ipv6
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   cisco_wlc:
     walk:
     - 1.3.6.1.4.1.14179.2.1.1.1.2
@@ -3392,6 +3396,8 @@ modules:
         type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   cyberpower:
     walk:
     - 1.3.6.1.4.1.3808.1.1.1
@@ -6004,6 +6010,8 @@ modules:
       enum_values:
         1: atsRedundancyLost
         2: atsFullyRedundant
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   ddwrt:
     walk:
     - 1.3.6.1.2.1.25.2
@@ -6439,6 +6447,8 @@ modules:
       type: DisplayString
       help: Describes whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
         is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.101
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   eap:
     get:
     - 1.3.6.1.4.1.11863.10.1.1.1.0
@@ -6447,6 +6457,8 @@ modules:
       oid: 1.3.6.1.4.1.11863.10.1.1.1
       type: gauge
       help: this used to get the count of clients - 1.3.6.1.4.1.11863.10.1.1.1
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   if_mib:
     walk:
     - 1.3.6.1.2.1.2
@@ -7704,6 +7716,8 @@ modules:
         labelname: ifName
         oid: 1.3.6.1.2.1.31.1.1.1.1
         type: DisplayString
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   infrapower_pdu:
     walk:
     - 1.3.6.1.4.1.34550.20.2.1.1.1.1
@@ -7782,6 +7796,8 @@ modules:
           regex: ^(?:(\d*?)(\d{2}))$
         - value: 0.0$1
           regex: ^(?:^(\d))$
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   ip_mib:
     walk:
     - 1.3.6.1.2.1.4.28
@@ -7821,6 +7837,8 @@ modules:
       indexes:
       - labelname: ipv4InterfaceIfIndex
         type: gauge
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   keepalived:
     walk:
     - 1.3.6.1.2.1.207.1.2.5
@@ -9677,6 +9695,8 @@ modules:
         type: gauge
       - labelname: realServerIndex
         type: gauge
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   kemp_loadmaster:
     walk:
     - 1.3.6.1.4.1.12196.13.0
@@ -10440,6 +10460,8 @@ modules:
       type: DisplayString
       help: Describes whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
         is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.101
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   liebert_pdu:
     walk:
     - 1.3.6.1.4.1.476.1.42.3.8.20
@@ -12946,6 +12968,8 @@ modules:
         labelname: lgpPduAuxSensorSysAssignLabel
         oid: 1.3.6.1.4.1.476.1.42.3.8.60.10.1.15
         type: DisplayString
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   mikrotik:
     walk:
     - 1.3.6.1.2.1.25
@@ -16564,6 +16588,8 @@ modules:
         type: DisplayString
       - labels: []
         labelname: laIndex
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   nec_ix:
     walk:
     - 1.3.6.1.4.1.119.2.3.84.11
@@ -18843,6 +18869,8 @@ modules:
       indexes:
       - labelname: picoNgnVpnIfIndex
         type: gauge
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   paloalto_fw:
     walk:
     - 1.3.6.1.2.1.25.1
@@ -19932,6 +19960,8 @@ modules:
       oid: 1.3.6.1.4.1.25461.2.1.2.5.1.3
       type: gauge
       help: Number of active tunnels - 1.3.6.1.4.1.25461.2.1.2.5.1.3
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   printer_mib:
     walk:
     - 1.3.6.1.2.1.25.3.5.1.1
@@ -20135,6 +20165,8 @@ modules:
         4: coverClosed
         5: interlockOpen
         6: interlockClosed
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   raritan:
     walk:
     - 1.3.6.1.4.1.13742.4.1.2.2.1.3
@@ -20401,6 +20433,8 @@ modules:
         type: gauge
       - labelname: sensorID
         type: gauge
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   servertech_sentry3:
     walk:
     - 1.3.6.1.4.1.1718.3.2.2
@@ -20930,6 +20964,8 @@ modules:
         type: gauge
       - labelname: outletIndex
         type: gauge
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   servertech_sentry4:
     walk:
     - 1.3.6.1.4.1.1718.4.1.14.3
@@ -23263,6 +23299,8 @@ modules:
         21: nvmFail
         22: profileError
         23: conflict
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   synology:
     walk:
     - 1.3.6.1.2.1.25.2
@@ -25038,6 +25076,8 @@ modules:
         type: DisplayString
       - labels: []
         labelname: serviceInfoIndex
+    walk_retry_enabled: true
+    walk_retry_delay_seconds: 1
   ubiquiti_airfiber:
     walk:
     - 1.3.6.1.4.1.41112.1.3

--- a/snmp.yml
+++ b/snmp.yml
@@ -2371,7 +2371,9 @@ modules:
       indexes:
       - labelname: rPDU2BankStatusIndex
         type: gauge
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   arista_sw:
     walk:
     - 1.3.6.1.2.1.25.2.3.1.6
@@ -2947,7 +2949,9 @@ modules:
           0: unknown
           1: ipv4
           2: ipv6
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   cisco_wlc:
     walk:
     - 1.3.6.1.4.1.14179.2.1.1.1.2
@@ -3394,7 +3398,9 @@ modules:
         type: DisplayString
       - labels: []
         labelname: bsnAPDot3MacAddress
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   cyberpower:
     walk:
     - 1.3.6.1.4.1.3808.1.1.1
@@ -6007,7 +6013,9 @@ modules:
       enum_values:
         1: atsRedundancyLost
         2: atsFullyRedundant
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   ddwrt:
     walk:
     - 1.3.6.1.2.1.25.2
@@ -6443,7 +6451,9 @@ modules:
       type: DisplayString
       help: Describes whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
         is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.101
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   eap:
     get:
     - 1.3.6.1.4.1.11863.10.1.1.1.0
@@ -6452,7 +6462,9 @@ modules:
       oid: 1.3.6.1.4.1.11863.10.1.1.1
       type: gauge
       help: this used to get the count of clients - 1.3.6.1.4.1.11863.10.1.1.1
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   if_mib:
     walk:
     - 1.3.6.1.2.1.2
@@ -7710,7 +7722,9 @@ modules:
         labelname: ifName
         oid: 1.3.6.1.2.1.31.1.1.1.1
         type: DisplayString
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   infrapower_pdu:
     walk:
     - 1.3.6.1.4.1.34550.20.2.1.1.1.1
@@ -7789,7 +7803,9 @@ modules:
           regex: ^(?:(\d*?)(\d{2}))$
         - value: 0.0$1
           regex: ^(?:^(\d))$
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   ip_mib:
     walk:
     - 1.3.6.1.2.1.4.28
@@ -7829,7 +7845,9 @@ modules:
       indexes:
       - labelname: ipv4InterfaceIfIndex
         type: gauge
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   keepalived:
     walk:
     - 1.3.6.1.2.1.207.1.2.5
@@ -9686,7 +9704,9 @@ modules:
         type: gauge
       - labelname: realServerIndex
         type: gauge
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   kemp_loadmaster:
     walk:
     - 1.3.6.1.4.1.12196.13.0
@@ -10450,7 +10470,9 @@ modules:
       type: DisplayString
       help: Describes whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
         is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.101
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   liebert_pdu:
     walk:
     - 1.3.6.1.4.1.476.1.42.3.8.20
@@ -12957,7 +12979,9 @@ modules:
         labelname: lgpPduAuxSensorSysAssignLabel
         oid: 1.3.6.1.4.1.476.1.42.3.8.60.10.1.15
         type: DisplayString
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   mikrotik:
     walk:
     - 1.3.6.1.2.1.25
@@ -16576,7 +16600,9 @@ modules:
         type: DisplayString
       - labels: []
         labelname: laIndex
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   nec_ix:
     walk:
     - 1.3.6.1.4.1.119.2.3.84.11
@@ -18856,7 +18882,9 @@ modules:
       indexes:
       - labelname: picoNgnVpnIfIndex
         type: gauge
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   paloalto_fw:
     walk:
     - 1.3.6.1.2.1.25.1
@@ -19946,7 +19974,9 @@ modules:
       oid: 1.3.6.1.4.1.25461.2.1.2.5.1.3
       type: gauge
       help: Number of active tunnels - 1.3.6.1.4.1.25461.2.1.2.5.1.3
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   printer_mib:
     walk:
     - 1.3.6.1.2.1.25.3.5.1.1
@@ -20150,7 +20180,9 @@ modules:
         4: coverClosed
         5: interlockOpen
         6: interlockClosed
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   raritan:
     walk:
     - 1.3.6.1.4.1.13742.4.1.2.2.1.3
@@ -20417,7 +20449,9 @@ modules:
         type: gauge
       - labelname: sensorID
         type: gauge
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   servertech_sentry3:
     walk:
     - 1.3.6.1.4.1.1718.3.2.2
@@ -20947,7 +20981,9 @@ modules:
         type: gauge
       - labelname: outletIndex
         type: gauge
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   servertech_sentry4:
     walk:
     - 1.3.6.1.4.1.1718.4.1.14.3
@@ -23281,7 +23317,9 @@ modules:
         21: nvmFail
         22: profileError
         23: conflict
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   synology:
     walk:
     - 1.3.6.1.2.1.25.2
@@ -25057,7 +25095,9 @@ modules:
         type: DisplayString
       - labels: []
         labelname: serviceInfoIndex
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   ubiquiti_airfiber:
     walk:
     - 1.3.6.1.4.1.41112.1.3
@@ -26243,7 +26283,9 @@ modules:
       indexes:
       - labelname: airFiberStatisticsIndex
         type: gauge
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   ubiquiti_airmax:
     walk:
     - 1.3.6.1.4.1.41112.1.4
@@ -26888,7 +26930,9 @@ modules:
       oid: 1.3.6.1.4.1.41112.1.4.9.9
       type: DisplayString
       help: GPS Horizontal Dilution of Precision - 1.3.6.1.4.1.41112.1.4.9.9
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10
   ubiquiti_unifi:
     walk:
     - 1.3.6.1.4.1.41112.1.6
@@ -27518,4 +27562,6 @@ modules:
       oid: 1.3.6.1.4.1.41112.1.6.3.6
       type: DisplayString
       help: ' - 1.3.6.1.4.1.41112.1.6.3.6'
-    walk_retry_enabled: true
+    walk_retry:
+      enabled: true
+      max_retires: 10

--- a/snmp.yml
+++ b/snmp.yml
@@ -2372,7 +2372,6 @@ modules:
       - labelname: rPDU2BankStatusIndex
         type: gauge
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   arista_sw:
     walk:
     - 1.3.6.1.2.1.25.2.3.1.6
@@ -2949,7 +2948,6 @@ modules:
           1: ipv4
           2: ipv6
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   cisco_wlc:
     walk:
     - 1.3.6.1.4.1.14179.2.1.1.1.2
@@ -3397,7 +3395,6 @@ modules:
       - labels: []
         labelname: bsnAPDot3MacAddress
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   cyberpower:
     walk:
     - 1.3.6.1.4.1.3808.1.1.1
@@ -6011,7 +6008,6 @@ modules:
         1: atsRedundancyLost
         2: atsFullyRedundant
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   ddwrt:
     walk:
     - 1.3.6.1.2.1.25.2
@@ -6448,7 +6444,6 @@ modules:
       help: Describes whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
         is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.101
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   eap:
     get:
     - 1.3.6.1.4.1.11863.10.1.1.1.0
@@ -6458,7 +6453,6 @@ modules:
       type: gauge
       help: this used to get the count of clients - 1.3.6.1.4.1.11863.10.1.1.1
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   if_mib:
     walk:
     - 1.3.6.1.2.1.2
@@ -7717,7 +7711,6 @@ modules:
         oid: 1.3.6.1.2.1.31.1.1.1.1
         type: DisplayString
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   infrapower_pdu:
     walk:
     - 1.3.6.1.4.1.34550.20.2.1.1.1.1
@@ -7797,7 +7790,6 @@ modules:
         - value: 0.0$1
           regex: ^(?:^(\d))$
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   ip_mib:
     walk:
     - 1.3.6.1.2.1.4.28
@@ -7838,7 +7830,6 @@ modules:
       - labelname: ipv4InterfaceIfIndex
         type: gauge
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   keepalived:
     walk:
     - 1.3.6.1.2.1.207.1.2.5
@@ -9696,7 +9687,6 @@ modules:
       - labelname: realServerIndex
         type: gauge
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   kemp_loadmaster:
     walk:
     - 1.3.6.1.4.1.12196.13.0
@@ -10461,7 +10451,6 @@ modules:
       help: Describes whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
         is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.101
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   liebert_pdu:
     walk:
     - 1.3.6.1.4.1.476.1.42.3.8.20
@@ -12969,7 +12958,6 @@ modules:
         oid: 1.3.6.1.4.1.476.1.42.3.8.60.10.1.15
         type: DisplayString
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   mikrotik:
     walk:
     - 1.3.6.1.2.1.25
@@ -16589,7 +16577,6 @@ modules:
       - labels: []
         labelname: laIndex
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   nec_ix:
     walk:
     - 1.3.6.1.4.1.119.2.3.84.11
@@ -18870,7 +18857,6 @@ modules:
       - labelname: picoNgnVpnIfIndex
         type: gauge
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   paloalto_fw:
     walk:
     - 1.3.6.1.2.1.25.1
@@ -19961,7 +19947,6 @@ modules:
       type: gauge
       help: Number of active tunnels - 1.3.6.1.4.1.25461.2.1.2.5.1.3
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   printer_mib:
     walk:
     - 1.3.6.1.2.1.25.3.5.1.1
@@ -20166,7 +20151,6 @@ modules:
         5: interlockOpen
         6: interlockClosed
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   raritan:
     walk:
     - 1.3.6.1.4.1.13742.4.1.2.2.1.3
@@ -20434,7 +20418,6 @@ modules:
       - labelname: sensorID
         type: gauge
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   servertech_sentry3:
     walk:
     - 1.3.6.1.4.1.1718.3.2.2
@@ -20965,7 +20948,6 @@ modules:
       - labelname: outletIndex
         type: gauge
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   servertech_sentry4:
     walk:
     - 1.3.6.1.4.1.1718.4.1.14.3
@@ -23300,7 +23282,6 @@ modules:
         22: profileError
         23: conflict
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   synology:
     walk:
     - 1.3.6.1.2.1.25.2
@@ -25077,7 +25058,6 @@ modules:
       - labels: []
         labelname: serviceInfoIndex
     walk_retry_enabled: true
-    walk_retry_delay_seconds: 1
   ubiquiti_airfiber:
     walk:
     - 1.3.6.1.4.1.41112.1.3
@@ -26263,6 +26243,7 @@ modules:
       indexes:
       - labelname: airFiberStatisticsIndex
         type: gauge
+    walk_retry_enabled: true
   ubiquiti_airmax:
     walk:
     - 1.3.6.1.4.1.41112.1.4
@@ -26907,6 +26888,7 @@ modules:
       oid: 1.3.6.1.4.1.41112.1.4.9.9
       type: DisplayString
       help: GPS Horizontal Dilution of Precision - 1.3.6.1.4.1.41112.1.4.9.9
+    walk_retry_enabled: true
   ubiquiti_unifi:
     walk:
     - 1.3.6.1.4.1.41112.1.6
@@ -27536,3 +27518,4 @@ modules:
       oid: 1.3.6.1.4.1.41112.1.6.3.6
       type: DisplayString
       help: ' - 1.3.6.1.4.1.41112.1.6.3.6'
+    walk_retry_enabled: true


### PR DESCRIPTION
@SuperQ @RichiH This PR proposes a solution to address the `snmp_exporter` issue of packets being fragmented in UDP. At higher max repetition values (above 1450 MTU), timeouts become more frequent, and at lower max values they can result in timeouts due to increased polling time. The solution being proposed tunes the `MaxRepetitions` value to eliminate/reduce timeout failures.