### PR TITLE
Fix and optimize generator Docker image building

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,8 +53,8 @@ jobs:
     steps:
     - prometheus/setup_build_environment:
         docker_version: ""
-    - run: make -C generator docker DOCKER_IMAGE_TAG=main
-    - run: make -C generator docker DOCKER_REPO=quay.io/prometheus DOCKER_IMAGE_TAG=main
+    - run: make -C generator docker REPO_TAG=main DOCKER_IMAGE_TAG=main
+    - run: make -C generator docker REPO_TAG=main DOCKER_REPO=quay.io/prometheus DOCKER_IMAGE_TAG=main
     - run: docker images
     - run: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
     - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
@@ -67,8 +67,8 @@ jobs:
     steps:
     - prometheus/setup_build_environment:
         docker_version: ""
-    - run: make -C generator docker DOCKER_IMAGE_TAG=$CIRCLE_TAG
-    - run: make -C generator docker DOCKER_IMAGE_TAG=$CIRCLE_TAG DOCKER_REPO=quay.io/prometheus
+    - run: make -C generator docker REPO_TAG=$CIRCLE_TAG DOCKER_IMAGE_TAG=$CIRCLE_TAG
+    - run: make -C generator docker REPO_TAG=$CIRCLE_TAG DOCKER_IMAGE_TAG=$CIRCLE_TAG DOCKER_REPO=quay.io/prometheus
     - run: docker login -u $DOCKER_LOGIN -p $DOCKER_PASSWORD
     - run: docker login -u $QUAY_LOGIN -p $QUAY_PASSWORD quay.io
     - run: |

--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -1,8 +1,9 @@
 FROM golang:latest
 
+ARG REPO_TAG=main
 RUN apt-get update && \
     apt-get install -y libsnmp-dev unzip && \
-    go install github.com/prometheus/snmp_exporter/generator@latest
+    go install github.com/prometheus/snmp_exporter/generator@"$REPO_TAG"
 
 WORKDIR "/opt"
 

--- a/generator/Dockerfile
+++ b/generator/Dockerfile
@@ -1,14 +1,23 @@
-FROM golang:latest
+FROM golang:bookworm AS builder
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libsnmp-dev
 
 ARG REPO_TAG=main
-RUN apt-get update && \
-    apt-get install -y libsnmp-dev unzip && \
-    go install github.com/prometheus/snmp_exporter/generator@"$REPO_TAG"
+RUN go install github.com/prometheus/snmp_exporter/generator@"$REPO_TAG"
+
+FROM debian:bookworm-slim
 
 WORKDIR "/opt"
 
-ENTRYPOINT ["/go/bin/generator"]
+ENTRYPOINT ["/bin/generator"]
 
-ENV MIBDIRS mibs
+ENV MIBDIRS=mibs
 
 CMD ["generate"]
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends libsnmp40 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /go/bin/generator /bin/generator

--- a/generator/Makefile
+++ b/generator/Makefile
@@ -16,8 +16,10 @@ MIB_PATH := 'mibs'
 
 CURL_OPTS ?= -L --no-progress-meter --retry 3 --retry-delay 3 --fail
 
+REPO_TAG ?= $(shell git rev-parse --abbrev-ref HEAD)
+
 DOCKER_IMAGE_NAME ?= snmp-generator
-DOCKER_IMAGE_TAG  ?= $(subst /,-,$(shell git rev-parse --abbrev-ref HEAD))
+DOCKER_IMAGE_TAG  ?= $(subst /,-,$(REPO_TAG))
 DOCKER_REPO       ?= prom
 
 SANITIZED_DOCKER_IMAGE_TAG := $(subst +,-,$(DOCKER_IMAGE_TAG))
@@ -79,7 +81,7 @@ parse_errors: generator mibs
 
 .PHONY: docker
 docker:
-	docker build -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)" .
+	docker build --build-arg REPO_TAG="$(REPO_TAG)" -t "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)" .
 
 .PHONY: docker-generate
 docker-generate: docker mibs


### PR DESCRIPTION
This PR implements a fix and an optimization to the generator Docker image building as described below.
To facilitate review, these two improvements were implemented in two separate commits.

* Fix Docker image of generator always pointing to latest tag
  * new `REPO_TAG` variable can be used to specify the tag/branch to use for a build
  * the Makefile default is to use the branch of the current repository `HEAD`
  * the Dockerfile default (if building manually with Docker) is `main`
  * updated CircleCI configuration to apply the correct `REPO_TAG` values
* Optimize Docker image of generator
  * use multi-stage build to reduce final image size
  * ensure to use the same Debian version (`bookworm`) for the builder and final images
  * use `--no-install-recommends` to reduce unnecessary dependency downloads
  * removed unnecessary `unzip` dependency in the image
  * use modern syntax (using equal sign) for `ENV` Dockerfile directive

The first commit addresses the problem that the Docker images for the generator currently always use the latest tagged version in the repository, instead of the latest commit of the branch pointed by the Docker image tag. This comit now allows to build Docker images for the generator using any tag or branch, no matter which tag is latest in the repository.

The most evident issue of the above is that the `prom/snmp-generator:main` image in Docker Hub (and also the corresponding image in Quay.io) actually contains the `generator` binary for the latest tag `v0.24.1` instead of a binary generated from the latest `main` branch as suggested by the image tag.

I spent some signifcant time trying to figure out why a newly built image of the generator was unable to process the current `generator.yml` configuration file in the `main` branch until I realized that the Dockerfile is fixed to `@latest`. This PR now allows the generator to work out of the box as shown below.

At the time of this writing, if you try to run `make docker-generate`, it fails because the `generator` binary in the built `prom/snmp-generator:main` image does not understand the latest changes done in the `main` branch since the latest tag:
```
$ git status
On branch main
$ cd generator
$ make docker-generate
(...)
docker run -ti -v "/home/hhromic/snmp_exporter/generator:/opt/" "prom/snmp-generator:main" generate
ts=2023-11-11T19:17:56.898Z caller=net_snmp.go:162 level=info msg="Loading MIBs" from=mibs
ts=2023-11-11T19:17:57.127Z caller=main.go:132 level=error msg="Error generating config netsnmp" err="error parsing yml config: yaml: unmarshal errors:\n  line 159: field scale not found in type main.plain\n  line 602: field scale not found in type main.plain\n  line 603: field offset not found in type main.plain"
make: *** [Makefile:86: docker-generate] Error 1
```

With this PR, the binary in the image is actually built from the `main` branch and it works as expected:
```
$ git status
On branch generator-docker-image
$ cd generator
$ make docker-generate REPO_TAG=main
(...)
docker run -ti -v "/home/hhromic/snmp_exporter/generator:/opt/" "prom/snmp-generator:main" generate
ts=2023-11-11T19:20:09.693Z caller=net_snmp.go:175 level=info msg="Loading MIBs" from=mibs
ts=2023-11-11T19:20:09.942Z caller=main.go:53 level=info msg="Generating config for module" module=paloalto_fw
ts=2023-11-11T19:20:09.970Z caller=main.go:68 level=info msg="Generated metrics" module=paloalto_fw metrics=204
(...)
ts=2023-11-11T19:20:11.813Z caller=main.go:93 level=info msg="Config written" file=/opt/snmp.yml
```
> **Note:** If this PR is merged, it will not be necessary to provide `REPO_TAG` while in the `main` branch.

The second commit optimizes the Docker image size by using a multi-stage build and removing unnecessary dependencies.

Image sizes before and after the optimization:
```
REPOSITORY            TAG       IMAGE ID       CREATED       SIZE
prom/snmp-generator   main      63565e35e294   7 hours ago   931MB
```
```
REPOSITORY            TAG       IMAGE ID       CREATED          SIZE
prom/snmp-generator   main      d140116eda2c   38 minutes ago   144MB
```

I hope you consider these improvements and let me know if you have any concerns.
If you simply don't want to include these changes, feel free to drop this PR. No worries.
