### PR TITLE
fix: workaround servertech_sentry3 zero-length integers

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -108,6 +108,7 @@ modules:
 # ftp://ftp.servertech.com/Pub/SNMP/sentry3/Sentry3OIDTree.txt
 # ftp://ftp.servertech.com/Pub/SNMP/sentry3/Sentry3.mib
   servertech_sentry3:
+    max_repetitions: 4 # See https://github.com/prometheus/snmp_exporter/issues/1080
     walk:
       - 1.3.6.1.4.1.1718.3.2.2  # infeedTable
       - 1.3.6.1.4.1.1718.3.2.3  # outletTable

--- a/snmp.yml
+++ b/snmp.yml
@@ -21026,6 +21026,7 @@ modules:
         type: gauge
       - labelname: outletIndex
         type: gauge
+    max_repetitions: 4
   servertech_sentry4:
     walk:
     - 1.3.6.1.4.1.1718.4.1.14.3


### PR DESCRIPTION
servertech_sentry3 devices can return bad ASN.1 data, an Integer with asnlength=0 under certain cases.

- Certain firmware versions only
- SNMP BULKGET
- Specific OIDs deep into the tree, at different repetition values

Work around the problem by setting max_repetitions=4, which doesn't trigger the device bug.

Closes: https://github.com/prometheus/snmp_exporter/issues/1080