### PR TITLE
Add SNMPInflight metric

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -275,6 +275,7 @@ type Metrics struct {
 	SNMPDuration           prometheus.Histogram
 	SNMPPackets            prometheus.Counter
 	SNMPRetries            prometheus.Counter
+	SNMPInflight           prometheus.Gauge
 }
 
 type NamedModule struct {
@@ -403,6 +404,8 @@ func (c Collector) collect(ch chan<- prometheus.Metric, logger log.Logger, clien
 
 // Collect implements Prometheus.Collector.
 func (c Collector) Collect(ch chan<- prometheus.Metric) {
+	c.metrics.SNMPInflight.Inc()
+	defer c.metrics.SNMPInflight.Dec()
 	wg := sync.WaitGroup{}
 	workerCount := c.concurrency
 	if workerCount < 1 {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -347,7 +347,9 @@ func (c Collector) collect(ch chan<- prometheus.Metric, logger log.Logger, clien
 	)
 	start := time.Now()
 	moduleLabel := prometheus.Labels{"module": module.name}
+	c.metrics.SNMPInflight.Inc()
 	results, err := ScrapeTarget(client, c.target, c.auth, module.Module, logger, c.metrics)
+	c.metrics.SNMPInflight.Dec()
 	if err != nil {
 		level.Info(logger).Log("msg", "Error scraping target", "err", err)
 		ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("snmp_error", "Error scraping target", nil, moduleLabel), err)
@@ -404,8 +406,6 @@ func (c Collector) collect(ch chan<- prometheus.Metric, logger log.Logger, clien
 
 // Collect implements Prometheus.Collector.
 func (c Collector) Collect(ch chan<- prometheus.Metric) {
-	c.metrics.SNMPInflight.Inc()
-	defer c.metrics.SNMPInflight.Dec()
 	wg := sync.WaitGroup{}
 	workerCount := c.concurrency
 	if workerCount < 1 {

--- a/main.go
+++ b/main.go
@@ -267,6 +267,13 @@ func main() {
 				Help:      "Number of SNMP packet retries.",
 			},
 		),
+		SNMPInflight: promauto.NewGauge(
+			prometheus.GaugeOpts{
+				Namespace: namespace,
+				Name:      "request_in_flight",
+				Help:      "Current number of requests being served.",
+			},
+		),
 	}
 
 	http.Handle(*metricsPath, promhttp.Handler()) // Normal metrics endpoint for SNMP exporter itself.

--- a/main.go
+++ b/main.go
@@ -271,7 +271,7 @@ func main() {
 			prometheus.GaugeOpts{
 				Namespace: namespace,
 				Name:      "request_in_flight",
-				Help:      "Current number of requests being served.",
+				Help:      "Current number of SNMP scrapes being requested.",
 			},
 		),
 	}


### PR DESCRIPTION
I have added an implementation to export the current number of requests.

```
> curl -s 'localhost:9116/metrics' | grep snmp_r
# HELP snmp_request_errors_total Errors in requests to the SNMP exporter
# TYPE snmp_request_errors_total counter
snmp_request_errors_total 0
# HELP snmp_request_in_flight Current number of requests being served.
# TYPE snmp_request_in_flight gauge
snmp_request_in_flight 0
```