### PR TITLE
Update keepalived MIB files to latest version

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -28,9 +28,9 @@ CISCO_URL         := https://raw.githubusercontent.com/cisco/cisco-mibs/2d465cce
 IANA_CHARSET_URL  := https://www.iana.org/assignments/ianacharset-mib/ianacharset-mib
 IANA_IFTYPE_URL   := https://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib
 IANA_PRINTER_URL  := https://www.iana.org/assignments/ianaprinter-mib/ianaprinter-mib
-KEEPALIVED_URL    := https://raw.githubusercontent.com/acassen/keepalived/v2.2.7/doc/KEEPALIVED-MIB.txt
-VRRP_URL          := https://raw.githubusercontent.com/acassen/keepalived/v2.2.7/doc/VRRP-MIB.txt
-VRRPV3_URL        := https://raw.githubusercontent.com/acassen/keepalived/v2.2.7/doc/VRRPv3-MIB.txt
+KEEPALIVED_URL    := https://raw.githubusercontent.com/acassen/keepalived/v2.2.8/doc/KEEPALIVED-MIB.txt
+VRRP_URL          := https://raw.githubusercontent.com/acassen/keepalived/v2.2.8/doc/VRRP-MIB.txt
+VRRPV3_URL        := https://raw.githubusercontent.com/acassen/keepalived/v2.2.8/doc/VRRPv3-MIB.txt
 KEMP_LM_URL       := https://kemptechnologies.com/files/packages/current/LM_mibs.zip
 MIKROTIK_URL      := 'https://box.mikrotik.com/f/a41daf63d0c14347a088/?dl=1'
 NEC_URL           := https://jpn.nec.com/univerge/ix/Manual/MIB

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -320,9 +320,9 @@ modules:
 
 # keepalived
 #
-# https://github.com/acassen/keepalived/blob/v2.2.7/doc/KEEPALIVED-MIB.txt
-# https://github.com/acassen/keepalived/blob/v2.2.7/doc/VRRP-MIB.txt
-# https://github.com/acassen/keepalived/blob/v2.2.7/doc/VRRPv3-MIB.txt
+# https://github.com/acassen/keepalived/blob/v2.2.8/doc/KEEPALIVED-MIB.txt
+# https://github.com/acassen/keepalived/blob/v2.2.8/doc/VRRP-MIB.txt
+# https://github.com/acassen/keepalived/blob/v2.2.8/doc/VRRPv3-MIB.txt
   keepalived:
     walk:
       - vrrpInstanceTable # Table of VRRP instances.

--- a/snmp.yml
+++ b/snmp.yml
@@ -8529,6 +8529,16 @@ modules:
       indexes:
       - labelname: vrrpInstanceIndex
         type: gauge
+    - name: vrrpInstanceV3ChecksumAsV2
+      oid: 1.3.6.1.4.1.9586.100.5.2.3.1.36
+      type: gauge
+      help: True if VRRPv3 IPv4 checksum excludes pseudo-header. - 1.3.6.1.4.1.9586.100.5.2.3.1.36
+      indexes:
+      - labelname: vrrpInstanceIndex
+        type: gauge
+      enum_values:
+        1: "true"
+        2: "false"
     - name: virtualServerGroupIndex
       oid: 1.3.6.1.4.1.9586.100.5.3.1.1.1
       type: gauge


### PR DESCRIPTION
Similar to #773, this PR updates the keepalived MIB files to latest version `v2.2.8`.
It also updates the `snmp.yml` file in the repository using the updated MIB files.

The upstream revision changelog for `KEEPALIVED-MIB`:
```
+     REVISION "202212090001Z"
+     DESCRIPTION "add VRRPv3 checksum as VRRPv2"
```