### PR TITLE
remove extra character from dell iDrac-SMIv1 MIB

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -183,6 +183,8 @@ $(MIBDIR)/.dell:
 	@echo ">> Downloading dell to $(TMP)"
 	@curl $(CURL_OPTS) $(CURL_USER_AGENT) -o $(TMP) $(DELL_URL)
 	@unzip -j -d $(MIBDIR) $(TMP) support/station/mibs/iDRAC-*.mib
+	# There are some additional characters behind MIB end that break parsing
+	@sed -i '$ d' $(MIBDIR)/iDRAC-SMIv1.mib
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.dell
 


### PR DESCRIPTION
The dell idrac mib is currently failing on parsing with the following error. This is because after the `MIB-END` indicitor, there are some broken characters interrupting the parsing.

```
Bad operator (: At line 13878 in ./mibs//iDRAC-SMIv1.mib
```

This can easily be solved by just removing the last line of this MIB.