### PR TITLE
chore: do not force `:Z` flag in Docker volume mount

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -24,6 +24,12 @@ DOCKER_REPO       ?= prom
 
 SANITIZED_DOCKER_IMAGE_TAG := $(subst +,-,$(DOCKER_IMAGE_TAG))
 
+SELINUX_ENABLED := $(shell cat /sys/fs/selinux/enforce 2> /dev/null || echo 0)
+
+ifeq ($(SELINUX_ENABLED),1)
+  DOCKER_VOL_OPTS ?= :z
+endif
+
 APC_URL           := https://download.schneider-electric.com/files?p_enDocType=Firmware&p_File_Name=powernet451.mib&p_Doc_Ref=APC_POWERNETMIB_451_EN
 ARISTA_URL        := https://www.arista.com/assets/data/docs/MIBS
 CISCO_URL         := https://raw.githubusercontent.com/cisco/cisco-mibs/2d465cce2de4e67a3561d8e41e4c99b597558d4b/v2
@@ -89,7 +95,7 @@ docker:
 
 .PHONY: docker-generate
 docker-generate: docker mibs
-	docker run -ti -v "${PWD}:/opt/:Z" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)" generate
+	docker run -ti -v "${PWD}:/opt$(DOCKER_VOL_OPTS)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)" generate
 
 .PHONY: docker-publish
 docker-publish:


### PR DESCRIPTION
Follow up on #1054
This PR adopts the approach seen in `etcd` for compatibilty with SELinux:
<https://github.com/kubernetes/kubernetes/blob/ad9b60e2c9ddb21e8b00cabbe27e639638a0ea88/cluster/images/etcd/Makefile#L76-L81>

Instead of forcing `:Z`, detect if SElinux is enabled and add `:z` on demand.
According to the documentation and multiple examples I could find, using `:z` seems to be less dangerous than `:Z`.

@jvillal-amp what is your opinion on using `:z` vs `:Z`?
Can you confirm if this PR still allows you to use `make docker-generate` in your SELinux environmnet?
