### PR TITLE
Add a "snmp_context" parameter to the URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ is not necessary within the Prometheus configuration file.
 Metrics concerning the operation of the exporter itself are available at the
 endpoint <http://localhost:9116/metrics>.
 
+It is possible to supply an optional `snmp_context` parameter in the URL, like this:
+<http://localhost:9116/snmp?auth=my_secure_v3&module=ddwrt&target=192.0.0.8&snmp_context=vrf-mgmt>
+The `snmp_context` parameter in the URL would override the `context_name` parameter in the `snmp.yml` file.
+
 ## Multi-Module Handling
 The multi-module functionality allows you to specify multiple modules, enabling the retrieval of information from several modules in a single scrape.
 The concurrency can be specified using the snmp-exporter option `--snmp.module-concurrency` (the default is 1).

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -299,10 +299,11 @@ type Collector struct {
 	logger      log.Logger
 	metrics     Metrics
 	concurrency int
+	snmpContext string
 }
 
-func New(ctx context.Context, target, authName string, auth *config.Auth, modules []*NamedModule, logger log.Logger, metrics Metrics, conc int) *Collector {
-	return &Collector{ctx: ctx, target: target, authName: authName, auth: auth, modules: modules, logger: logger, metrics: metrics, concurrency: conc}
+func New(ctx context.Context, target, authName, snmpContext string, auth *config.Auth, modules []*NamedModule, logger log.Logger, metrics Metrics, conc int) *Collector {
+	return &Collector{ctx: ctx, target: target, authName: authName, auth: auth, modules: modules, logger: logger, metrics: metrics, concurrency: conc, snmpContext: snmpContext}
 }
 
 // Describe implements Prometheus.Collector.
@@ -429,7 +430,7 @@ func (c Collector) Collect(ch chan<- prometheus.Metric) {
 			// Set the options.
 			client.SetOptions(func(g *gosnmp.GoSNMP) {
 				g.Context = ctx
-				c.auth.ConfigureSNMP(g)
+				c.auth.ConfigureSNMP(g, c.snmpContext)
 			})
 			if err = client.Connect(); err != nil {
 				level.Info(logger).Log("msg", "Error connecting to target", "err", err)

--- a/config/config.go
+++ b/config/config.go
@@ -129,7 +129,7 @@ func (c *Module) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 // ConfigureSNMP sets the various version and auth settings.
-func (c Auth) ConfigureSNMP(g *gosnmp.GoSNMP) {
+func (c Auth) ConfigureSNMP(g *gosnmp.GoSNMP, snmpContext string) {
 	switch c.Version {
 	case 1:
 		g.Version = gosnmp.Version1
@@ -139,7 +139,12 @@ func (c Auth) ConfigureSNMP(g *gosnmp.GoSNMP) {
 		g.Version = gosnmp.Version3
 	}
 	g.Community = string(c.Community)
-	g.ContextName = c.ContextName
+
+	if snmpContext == "" {
+		g.ContextName = c.ContextName
+	} else {
+		g.ContextName = snmpContext
+	}
 
 	// v3 security settings.
 	g.SecurityModel = gosnmp.UserSecurityModel


### PR DESCRIPTION
This PR adds a `snmp_context` parameter to the URL, e.g.:
```
/snmp?target=10.11.12.13&auth=mystrongauth&module=snmp_inventory&snmp_context=vrf-mgmt
```

Fixes #1040

This is essentially the same PR as #845.

I have not tested this yet. What do you think would be a good way to test? For now I'll try to set something up with [snmpsim](https://github.com/etingof/snmpsim). Also, I'm not sure if I need to add any unit tests?

@SuperQ @RichiH