### PR TITLE
Document AES192C and AES256C privacy protocols, as used by Cisco devices

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -100,7 +100,7 @@ auths:
                     # Required if security_level is authNoPriv or authPriv.
     auth_protocol: MD5  # MD5, SHA, SHA224, SHA256, SHA384, or SHA512. Defaults to MD5. -a option to NetSNMP.
                         # Used if security_level is authNoPriv or authPriv.
-    priv_protocol: DES  # DES, AES, AES192, or AES256. Defaults to DES. -x option to NetSNMP.
+    priv_protocol: DES  # DES, AES, AES192, AES256, AES192C, or AES256C. Defaults to DES. -x option to NetSNMP.
                         # Used if security_level is authPriv.
     priv_password: otherPass # Has no default. Also known as privKey, -X option to NetSNMP.
                              # Required if security_level is authPriv.


### PR DESCRIPTION
Ref: https://github.com/markabrahams/node-net-snmp/issues/154#issuecomment-757456861

Source code references:
* https://github.com/prometheus/snmp_exporter/blob/v0.25.0/config/config.go#L152-L165
* https://github.com/gosnmp/gosnmp/blob/v1.37.0/v3_usm.go#L118-L127