### PR TITLE
Add an offset factor

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -610,6 +610,7 @@ func pduToSamples(indexOids []int, pdu *gosnmp.SnmpPDU, metric *config.Metric, o
 	if metric.Scale != 0.0 {
 		value *= metric.Scale
 	}
+	value += metric.Offset
 
 	sample, err := prometheus.NewConstMetric(prometheus.NewDesc(metric.Name, metric.Help, labelnames, nil),
 		t, value, labelvalues...)

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -252,6 +252,41 @@ func TestPduToSample(t *testing.T) {
 			pdu: &gosnmp.SnmpPDU{
 				Name:  "1.1.1.1.1",
 				Type:  gosnmp.Integer,
+				Value: 70,
+			},
+			indexOids: []int{},
+			metric: &config.Metric{
+				Name:   "test_metric",
+				Oid:    "1.1.1.1.1",
+				Type:   "gauge",
+				Help:   "Help string",
+				Offset: -1.0,
+			},
+			oidToPdu:        make(map[string]gosnmp.SnmpPDU),
+			expectedMetrics: []string{`Desc{fqName: "test_metric", help: "Help string", constLabels: {}, variableLabels: []} gauge:{value:69}`},
+		},
+		{
+			pdu: &gosnmp.SnmpPDU{
+				Name:  "1.1.1.1.1",
+				Type:  gosnmp.Integer,
+				Value: 2,
+			},
+			indexOids: []int{},
+			metric: &config.Metric{
+				Name:   "test_metric",
+				Oid:    "1.1.1.1.1",
+				Type:   "gauge",
+				Help:   "Help string",
+				Offset: 2.0,
+				Scale:  -1.0,
+			},
+			oidToPdu:        make(map[string]gosnmp.SnmpPDU),
+			expectedMetrics: []string{`Desc{fqName: "test_metric", help: "Help string", constLabels: {}, variableLabels: []} gauge:{value:0}`},
+		},
+		{
+			pdu: &gosnmp.SnmpPDU{
+				Name:  "1.1.1.1.1",
+				Type:  gosnmp.Integer,
 				Value: -2,
 			},
 			indexOids: []int{},

--- a/config/config.go
+++ b/config/config.go
@@ -191,6 +191,7 @@ type Metric struct {
 	Lookups        []*Lookup                  `yaml:"lookups,omitempty"`
 	RegexpExtracts map[string][]RegexpExtract `yaml:"regex_extracts,omitempty"`
 	EnumValues     map[int]string             `yaml:"enum_values,omitempty"`
+	Offset         float64                    `yaml:"offset,omitempty"`
 	Scale          float64                    `yaml:"scale,omitempty"`
 }
 

--- a/generator/FORMAT.md
+++ b/generator/FORMAT.md
@@ -62,6 +62,7 @@ modules:
          Temp: # A new metric will be created appending this to the metricName to become metricNameTemp.
            - regex: '(.*)' # Regex to extract a value from the returned SNMP walks's value.
              value: '$1' # Parsed as float64, defaults to $1.
+       offset: 0.0  # Adds the value to the sample. Applied after scale.
        scale: 0.125 # Scale the sample by this value, for example bits to bytes.
        enum_values: # Enum for this metric. Only used with the enum types.
           0: true

--- a/generator/README.md
+++ b/generator/README.md
@@ -146,6 +146,7 @@ modules:
               value: '1' # The first entry whose regex matches and whose value parses wins.
             - regex: '.*'
               value: '0'
+        offset: 1.0 # Add the value to the same. Applied after scale.
         scale: 1.0 # Scale the value of the sample by this value.
         type: DisplayString # Override the metric type, possible types are:
                              #   gauge:   An integer with type gauge.

--- a/generator/config.go
+++ b/generator/config.go
@@ -29,6 +29,7 @@ type Config struct {
 type MetricOverrides struct {
 	Ignore         bool                              `yaml:"ignore,omitempty"`
 	RegexpExtracts map[string][]config.RegexpExtract `yaml:"regex_extracts,omitempty"`
+	Offset         float64                           `yaml:"offset,omitempty"`
 	Scale          float64                           `yaml:"scale,omitempty"`
 	Type           string                            `yaml:"type,omitempty"`
 }

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -597,6 +597,10 @@ modules:
         ignore: true # Lookup metric
       ifType:
         type: EnumAsInfo
+      # Remap enums where 1==true, 2==false to become 0==false, 1==true.
+      hrDiskStorageRemoveble:
+        scale: -1.0
+        offset: 2.0
 
 # CyberPower
 #

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -522,6 +522,7 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 		for _, metric := range out.Metrics {
 			if name == metric.Name || name == metric.Oid {
 				metric.RegexpExtracts = params.RegexpExtracts
+				metric.Offset = params.Offset
 				metric.Scale = params.Scale
 			}
 		}

--- a/snmp.yml
+++ b/snmp.yml
@@ -13225,6 +13225,8 @@ modules:
       enum_values:
         1: "true"
         2: "false"
+      offset: 2
+      scale: -1
     - name: hrDiskStorageCapacity
       oid: 1.3.6.1.2.1.25.3.6.1.4
       type: gauge


### PR DESCRIPTION
Allow the metric value to be offset from the scraped sample. For example
useful in fixing ENUMS where 1 is true and 2 is false. Offset is applied
after scale to match standard math order of operations.