### PR TITLE
Add cache client to improve SNMP scraping

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -419,13 +419,14 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 		go func(i int) {
 			defer wg.Done()
 			logger := log.With(c.logger, "worker", i)
-			client, err := scraper.NewGoSNMP(logger, c.target, *srcAddress)
+			scrape, err := scraper.NewGoSNMP(logger, c.target, *srcAddress)
 			if err != nil {
 				level.Info(logger).Log("msg", err)
 				cancel()
 				ch <- prometheus.NewInvalidMetric(prometheus.NewDesc("snmp_error", "Error during initialisation of the Worker", nil, nil), err)
 				return
 			}
+			client := scraper.NewCacheClient(scrape)
 			// Set the options.
 			client.SetOptions(func(g *gosnmp.GoSNMP) {
 				g.Context = ctx

--- a/scraper/cache.go
+++ b/scraper/cache.go
@@ -1,0 +1,55 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scraper
+
+import "github.com/gosnmp/gosnmp"
+
+type cacheClient struct {
+	scraper     SNMPScraper
+	walkResults map[string][]gosnmp.SnmpPDU
+}
+
+func NewCacheClient(scraper SNMPScraper) *cacheClient {
+	return &cacheClient{
+		scraper:     scraper,
+		walkResults: make(map[string][]gosnmp.SnmpPDU),
+	}
+}
+
+func (c *cacheClient) Get(oids []string) (*gosnmp.SnmpPacket, error) {
+	return c.scraper.Get(oids)
+}
+
+func (c *cacheClient) WalkAll(oid string) ([]gosnmp.SnmpPDU, error) {
+	if result, ok := c.walkResults[oid]; ok {
+		return result, nil
+	}
+	results, err := c.scraper.WalkAll(oid)
+	if err == nil {
+		c.walkResults[oid] = results
+	}
+	return results, err
+}
+
+func (c *cacheClient) Connect() error {
+	return c.scraper.Connect()
+}
+
+func (c *cacheClient) Close() error {
+	return c.scraper.Close()
+}
+
+func (c *cacheClient) SetOptions(fns ...func(*gosnmp.GoSNMP)) {
+	c.scraper.SetOptions(fns...)
+}

--- a/scraper/cache_test.go
+++ b/scraper/cache_test.go
@@ -1,0 +1,107 @@
+// Copyright 2024 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scraper
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/gosnmp/gosnmp"
+)
+
+func TestCacheClient(t *testing.T) {
+	cases := []struct {
+		name          string
+		getResponse   map[string]gosnmp.SnmpPDU
+		walkResponses map[string][]gosnmp.SnmpPDU
+		getRequest    [][]string
+		walkRequest   []string
+		getCall       []string
+		walkCall      []string
+	}{
+		{
+			name: "basic",
+			getResponse: map[string]gosnmp.SnmpPDU{
+				"1.3.6.1.2.1.1.1.0": {Type: gosnmp.OctetString, Name: "1.3.6.1.2.1.1.1.0", Value: "Test Device"},
+			},
+			walkResponses: map[string][]gosnmp.SnmpPDU{
+				"1.3.6.1.2.1.2.2.1.2": {
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.2.2.1.2.1", Value: "lo"},
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.2.2.1.2.2", Value: "Intel Corporation 82540EM Gigabit Ethernet Controller"},
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.2.2.1.2.3", Value: "Intel Corporation 82540EM Gigabit Ethernet Controller"},
+				},
+				"1.3.6.1.2.1.31.1.1.1.18": {
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.31.1.1.1.18.1", Value: "lo"},
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.31.1.1.1.18.2", Value: "eth0"},
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.31.1.1.1.18.3", Value: "swp1"},
+				},
+			},
+			getRequest:  [][]string{{"1.3.6.1.2.1.1.1.0"}},
+			walkRequest: []string{"1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.31.1.1.1.18"},
+			getCall:     []string{"1.3.6.1.2.1.1.1.0"},
+			walkCall:    []string{"1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.31.1.1.1.18"},
+		},
+		{
+			name: "de-duplicate in walk",
+			walkResponses: map[string][]gosnmp.SnmpPDU{
+				"1.3.6.1.2.1.2.2.1.2": {
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.2.2.1.2.1", Value: "lo"},
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.2.2.1.2.2", Value: "Intel Corporation 82540EM Gigabit Ethernet Controller"},
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.2.2.1.2.3", Value: "Intel Corporation 82540EM Gigabit Ethernet Controller"},
+				},
+				"1.3.6.1.2.1.31.1.1.1.18": {
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.31.1.1.1.18.1", Value: "lo"},
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.31.1.1.1.18.2", Value: "eth0"},
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.31.1.1.1.18.3", Value: "swp1"},
+				},
+			},
+			walkRequest: []string{"1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.31.1.1.1.18", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.31.1.1.1.18"},
+			getCall:     []string{},
+			walkCall:    []string{"1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.31.1.1.1.18"},
+		},
+	}
+
+	for _, c := range cases {
+		tt := c
+		t.Run(tt.name, func(t *testing.T) {
+			mock := NewMockSNMPScraper(tt.getResponse, tt.walkResponses)
+			client := NewCacheClient(mock)
+			for _, oids := range tt.getRequest {
+				res, err := client.Get(oids)
+				if err != nil {
+					t.Errorf("Get returned an error: %v", err)
+				}
+				pdus := res.Variables
+				if len(pdus) != len(oids) {
+					t.Errorf("Expected %d PDUs, got %d", len(oids), len(pdus))
+				}
+			}
+			for _, oid := range tt.walkRequest {
+				res, err := client.WalkAll(oid)
+				if err != nil {
+					t.Errorf("WalkAll returned an error: %v", err)
+				}
+				if len(res) != len(tt.walkResponses[oid]) {
+					t.Errorf("Expected %d PDUs, got %d", len(tt.walkResponses[oid]), len(res))
+				}
+			}
+			if !reflect.DeepEqual(mock.CallGet(), tt.getCall) {
+				t.Errorf("Expected get call %v, got %v", tt.getCall, mock.CallGet())
+			}
+			if !reflect.DeepEqual(mock.CallWalk(), tt.walkCall) {
+				t.Errorf("Expected walk call %v, got %v", tt.walkCall, mock.CallWalk())
+			}
+		})
+	}
+}


### PR DESCRIPTION
I add the ability to return from Cache for duplicate requests.
If multiple modules are specified and duplicate Metrics are defined, this will not work well.
It may also not be cached if more than one Worker is running.

## generator.yml
```
modules:
  if_mib:
    walk: [ifOperStatus]
    lookups:
      - source_indexes: [ifIndex]
        lookup: ifAlias
      - source_indexes: [ifIndex]
        lookup: 1.3.6.1.2.1.2.2.1.2 # ifDescr
      - source_indexes: [ifIndex]
        lookup: 1.3.6.1.2.1.31.1.1.1.1 # ifName
  if_mib2:
    walk: [ifAdminStatus]
    lookups:
      - source_indexes: [ifIndex]
        lookup: ifAlias
      - source_indexes: [ifIndex]
        lookup: 1.3.6.1.2.1.2.2.1.2 # ifDescr
      - source_indexes: [ifIndex]
        lookup: 1.3.6.1.2.1.31.1.1.1.1 # ifName
```

## testing
It can be seen that the snmp_scrape_packets_sent is decreasing.
```
> curl 'localhost:9116/snmp?target=192.168.64.3&module=if_mib,if_mib2'
# HELP ifAdminStatus The desired state of the interface - 1.3.6.1.2.1.2.2.1.7
# TYPE ifAdminStatus gauge
ifAdminStatus{ifAlias="eth0",ifDescr="Intel Corporation 82540EM Gigabit Ethernet Controller",ifIndex="2",ifName="eth0"} 1
ifAdminStatus{ifAlias="lo",ifDescr="lo",ifIndex="1",ifName="lo"} 1
ifAdminStatus{ifAlias="swp1",ifDescr="Intel Corporation 82540EM Gigabit Ethernet Controller",ifIndex="3",ifName="swp1"} 2
# HELP ifOperStatus The current operational state of the interface - 1.3.6.1.2.1.2.2.1.8
# TYPE ifOperStatus gauge
ifOperStatus{ifAlias="eth0",ifDescr="Intel Corporation 82540EM Gigabit Ethernet Controller",ifIndex="2",ifName="eth0"} 1
ifOperStatus{ifAlias="lo",ifDescr="lo",ifIndex="1",ifName="lo"} 1
ifOperStatus{ifAlias="swp1",ifDescr="Intel Corporation 82540EM Gigabit Ethernet Controller",ifIndex="3",ifName="swp1"} 2
# HELP snmp_scrape_duration_seconds Total SNMP time scrape took (walk and processing).
# TYPE snmp_scrape_duration_seconds gauge
snmp_scrape_duration_seconds{module="if_mib"} 0.030786458
snmp_scrape_duration_seconds{module="if_mib2"} 0.002798083
# HELP snmp_scrape_packets_retried Packets retried for get, bulkget, and walk.
# TYPE snmp_scrape_packets_retried gauge
snmp_scrape_packets_retried{module="if_mib"} 0
snmp_scrape_packets_retried{module="if_mib2"} 0
# HELP snmp_scrape_packets_sent Packets sent for get, bulkget, and walk; including retries.
# TYPE snmp_scrape_packets_sent gauge
snmp_scrape_packets_sent{module="if_mib"} 4
snmp_scrape_packets_sent{module="if_mib2"} 1
# HELP snmp_scrape_pdus_returned PDUs returned from get, bulkget, and walk.
# TYPE snmp_scrape_pdus_returned gauge
snmp_scrape_pdus_returned{module="if_mib"} 12
snmp_scrape_pdus_returned{module="if_mib2"} 12
# HELP snmp_scrape_walk_duration_seconds Time SNMP walk/bulkwalk took.
# TYPE snmp_scrape_walk_duration_seconds gauge
snmp_scrape_walk_duration_seconds{module="if_mib"} 0.030733375
snmp_scrape_walk_duration_seconds{module="if_mib2"} 0.002757625
```