### PR TITLE
Added 'oids-out-of-order' query parameter

### DIFF
--- a/main.go
+++ b/main.go
@@ -102,6 +102,10 @@ func handler(w http.ResponseWriter, r *http.Request, logger log.Logger, exporter
 		authName = "public_v2"
 	}
 
+	var scraperOptions collector.ScraperOptions
+	oidsOutOfOrder = query.Get("oids-out-of-order")
+	scraperOptions.doNotCheckOIDsReturnedInOrder = (oidsOutOfOrder == "true")
+
 	queryModule := query["module"]
 	if len(queryModule) == 0 {
 		queryModule = append(queryModule, "if_mib")
@@ -141,7 +145,7 @@ func handler(w http.ResponseWriter, r *http.Request, logger log.Logger, exporter
 	sc.RUnlock()
 	logger = log.With(logger, "auth", authName, "target", target)
 	registry := prometheus.NewRegistry()
-	c := collector.New(r.Context(), target, authName, auth, nmodules, logger, exporterMetrics, *concurrency)
+	c := collector.New(r.Context(), target, authName, auth, nmodules, logger, exporterMetrics, *concurrency, scraperOptions)
 	registry.MustRegister(c)
 	// Delegate http serving to Prometheus client library, which will call collector.Collect.
 	h := promhttp.HandlerFor(registry, promhttp.HandlerOpts{})

--- a/scraper/gosnmp.go
+++ b/scraper/gosnmp.go
@@ -31,7 +31,7 @@ type GoSNMPWrapper struct {
 	logger log.Logger
 }
 
-func NewGoSNMP(logger log.Logger, target, srcAddress string) (*GoSNMPWrapper, error) {
+func NewGoSNMP(logger log.Logger, target, srcAddress string, doNotCheckOIDsReturnedInOrder bool) (*GoSNMPWrapper, error) {
 	transport := "udp"
 	if s := strings.SplitN(target, "://", 2); len(s) == 2 {
 		transport = s[0]
@@ -51,6 +51,7 @@ func NewGoSNMP(logger log.Logger, target, srcAddress string) (*GoSNMPWrapper, er
 		Target:    target,
 		Port:      port,
 		LocalAddr: srcAddress,
+		AppOpts:   {"c": doNotCheckOIDsReturnedInOrder},
 	}
 	return &GoSNMPWrapper{c: g, logger: logger}, nil
 }


### PR DESCRIPTION
This PR adds a configuration option to have GoSNMP ignore the "OID not increasing" errors it encountes. This is done by setting `AppOpts["c"]` in GoSNMP (see https://github.com/gosnmp/gosnmp/blob/v1.37.0/gosnmp.go#L139) to `true`.