### PR TITLE
Add generator HELP override

### DIFF
--- a/generator/FORMAT.md
+++ b/generator/FORMAT.md
@@ -23,6 +23,9 @@ modules:
      - name:  sysUpTime
        oid:   1.3.6.1.2.1.1.3
        type:  gauge
+       # The HELP text included with the scrape metrics.
+       help: The value of sysUpTime on the most recent occasion at which any one or
+         more of this entry's counters suffered a discontinuity - 1.3.6.1.4.1.30065.3.1.1.1.1.46
        # See README.md type override for a list of valid types
        # Non-numeric types are represented as a gauge with value 1, and the rendered value
        # as a label value on that gauge.

--- a/generator/README.md
+++ b/generator/README.md
@@ -148,6 +148,7 @@ modules:
     overrides: # Allows for per-module overrides of bits of MIBs
       metricName:
         ignore: true # Drops the metric from the output.
+        help: "string" # Override the generated HELP text provided by the MIB Description.
         regex_extracts:
           Temp: # A new metric will be created appending this to the metricName to become metricNameTemp.
             - regex: '(.*)' # Regex to extract a value from the returned SNMP walks's value.

--- a/generator/config.go
+++ b/generator/config.go
@@ -32,6 +32,7 @@ type MetricOverrides struct {
 	Offset         float64                           `yaml:"offset,omitempty"`
 	Scale          float64                           `yaml:"scale,omitempty"`
 	Type           string                            `yaml:"type,omitempty"`
+	Help           string                            `yaml:"help,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -162,6 +162,7 @@ modules:
     overrides:
       st4TempSensorValue:
         scale: 0.1
+        help: The measured temperature on the sensor in degrees using the scale selected by st4TempSensorScale - 1.3.6.1.4.1.1718.4.1.9.3.1.1
 
 # Palo Alto Firewalls
 #

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -530,6 +530,9 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 				metric.RegexpExtracts = params.RegexpExtracts
 				metric.Offset = params.Offset
 				metric.Scale = params.Scale
+				if params.Help != "" {
+					metric.Help = params.Help
+				}
 			}
 		}
 	}

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -182,6 +182,7 @@ func TestGenerateConfigModule(t *testing.T) {
 	overrides := make(map[string]MetricOverrides)
 	overrides["root"] = MetricOverrides{
 		RegexpExtracts: strMetrics,
+		Help:           "help override",
 	}
 
 	cases := []struct {
@@ -189,7 +190,7 @@ func TestGenerateConfigModule(t *testing.T) {
 		cfg  *ModuleConfig  // SNMP generator config.
 		out  *config.Module // SNMP exporter config.
 	}{
-		// Simple metric with Regexp override.
+		// Simple metric with Regexp and Help override.
 		{
 			node: &Node{Oid: "1", Access: "ACCESS_READONLY", Type: "INTEGER", Label: "root"},
 			cfg: &ModuleConfig{
@@ -203,7 +204,7 @@ func TestGenerateConfigModule(t *testing.T) {
 						Name:           "root",
 						Oid:            "1",
 						Type:           "gauge",
-						Help:           " - 1",
+						Help:           "help override",
 						RegexpExtracts: strMetrics,
 					},
 				},

--- a/snmp.yml
+++ b/snmp.yml
@@ -23309,8 +23309,8 @@ modules:
     - name: st4TempSensorValue
       oid: 1.3.6.1.4.1.1718.4.1.9.3.1.1
       type: gauge
-      help: The measured temperature on the sensor in tenth degrees using the scale
-        selected by st4TempSensorScale - 1.3.6.1.4.1.1718.4.1.9.3.1.1
+      help: The measured temperature on the sensor in degrees using the scale selected
+        by st4TempSensorScale - 1.3.6.1.4.1.1718.4.1.9.3.1.1
       indexes:
       - labelname: st4UnitIndex
         type: gauge


### PR DESCRIPTION
Allow override of the metric HELP text in the generator. Allows for altering generated MIB documentation.
* Update example help text for `st4TempSensorValue` to match scale override.

Fixes: https://github.com/prometheus/snmp_exporter/issues/1105