### PR TITLE
fix(parse_errors command): fix mibs directory specification for parse_errors command 

### DIFF
--- a/generator/main.go
+++ b/generator/main.go
@@ -98,7 +98,7 @@ var (
 	failOnParseErrors  = kingpin.Flag("fail-on-parse-errors", "Exit with a non-zero status if there are MIB parsing errors").Default("false").Bool()
 	snmpMIBOpts        = kingpin.Flag("snmp.mibopts", "Toggle various defaults controlling MIB parsing, see snmpwalk --help").String()
 	generateCommand    = kingpin.Command("generate", "Generate snmp.yml from generator.yml")
-	userMibsDir        = generateCommand.Flag("mibs-dir", "Paths to mibs directory").Default("").Short('m').Strings()
+	userMibsDir        = kingpin.Flag("mibs-dir", "Paths to mibs directory").Default("").Short('m').Strings()
 	generatorYmlPath   = generateCommand.Flag("generator-path", "Path to the input generator.yml file").Default("generator.yml").Short('g').String()
 	outputPath         = generateCommand.Flag("output-path", "Path to write the snmp_exporter's config file").Default("snmp.yml").Short('o').String()
 	parseErrorsCommand = kingpin.Command("parse_errors", "Debug: Print the parse errors output by NetSNMP")


### PR DESCRIPTION
@SuperQ, this PR fixes an issue where the `parse_errors` command was not finding the `./mibs` directory, therefore preventing the `parse_errors` command from working properly. This fix also adds support for manually specifying the mibs directory via the `-m` flag in the `parse_errors` command. 

### Context

Previously, the `parse_errors` command was not correctly finding the default `mibs` directory, nor did it allow the user to manually specify a mibs directory. 

The `make generate` (or `generator generate` after building) works by defaulting to the sibling `./mibs` directory, but `make parse_errors` (or `generator parse_errors`) does not. The reason for this, is because the command line parser will interpret an omitted flag as an empty string. So [this line](https://github.com/prometheus/snmp_exporter/blob/4d0572660e7ae79d2c9525efa9d6897cf9218a80/generator/net_snmp.go#L159-L161), when running the `generate` command, is evaluating to a length of `1` with an empty string, therefore defaulting to the `C.netsnmp_get_mib_directory()`. But since this flag wasn't enable for the `parse_errors` command, that same line was evaluating to a length of `0`, and no default was being returned. 
