### PR TITLE
Update Cisco MIBs

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -33,7 +33,7 @@ endif
 
 APC_URL           := https://download.schneider-electric.com/files?p_enDocType=Firmware&p_File_Name=powernet451.mib&p_Doc_Ref=APC_POWERNETMIB_451_EN
 ARISTA_URL        := https://www.arista.com/assets/data/docs/MIBS
-CISCO_URL         := https://raw.githubusercontent.com/cisco/cisco-mibs/2d465cce2de4e67a3561d8e41e4c99b597558d4b/v2
+CISCO_URL         := https://raw.githubusercontent.com/cisco/cisco-mibs/f55dc443daff58dfc86a764047ded2248bb94e12/v2
 DELL_URL          := https://dl.dell.com/FOLDER11196144M/1/Dell-OM-MIBS-11010_A00.zip
 IANA_CHARSET_URL  := https://www.iana.org/assignments/ianacharset-mib/ianacharset-mib
 IANA_IFTYPE_URL   := https://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib

--- a/snmp.yml
+++ b/snmp.yml
@@ -3034,6 +3034,8 @@ modules:
         1: dot11b
         2: dot11a
         4: uwb
+        6: dot116ghz
+        7: dot11xor56ghz
     - name: bsnAPIfPhyChannelNumber
       oid: 1.3.6.1.4.1.14179.2.2.2.1.4
       type: gauge


### PR DESCRIPTION
Update Cisco MIBs to latest upstream commit now that https://github.com/cisco/cisco-mibs/issues/19 is fixed.