### PR TITLE
Skip using an interactive terminal in "make docker-generate".

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -95,7 +95,7 @@ docker:
 
 .PHONY: docker-generate
 docker-generate: docker mibs
-	docker run -ti -v "${PWD}:/opt$(DOCKER_VOL_OPTS)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)" generate
+	docker run -v "${PWD}:/opt$(DOCKER_VOL_OPTS)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)" generate
 
 .PHONY: docker-publish
 docker-publish:


### PR DESCRIPTION
The "docker-generate" target does not actually seem to need user interaction. But requiring an interactive terminal in the "docker run" command does make it impossible/harder to embed it in an automated environment like CI/CD.

This patch simply removes the allocation of such a terminal. The "make docker-generate" seems to run just fine without it.