### PR TITLE
Fine tune Dell iDrac mib fix for macos

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -184,7 +184,8 @@ $(MIBDIR)/.dell:
 	@curl $(CURL_OPTS) $(CURL_USER_AGENT) -o $(TMP) $(DELL_URL)
 	@unzip -j -d $(MIBDIR) $(TMP) support/station/mibs/iDRAC-*.mib
 	# There are some additional characters behind MIB end that break parsing
-	@sed -i '$ d' $(MIBDIR)/iDRAC-SMIv1.mib
+	@sed '$ d' $(MIBDIR)/iDRAC-SMIv1.mib > $(MIBDIR)/iDRAC-SMIv1.mib.temp
+	@mv $(MIBDIR)/iDRAC-SMIv1.mib.temp $(MIBDIR)/iDRAC-SMIv1.mib
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.dell
 


### PR DESCRIPTION
The previous implementation appearently breaks on the Mac `sed` implementation I noticed. This still applies the fix, but uses an intermediate temporary file that atomically moved in place after the operation.