### PR TITLE
Refactoring of Scrape process, fixing multiple module issues

### DIFF
--- a/scraper/gosnmp.go
+++ b/scraper/gosnmp.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2024 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/scraper/gosnmp.go
+++ b/scraper/gosnmp.go
@@ -1,3 +1,16 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package scraper
 
 import (

--- a/scraper/gosnmp.go
+++ b/scraper/gosnmp.go
@@ -48,10 +48,6 @@ func (g *GoSNMPWrapper) SetOptions(fns ...func(*gosnmp.GoSNMP)) {
 	}
 }
 
-func (g *GoSNMPWrapper) GetVersion() gosnmp.SnmpVersion {
-	return g.c.Version
-}
-
 func (g *GoSNMPWrapper) Connect() error {
 	st := time.Now()
 	err := g.c.Connect()

--- a/scraper/gosnmp.go
+++ b/scraper/gosnmp.go
@@ -1,0 +1,108 @@
+package scraper
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+	"github.com/gosnmp/gosnmp"
+)
+
+type GoSNMPWrapper struct {
+	c      *gosnmp.GoSNMP
+	logger log.Logger
+}
+
+func NewGoSNMP(logger log.Logger, target, srcAddress string) (*GoSNMPWrapper, error) {
+	transport := "udp"
+	if s := strings.SplitN(target, "://", 2); len(s) == 2 {
+		transport = s[0]
+		target = s[1]
+	}
+	port := uint16(161)
+	if host, _port, err := net.SplitHostPort(target); err == nil {
+		target = host
+		p, err := strconv.Atoi(_port)
+		if err != nil {
+			return nil, fmt.Errorf("error converting port number to int for target %q: %w", target, err)
+		}
+		port = uint16(p)
+	}
+	g := &gosnmp.GoSNMP{
+		Transport: transport,
+		Target:    target,
+		Port:      port,
+		LocalAddr: srcAddress,
+	}
+	return &GoSNMPWrapper{c: g, logger: logger}, nil
+}
+
+func (g *GoSNMPWrapper) SetOptions(fns ...func(*gosnmp.GoSNMP)) {
+	for _, fn := range fns {
+		fn(g.c)
+	}
+}
+
+func (g *GoSNMPWrapper) GetVersion() gosnmp.SnmpVersion {
+	return g.c.Version
+}
+
+func (g *GoSNMPWrapper) Connect() error {
+	st := time.Now()
+	err := g.c.Connect()
+	if err != nil {
+		if err == context.Canceled {
+			return fmt.Errorf("scrape cancelled after %s (possible timeout) connecting to target %s",
+				time.Since(st), g.c.Target)
+		}
+		return fmt.Errorf("error connecting to target %s: %s", g.c.Target, err)
+	}
+	return nil
+}
+
+func (g *GoSNMPWrapper) Close() error {
+	return g.c.Conn.Close()
+}
+
+func (g *GoSNMPWrapper) Get(oids []string) (results *gosnmp.SnmpPacket, err error) {
+	level.Debug(g.logger).Log("msg", "Getting OIDs", "oids", oids)
+	st := time.Now()
+	results, err = g.c.Get(oids)
+	if err != nil {
+		if err == context.Canceled {
+			err = fmt.Errorf("scrape cancelled after %s (possible timeout) getting target %s",
+				time.Since(st), g.c.Target)
+		} else {
+			err = fmt.Errorf("error getting target %s: %s", g.c.Target, err)
+		}
+		return
+	}
+	level.Debug(g.logger).Log("msg", "Get of OIDs completed", "oids", oids, "duration_seconds", time.Since(st))
+	return
+}
+
+func (g *GoSNMPWrapper) WalkAll(oid string) (results []gosnmp.SnmpPDU, err error) {
+	level.Debug(g.logger).Log("msg", "Walking subtree", "oid", oid)
+	st := time.Now()
+	if g.c.Version == gosnmp.Version1 {
+		results, err = g.c.WalkAll(oid)
+	} else {
+		results, err = g.c.BulkWalkAll(oid)
+	}
+	if err != nil {
+		if err == context.Canceled {
+			err = fmt.Errorf("scrape canceled after %s (possible timeout) walking target %s",
+				time.Since(st), g.c.Target)
+		} else {
+			err = fmt.Errorf("error walking target %s: %s", g.c.Target, err)
+		}
+		return
+	}
+	level.Debug(g.logger).Log("msg", "Walk of subtree completed", "oid", oid, "duration_seconds", time.Since(st))
+	return
+}

--- a/scraper/mock.go
+++ b/scraper/mock.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2024 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/scraper/mock.go
+++ b/scraper/mock.go
@@ -1,0 +1,68 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scraper
+
+import (
+	"strings"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+type MockSNMPScraper struct {
+	GetResponses     map[string]*gosnmp.SnmpPDU
+	WalkAllResponses map[string]gosnmp.SnmpPDU
+	ConnectError     error
+	CloseError       error
+}
+
+func (m *MockSNMPScraper) Get(oids []string) (*gosnmp.SnmpPacket, error) {
+	pdus := make([]gosnmp.SnmpPDU, 0, len(oids))
+	for _, oid := range oids {
+		if response, exists := m.GetResponses[oid]; exists {
+			pdus = append(pdus, *response)
+		} else {
+			pdus = append(pdus, gosnmp.SnmpPDU{
+				Name:  oid,
+				Type:  gosnmp.NoSuchObject,
+				Value: nil,
+			})
+		}
+	}
+	return &gosnmp.SnmpPacket{
+		Variables: pdus,
+		Error:     gosnmp.NoError,
+	}, nil
+}
+
+func (m *MockSNMPScraper) WalkAll(baseOID string) ([]gosnmp.SnmpPDU, error) {
+	var pdus []gosnmp.SnmpPDU
+	for k, v := range m.WalkAllResponses {
+		if strings.HasPrefix(k, baseOID) {
+			pdus = append(pdus, v)
+		}
+	}
+	return pdus, nil
+
+}
+
+func (m *MockSNMPScraper) Connect() error {
+	return m.ConnectError
+}
+
+func (m *MockSNMPScraper) Close() error {
+	return m.CloseError
+}
+
+func (m *MockSNMPScraper) SetOptions(...func(*gosnmp.GoSNMP)) {
+}

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -1,4 +1,4 @@
-// Copyright 2018 The Prometheus Authors
+// Copyright 2024 The Prometheus Authors
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -1,3 +1,16 @@
+// Copyright 2018 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package scraper
 
 import (

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -1,0 +1,14 @@
+package scraper
+
+import (
+	"github.com/gosnmp/gosnmp"
+)
+
+type SNMPScraper interface {
+	Get([]string) (*gosnmp.SnmpPacket, error)
+	WalkAll(string) ([]gosnmp.SnmpPDU, error)
+	Connect() error
+	Close() error
+	GetVersion() gosnmp.SnmpVersion
+	SetOptions(...func(*gosnmp.GoSNMP))
+}

--- a/scraper/scraper.go
+++ b/scraper/scraper.go
@@ -9,6 +9,5 @@ type SNMPScraper interface {
 	WalkAll(string) ([]gosnmp.SnmpPDU, error)
 	Connect() error
 	Close() error
-	GetVersion() gosnmp.SnmpVersion
 	SetOptions(...func(*gosnmp.GoSNMP))
 }


### PR DESCRIPTION
Since enabling the specification of multiple modules, we have observed an increase in DNS requests. 
This issue seems to stem from gosnmp performing name resolution for each module. 
We have revised the implementation around SNMP scraping. 
By having each worker hold its instance of gosnmp, we can resolve the aforementioned issue.

Additionally,  we improved maintainability by utilizing an interface to hold gosnmp instead of doing so directly in ScrapeTarget. We're hoping this change will enable us to implement a scraper that avoids retrieving the same OID multiple times by caching the OIDs once they are fetched. 
Initially, we contemplated completely eliminating the dependency on gosnmp, but such a measure would have excessively broadened the scope of implementation, prompting us to forgo this option.

I haven't yet implemented error handling for connection failures, and it's still a work in progress, but I would appreciate a review including feedback on the general direction.

## test env
```
> go run ./ --log.level=debug --config.file ./generator/snmp.yml --web.listen-address :9117
ts=2024-02-09T08:32:07.864Z caller=main.go:194 level=info msg="Starting snmp_exporter" version="(version=, branch=, revision=unknown)" concurrency=1
ts=2024-02-09T08:32:07.865Z caller=main.go:195 level=info build_context="(go=go1.21.6, platform=darwin/arm64, user=, date=, tags=unknown)"
ts=2024-02-09T08:32:07.867Z caller=tls_config.go:313 level=info msg="Listening on" address=[::]:9117
ts=2024-02-09T08:32:07.867Z caller=tls_config.go:316 level=info msg="TLS is disabled." http2=false address=[::]:9117
ts=2024-02-09T08:38:02.606Z caller=collector.go:437 level=debug auth=public_v2 target=192.168.64.3 module=if_mib msg="Starting scrape"
ts=2024-02-09T08:38:02.607Z caller=gosnmp.go:90 level=debug auth=public_v2 target=192.168.64.3 worker=0 msg="Walking subtree" oid=1.3.6.1.2.1.2
ts=2024-02-09T08:38:02.644Z caller=gosnmp.go:106 level=debug auth=public_v2 target=192.168.64.3 worker=0 msg="Walk of subtree completed" oid=1.3.6.1.2.1.2 duration_seconds=37.255167ms
ts=2024-02-09T08:38:02.644Z caller=gosnmp.go:90 level=debug auth=public_v2 target=192.168.64.3 worker=0 msg="Walking subtree" oid=1.3.6.1.2.1.31.1.1
ts=2024-02-09T08:38:02.744Z caller=gosnmp.go:106 level=debug auth=public_v2 target=192.168.64.3 worker=0 msg="Walk of subtree completed" oid=1.3.6.1.2.1.31.1.1 duration_seconds=100.006833ms
ts=2024-02-09T08:38:02.746Z caller=collector.go:441 level=debug auth=public_v2 target=192.168.64.3 module=if_mib msg="Finished scrape" duration_seconds=0.139322458
ts=2024-02-09T08:38:02.746Z caller=collector.go:437 level=debug auth=public_v2 target=192.168.64.3 module=sysDescr msg="Starting scrape"
ts=2024-02-09T08:38:02.746Z caller=gosnmp.go:73 level=debug auth=public_v2 target=192.168.64.3 worker=0 msg="Getting OIDs" oids="unsupported value type"
ts=2024-02-09T08:38:02.960Z caller=gosnmp.go:85 level=debug auth=public_v2 target=192.168.64.3 worker=0 msg="Get of OIDs completed" oids="unsupported value type" duration_seconds=213.846666ms
ts=2024-02-09T08:38:02.960Z caller=collector.go:441 level=debug auth=public_v2 target=192.168.64.3 module=sysDescr msg="Finished scrape" duration_seconds=0.213982416

> ./snmp_exporter_orig --config.file ./generator/snmp.yml
ts=2024-02-09T06:26:36.501Z caller=main.go:194 level=info msg="Starting snmp_exporter" version="(version=, branch=, revision=acb6e787f193d340f2c84e1fa0b4744e7fea7e63-modified)" concurrency=1
ts=2024-02-09T06:26:36.501Z caller=main.go:195 level=info build_context="(go=go1.21.6, platform=darwin/arm64, user=, date=, tags=unknown)"
ts=2024-02-09T06:26:36.504Z caller=tls_config.go:313 level=info msg="Listening on" address=[::]:9116
ts=2024-02-09T06:26:36.504Z caller=tls_config.go:316 level=info msg="TLS is disabled." http2=false address=[::]:9116
```

## test command log
```
> curl -s 'localhost:9116/snmp?target=192.168.64.3&module=if_mib,sysDescr' | tee orig | tail
# TYPE snmp_scrape_pdus_returned gauge
snmp_scrape_pdus_returned{module="if_mib"} 121
snmp_scrape_pdus_returned{module="sysDescr"} 1
# HELP snmp_scrape_walk_duration_seconds Time SNMP walk/bulkwalk took.
# TYPE snmp_scrape_walk_duration_seconds gauge
snmp_scrape_walk_duration_seconds{module="if_mib"} 0.0686725
snmp_scrape_walk_duration_seconds{module="sysDescr"} 0.001960042
# HELP sysDescr A textual description of the entity - 1.3.6.1.2.1.1.1
# TYPE sysDescr gauge
sysDescr{sysDescr="Cumulus Linux 3.7.16 (Linux Kernel 4.1.33-1+cl3.7.15u1)"} 1

> curl -s 'localhost:9117/snmp?target=192.168.64.3&module=if_mib,sysDescr' | tee new | tail
# TYPE snmp_scrape_pdus_returned gauge
snmp_scrape_pdus_returned{module="if_mib"} 121
snmp_scrape_pdus_returned{module="sysDescr"} 1
# HELP snmp_scrape_walk_duration_seconds Time SNMP walk/bulkwalk took.
# TYPE snmp_scrape_walk_duration_seconds gauge
snmp_scrape_walk_duration_seconds{module="if_mib"} 0.0529665
snmp_scrape_walk_duration_seconds{module="sysDescr"} 0.009939875
# HELP sysDescr A textual description of the entity - 1.3.6.1.2.1.1.1
# TYPE sysDescr gauge
sysDescr{sysDescr="Cumulus Linux 3.7.16 (Linux Kernel 4.1.33-1+cl3.7.15u1)"} 1

> diff orig new
48c48
< ifHCOutOctets{ifAlias="eth0",ifDescr="Intel Corporation 82540EM Gigabit Ethernet Controller",ifIndex="2",ifName="eth0"} 639396
---
> ifHCOutOctets{ifAlias="eth0",ifDescr="Intel Corporation 82540EM Gigabit Ethernet Controller",ifIndex="2",ifName="eth0"} 634472
53c53
< ifHCOutUcastPkts{ifAlias="eth0",ifDescr="Intel Corporation 82540EM Gigabit Ethernet Controller",ifIndex="2",ifName="eth0"} 3238
---
> ifHCOutUcastPkts{ifAlias="eth0",ifDescr="Intel Corporation 82540EM Gigabit Ethernet Controller",ifIndex="2",ifName="eth0"} 3229
191,192c191,192
< snmp_scrape_duration_seconds{module="if_mib"} 0.164523709
< snmp_scrape_duration_seconds{module="sysDescr"} 0.19121475
---
> snmp_scrape_duration_seconds{module="if_mib"} 0.139320042
> snmp_scrape_duration_seconds{module="sysDescr"} 0.213978041
207,208c207,208
< snmp_scrape_walk_duration_seconds{module="if_mib"} 0.16301675
< snmp_scrape_walk_duration_seconds{module="sysDescr"} 0.191177
---
> snmp_scrape_walk_duration_seconds{module="if_mib"} 0.137472542
> snmp_scrape_walk_duration_seconds{module="sysDescr"} 0.213934416
```