### PR TITLE
Fix curl failed

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -14,7 +14,7 @@
 MIBDIR   := mibs
 MIB_PATH := 'mibs'
 
-CURL_OPTS ?= -L --no-progress-meter --retry 3 --retry-delay 3 --fail
+CURL_OPTS ?= -L -sS --retry 3 --retry-delay 3 --fail
 
 REPO_TAG ?= $(shell git rev-parse --abbrev-ref HEAD)
 


### PR DESCRIPTION
Fixes: #1093 
```
curl version is 7.61.1  in rhel8.8,
and --no-progress-meter is added in 7.67.0.
so there is error curl: option --no-progress-meter: is unknown

For better compatibility, we shoule use the option -sS
```