### PR TITLE
Fix do not expand envvars for empty config fields

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -47,20 +47,26 @@ func LoadFile(paths []string, expandEnvVars bool) (*Config, error) {
 	if expandEnvVars {
 		var err error
 		for i, auth := range cfg.Auths {
-			cfg.Auths[i].Username, err = substituteEnvVariables(auth.Username)
-			if err != nil {
-				return nil, err
+			if auth.Username != "" {
+				cfg.Auths[i].Username, err = substituteEnvVariables(auth.Username)
+				if err != nil {
+					return nil, err
+				}
 			}
-			password, err := substituteEnvVariables(string(auth.Password))
-			if err != nil {
-				return nil, err
+			if auth.Password != "" {
+				password, err := substituteEnvVariables(string(auth.Password))
+				if err != nil {
+					return nil, err
+				}
+				cfg.Auths[i].Password.Set(password)
 			}
-			cfg.Auths[i].Password.Set(password)
-			privPassword, err := substituteEnvVariables(string(auth.PrivPassword))
-			if err != nil {
-				return nil, err
+			if auth.PrivPassword != "" {
+				privPassword, err := substituteEnvVariables(string(auth.PrivPassword))
+				if err != nil {
+					return nil, err
+				}
+				cfg.Auths[i].PrivPassword.Set(privPassword)
 			}
-			cfg.Auths[i].PrivPassword.Set(privPassword)
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -14,7 +14,6 @@
 package main
 
 import (
-	"os"
 	"strings"
 	"testing"
 
@@ -71,12 +70,9 @@ func TestLoadMultipleConfigs(t *testing.T) {
 
 // When all environment variables are present
 func TestEnvSecrets(t *testing.T) {
-	os.Setenv("ENV_USERNAME", "snmp_username")
-	os.Setenv("ENV_PASSWORD", "snmp_password")
-	os.Setenv("ENV_PRIV_PASSWORD", "snmp_priv_password")
-	defer os.Unsetenv("ENV_USERNAME")
-	defer os.Unsetenv("ENV_PASSWORD")
-	defer os.Unsetenv("ENV_PRIV_PASSWORD")
+	t.Setenv("ENV_USERNAME", "snmp_username")
+	t.Setenv("ENV_PASSWORD", "snmp_password")
+	t.Setenv("ENV_PRIV_PASSWORD", "snmp_priv_password")
 
 	sc := &SafeConfig{}
 	err := sc.ReloadConfig([]string{"testdata/snmp-auth-envvars.yml"}, true)
@@ -106,10 +102,8 @@ func TestEnvSecrets(t *testing.T) {
 
 // When environment variable(s) are absent
 func TestEnvSecretsMissing(t *testing.T) {
-	os.Setenv("ENV_PASSWORD", "snmp_password")
-	os.Setenv("ENV_PRIV_PASSWORD", "snmp_priv_password")
-	defer os.Unsetenv("ENV_PASSWORD")
-	defer os.Unsetenv("ENV_PRIV_PASSWORD")
+	t.Setenv("ENV_PASSWORD", "snmp_password")
+	t.Setenv("ENV_PRIV_PASSWORD", "snmp_priv_password")
 
 	sc := &SafeConfig{}
 	err := sc.ReloadConfig([]string{"testdata/snmp-auth-envvars.yml"}, true)
@@ -120,5 +114,14 @@ func TestEnvSecretsMissing(t *testing.T) {
 		} else {
 			t.Errorf("Error loading config %v: %v", "testdata/snmp-auth-envvars.yml", err)
 		}
+	}
+}
+
+// When SNMPv2 was specified without credentials
+func TestEnvSecretsNotSpecified(t *testing.T) {
+	sc := &SafeConfig{}
+	err := sc.ReloadConfig([]string{"testdata/snmp-auth-v2nocreds.yml"}, true)
+	if err != nil {
+		t.Errorf("Error loading config %v: %v", "testdata/snmp-auth-v2nocreds.yml", err)
 	}
 }

--- a/testdata/snmp-auth-v2nocreds.yml
+++ b/testdata/snmp-auth-v2nocreds.yml
@@ -1,0 +1,4 @@
+auths:
+  v2_without_secret:
+    community: mysecret
+    version: 2


### PR DESCRIPTION
Fixes an error loading the config, if any `Auth` section contains an empty `Username`, `Password` or `PrivPassword`
@SuperQ @RichiH

fixes #1145