### PR TITLE
delete buildrequire gcc-c++ in rhel from README.md 

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -11,7 +11,7 @@ Due to the dynamic dependency on NetSNMP, you must build the generator yourself.
 # Debian-based distributions.
 sudo apt-get install unzip build-essential libsnmp-dev # Debian-based distros
 # Redhat-based distributions.
-sudo yum install gcc gcc-g++ make net-snmp net-snmp-utils net-snmp-libs net-snmp-devel # RHEL-based distros
+sudo yum install gcc make net-snmp net-snmp-utils net-snmp-libs net-snmp-devel # RHEL-based distros
 
 git clone https://github.com/prometheus/snmp_exporter.git
 cd snmp_exporter/generator


### PR DESCRIPTION
#1091 
it don't need a C++ compiler 

```
$ rpm -q gcc-c++
package gcc-c++ is not installed
$ make generator
go build
$ echo $?
0
$ ll generator
-rwxr-xr-x 1 root root 7455880 Jan 15 16:25 generator

```
