### PR TITLE
Fix documented default value for community

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -86,8 +86,8 @@ auths:
     version: 2  # SNMP version to use. Defaults to 2.
                 # 1 will use GETNEXT, 2 and 3 use GETBULK.
 
-    # Community string is used with SNMP v1 and v2. Defaults to "public_v2".
-    community: public_v2
+    # Community string is used with SNMP v1 and v2. Defaults to "public".
+    community: public
 
     # v3 has different and more complex settings.
     # Which are required depends on the security_level.


### PR DESCRIPTION
The documentation (README) say that the default value for the SNMP community is `"public_v2"`. But I believe this is wrong:
* https://github.com/prometheus/snmp_exporter/blob/9c42d6c874d479314e612bca69558c81f8e26287/snmp.yml#L4
* https://github.com/prometheus/snmp_exporter/blob/9c42d6c874d479314e612bca69558c81f8e26287/config/config.go#L52

