### PR TITLE
Deduplicate UCD-SNMP-MIB OIDs

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -210,12 +210,6 @@ modules:
 #
   synology:
     walk:
-      - laNames
-      - laLoadInt
-      - ssCpuUser
-      - ssCpuSystem
-      - ssCpuIdle
-      - memory
       - 1.3.6.1.4.1.6574.1       # synoSystem
       - 1.3.6.1.4.1.6574.2       # synoDisk
       - 1.3.6.1.4.1.6574.3       # synoRaid
@@ -240,9 +234,6 @@ modules:
         drop_source_indexes: true
       - source_indexes: [raidIndex]
         lookup: raidName
-        drop_source_indexes: true
-      - source_indexes: [laIndex]
-        lookup: laNames
         drop_source_indexes: true
     overrides:
       diskModel:
@@ -270,23 +261,29 @@ modules:
       version:
         type: DisplayString
 
-# DD-WRT
+# UCD-SNMP-MIB
 #
-# The list of SNMP OIDs to care about for DD-WRT can be found here: https://www.dd-wrt.com/wiki/index.php/SNMP#Known_OID.C2.B4s_via_SNMP
+# University of California, Davis extensions. Commonly used for host
+# metrics. For example, Linux-based systems, DD-WRT, Synology,
+# Mikrotik, Kemp LoadMaster, etc.
 #
-# Tested on  DD-WRT v3.0-r31825 (04/06/17) with an ASUS RT-AC66U
+# http://www.net-snmp.org/docs/mibs/UCD-SNMP-MIB.txt
 #
-  ddwrt:
+  ucd_la_table:
     walk:
-      - 1.3.6.1.4.1.2021.4 # memory
-      - 1.3.6.1.4.1.2021.10.1.1 # laIndex
       - 1.3.6.1.4.1.2021.10.1.2 # laNames
       - 1.3.6.1.4.1.2021.10.1.5 # laLoadInt
-      - 1.3.6.1.4.1.2021.11 # systemStats
+      - 1.3.6.1.4.1.2021.10.1.6 # laLoadFloat
     lookups:
       - source_indexes: [laIndex]
         lookup: laNames
         drop_source_indexes: true
+  ucd_memory:
+    walk:
+      - 1.3.6.1.4.1.2021.4 # memory
+  ucd_system_stats:
+    walk:
+      - 1.3.6.1.4.1.2021.11 # systemStats
 
 # Ubiquiti / AirFiber
 #
@@ -366,12 +363,6 @@ modules:
 # https://support.kemptechnologies.com/hc/en-us/articles/202375677-LoadMaster-SNMP-MIB-s
   kemp_loadmaster:
     walk:
-      - laNames
-      - laLoadInt
-      - ssCpuUser
-      - ssCpuSystem
-      - ssCpuIdle
-      - memory
       - 1.3.6.1.4.1.12196.13.0 # VSdesc
       - 1.3.6.1.4.1.12196.13.1 # VSentry
       - 1.3.6.1.4.1.12196.13.2 # RSentry
@@ -558,7 +549,6 @@ modules:
 # http://download2.mikrotik.com/Mikrotik.mib
   mikrotik:
     walk:
-      - laIndex
       - sysDescr
       - mikrotik
     lookups:
@@ -566,9 +556,6 @@ modules:
         lookup: ifName
       - source_indexes: [mtxrInterfaceStatsIndex]
         lookup: ifName
-      - source_indexes: [laIndex]
-        lookup: laNames
-        drop_source_indexes: true
       - source_indexes: [mtxrGaugeIndex]
         lookup: mtxrGaugeName
         drop_source_indexes: true

--- a/snmp.yml
+++ b/snmp.yml
@@ -6936,325 +6936,6 @@ modules:
       enum_values:
         1: atsRedundancyLost
         2: atsFullyRedundant
-  ddwrt:
-    walk:
-    - 1.3.6.1.4.1.2021.10.1.1
-    - 1.3.6.1.4.1.2021.10.1.2
-    - 1.3.6.1.4.1.2021.10.1.5
-    - 1.3.6.1.4.1.2021.11
-    - 1.3.6.1.4.1.2021.4
-    metrics:
-    - name: laIndex
-      oid: 1.3.6.1.4.1.2021.10.1.1
-      type: gauge
-      help: reference index/row number for each observed loadave. - 1.3.6.1.4.1.2021.10.1.1
-      indexes:
-      - labelname: laIndex
-        type: gauge
-      lookups:
-      - labels:
-        - laIndex
-        labelname: laNames
-        oid: 1.3.6.1.4.1.2021.10.1.2
-        type: DisplayString
-      - labels: []
-        labelname: laIndex
-    - name: laNames
-      oid: 1.3.6.1.4.1.2021.10.1.2
-      type: DisplayString
-      help: The list of loadave names we're watching. - 1.3.6.1.4.1.2021.10.1.2
-      indexes:
-      - labelname: laIndex
-        type: gauge
-      lookups:
-      - labels:
-        - laIndex
-        labelname: laNames
-        oid: 1.3.6.1.4.1.2021.10.1.2
-        type: DisplayString
-      - labels: []
-        labelname: laIndex
-    - name: laLoadInt
-      oid: 1.3.6.1.4.1.2021.10.1.5
-      type: gauge
-      help: The 1,5 and 15 minute load averages as an integer - 1.3.6.1.4.1.2021.10.1.5
-      indexes:
-      - labelname: laIndex
-        type: gauge
-      lookups:
-      - labels:
-        - laIndex
-        labelname: laNames
-        oid: 1.3.6.1.4.1.2021.10.1.2
-        type: DisplayString
-      - labels: []
-        labelname: laIndex
-    - name: ssIndex
-      oid: 1.3.6.1.4.1.2021.11.1
-      type: gauge
-      help: Bogus Index - 1.3.6.1.4.1.2021.11.1
-    - name: ssErrorName
-      oid: 1.3.6.1.4.1.2021.11.2
-      type: DisplayString
-      help: Bogus Name - 1.3.6.1.4.1.2021.11.2
-    - name: ssSwapIn
-      oid: 1.3.6.1.4.1.2021.11.3
-      type: gauge
-      help: The average amount of memory swapped in from disk, calculated over the
-        last minute. - 1.3.6.1.4.1.2021.11.3
-    - name: ssSwapOut
-      oid: 1.3.6.1.4.1.2021.11.4
-      type: gauge
-      help: The average amount of memory swapped out to disk, calculated over the
-        last minute. - 1.3.6.1.4.1.2021.11.4
-    - name: ssIOSent
-      oid: 1.3.6.1.4.1.2021.11.5
-      type: gauge
-      help: The average amount of data written to disk or other block device, calculated
-        over the last minute - 1.3.6.1.4.1.2021.11.5
-    - name: ssIOReceive
-      oid: 1.3.6.1.4.1.2021.11.6
-      type: gauge
-      help: The average amount of data read from disk or other block device, calculated
-        over the last minute - 1.3.6.1.4.1.2021.11.6
-    - name: ssSysInterrupts
-      oid: 1.3.6.1.4.1.2021.11.7
-      type: gauge
-      help: The average rate of interrupts processed (including the clock) calculated
-        over the last minute - 1.3.6.1.4.1.2021.11.7
-    - name: ssSysContext
-      oid: 1.3.6.1.4.1.2021.11.8
-      type: gauge
-      help: The average rate of context switches, calculated over the last minute
-        - 1.3.6.1.4.1.2021.11.8
-    - name: ssCpuUser
-      oid: 1.3.6.1.4.1.2021.11.9
-      type: gauge
-      help: The percentage of CPU time spent processing user-level code, calculated
-        over the last minute - 1.3.6.1.4.1.2021.11.9
-    - name: ssCpuSystem
-      oid: 1.3.6.1.4.1.2021.11.10
-      type: gauge
-      help: The percentage of CPU time spent processing system-level code, calculated
-        over the last minute - 1.3.6.1.4.1.2021.11.10
-    - name: ssCpuIdle
-      oid: 1.3.6.1.4.1.2021.11.11
-      type: gauge
-      help: The percentage of processor time spent idle, calculated over the last
-        minute - 1.3.6.1.4.1.2021.11.11
-    - name: ssCpuRawUser
-      oid: 1.3.6.1.4.1.2021.11.50
-      type: counter
-      help: The number of 'ticks' (typically 1/100s) spent processing user-level code
-        - 1.3.6.1.4.1.2021.11.50
-    - name: ssCpuRawNice
-      oid: 1.3.6.1.4.1.2021.11.51
-      type: counter
-      help: The number of 'ticks' (typically 1/100s) spent processing reduced-priority
-        code - 1.3.6.1.4.1.2021.11.51
-    - name: ssCpuRawSystem
-      oid: 1.3.6.1.4.1.2021.11.52
-      type: counter
-      help: The number of 'ticks' (typically 1/100s) spent processing system-level
-        code - 1.3.6.1.4.1.2021.11.52
-    - name: ssCpuRawIdle
-      oid: 1.3.6.1.4.1.2021.11.53
-      type: counter
-      help: The number of 'ticks' (typically 1/100s) spent idle - 1.3.6.1.4.1.2021.11.53
-    - name: ssCpuRawWait
-      oid: 1.3.6.1.4.1.2021.11.54
-      type: counter
-      help: The number of 'ticks' (typically 1/100s) spent waiting for IO - 1.3.6.1.4.1.2021.11.54
-    - name: ssCpuRawKernel
-      oid: 1.3.6.1.4.1.2021.11.55
-      type: counter
-      help: The number of 'ticks' (typically 1/100s) spent processing kernel-level
-        code - 1.3.6.1.4.1.2021.11.55
-    - name: ssCpuRawInterrupt
-      oid: 1.3.6.1.4.1.2021.11.56
-      type: counter
-      help: The number of 'ticks' (typically 1/100s) spent processing hardware interrupts
-        - 1.3.6.1.4.1.2021.11.56
-    - name: ssIORawSent
-      oid: 1.3.6.1.4.1.2021.11.57
-      type: counter
-      help: Number of blocks sent to a block device - 1.3.6.1.4.1.2021.11.57
-    - name: ssIORawReceived
-      oid: 1.3.6.1.4.1.2021.11.58
-      type: counter
-      help: Number of blocks received from a block device - 1.3.6.1.4.1.2021.11.58
-    - name: ssRawInterrupts
-      oid: 1.3.6.1.4.1.2021.11.59
-      type: counter
-      help: Number of interrupts processed - 1.3.6.1.4.1.2021.11.59
-    - name: ssRawContexts
-      oid: 1.3.6.1.4.1.2021.11.60
-      type: counter
-      help: Number of context switches - 1.3.6.1.4.1.2021.11.60
-    - name: ssCpuRawSoftIRQ
-      oid: 1.3.6.1.4.1.2021.11.61
-      type: counter
-      help: The number of 'ticks' (typically 1/100s) spent processing software interrupts
-        - 1.3.6.1.4.1.2021.11.61
-    - name: ssRawSwapIn
-      oid: 1.3.6.1.4.1.2021.11.62
-      type: counter
-      help: Number of blocks swapped in - 1.3.6.1.4.1.2021.11.62
-    - name: ssRawSwapOut
-      oid: 1.3.6.1.4.1.2021.11.63
-      type: counter
-      help: Number of blocks swapped out - 1.3.6.1.4.1.2021.11.63
-    - name: ssCpuRawSteal
-      oid: 1.3.6.1.4.1.2021.11.64
-      type: counter
-      help: The number of 'ticks' (typically 1/100s) spent by the hypervisor code
-        to run other VMs even though the CPU in the current VM had something runnable
-        - 1.3.6.1.4.1.2021.11.64
-    - name: ssCpuRawGuest
-      oid: 1.3.6.1.4.1.2021.11.65
-      type: counter
-      help: The number of 'ticks' (typically 1/100s) spent by the CPU to run a virtual
-        CPU (guest) - 1.3.6.1.4.1.2021.11.65
-    - name: ssCpuRawGuestNice
-      oid: 1.3.6.1.4.1.2021.11.66
-      type: counter
-      help: The number of 'ticks' (typically 1/100s) spent by the CPU to run a niced
-        virtual CPU (guest) - 1.3.6.1.4.1.2021.11.66
-    - name: ssCpuNumCpus
-      oid: 1.3.6.1.4.1.2021.11.67
-      type: gauge
-      help: The number of processors, as counted by the agent - 1.3.6.1.4.1.2021.11.67
-    - name: memIndex
-      oid: 1.3.6.1.4.1.2021.4.1
-      type: gauge
-      help: Bogus Index - 1.3.6.1.4.1.2021.4.1
-    - name: memErrorName
-      oid: 1.3.6.1.4.1.2021.4.2
-      type: DisplayString
-      help: Bogus Name - 1.3.6.1.4.1.2021.4.2
-    - name: memTotalSwap
-      oid: 1.3.6.1.4.1.2021.4.3
-      type: gauge
-      help: The total amount of swap space configured for this host. - 1.3.6.1.4.1.2021.4.3
-    - name: memAvailSwap
-      oid: 1.3.6.1.4.1.2021.4.4
-      type: gauge
-      help: The amount of swap space currently unused or available. - 1.3.6.1.4.1.2021.4.4
-    - name: memTotalReal
-      oid: 1.3.6.1.4.1.2021.4.5
-      type: gauge
-      help: The total amount of real/physical memory installed on this host. - 1.3.6.1.4.1.2021.4.5
-    - name: memAvailReal
-      oid: 1.3.6.1.4.1.2021.4.6
-      type: gauge
-      help: The amount of real/physical memory currently unused or available. - 1.3.6.1.4.1.2021.4.6
-    - name: memTotalSwapTXT
-      oid: 1.3.6.1.4.1.2021.4.7
-      type: gauge
-      help: The total amount of swap space or virtual memory allocated for text pages
-        on this host - 1.3.6.1.4.1.2021.4.7
-    - name: memAvailSwapTXT
-      oid: 1.3.6.1.4.1.2021.4.8
-      type: gauge
-      help: The amount of swap space or virtual memory currently being used by text
-        pages on this host - 1.3.6.1.4.1.2021.4.8
-    - name: memTotalRealTXT
-      oid: 1.3.6.1.4.1.2021.4.9
-      type: gauge
-      help: The total amount of real/physical memory allocated for text pages on this
-        host - 1.3.6.1.4.1.2021.4.9
-    - name: memAvailRealTXT
-      oid: 1.3.6.1.4.1.2021.4.10
-      type: gauge
-      help: The amount of real/physical memory currently being used by text pages
-        on this host - 1.3.6.1.4.1.2021.4.10
-    - name: memTotalFree
-      oid: 1.3.6.1.4.1.2021.4.11
-      type: gauge
-      help: The total amount of memory free or available for use on this host - 1.3.6.1.4.1.2021.4.11
-    - name: memMinimumSwap
-      oid: 1.3.6.1.4.1.2021.4.12
-      type: gauge
-      help: The minimum amount of swap space expected to be kept free or available
-        during normal operation of this host - 1.3.6.1.4.1.2021.4.12
-    - name: memShared
-      oid: 1.3.6.1.4.1.2021.4.13
-      type: gauge
-      help: The total amount of real or virtual memory currently allocated for use
-        as shared memory - 1.3.6.1.4.1.2021.4.13
-    - name: memBuffer
-      oid: 1.3.6.1.4.1.2021.4.14
-      type: gauge
-      help: The total amount of real or virtual memory currently allocated for use
-        as memory buffers - 1.3.6.1.4.1.2021.4.14
-    - name: memCached
-      oid: 1.3.6.1.4.1.2021.4.15
-      type: gauge
-      help: The total amount of real or virtual memory currently allocated for use
-        as cached memory - 1.3.6.1.4.1.2021.4.15
-    - name: memUsedSwapTXT
-      oid: 1.3.6.1.4.1.2021.4.16
-      type: gauge
-      help: The amount of swap space or virtual memory currently being used by text
-        pages on this host - 1.3.6.1.4.1.2021.4.16
-    - name: memUsedRealTXT
-      oid: 1.3.6.1.4.1.2021.4.17
-      type: gauge
-      help: The amount of real/physical memory currently being used by text pages
-        on this host - 1.3.6.1.4.1.2021.4.17
-    - name: memTotalSwapX
-      oid: 1.3.6.1.4.1.2021.4.18
-      type: counter
-      help: The total amount of swap space configured for this host. - 1.3.6.1.4.1.2021.4.18
-    - name: memAvailSwapX
-      oid: 1.3.6.1.4.1.2021.4.19
-      type: counter
-      help: The amount of swap space currently unused or available. - 1.3.6.1.4.1.2021.4.19
-    - name: memTotalRealX
-      oid: 1.3.6.1.4.1.2021.4.20
-      type: counter
-      help: The total amount of real/physical memory installed on this host. - 1.3.6.1.4.1.2021.4.20
-    - name: memAvailRealX
-      oid: 1.3.6.1.4.1.2021.4.21
-      type: counter
-      help: The amount of real/physical memory currently unused or available. - 1.3.6.1.4.1.2021.4.21
-    - name: memTotalFreeX
-      oid: 1.3.6.1.4.1.2021.4.22
-      type: counter
-      help: The total amount of memory free or available for use on this host - 1.3.6.1.4.1.2021.4.22
-    - name: memMinimumSwapX
-      oid: 1.3.6.1.4.1.2021.4.23
-      type: counter
-      help: The minimum amount of swap space expected to be kept free or available
-        during normal operation of this host - 1.3.6.1.4.1.2021.4.23
-    - name: memSharedX
-      oid: 1.3.6.1.4.1.2021.4.24
-      type: counter
-      help: The total amount of real or virtual memory currently allocated for use
-        as shared memory - 1.3.6.1.4.1.2021.4.24
-    - name: memBufferX
-      oid: 1.3.6.1.4.1.2021.4.25
-      type: counter
-      help: The total amount of real or virtual memory currently allocated for use
-        as memory buffers - 1.3.6.1.4.1.2021.4.25
-    - name: memCachedX
-      oid: 1.3.6.1.4.1.2021.4.26
-      type: counter
-      help: The total amount of real or virtual memory currently allocated for use
-        as cached memory - 1.3.6.1.4.1.2021.4.26
-    - name: memSwapError
-      oid: 1.3.6.1.4.1.2021.4.100
-      type: gauge
-      help: Indicates whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
-        is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.100
-      enum_values:
-        0: noError
-        1: error
-    - name: memSwapErrorMsg
-      oid: 1.3.6.1.4.1.2021.4.101
-      type: DisplayString
-      help: Describes whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
-        is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.101
   dell:
     walk:
     - 1.3.6.1.4.1.674.10892.5.2
@@ -17096,13 +16777,6 @@ modules:
     - 1.3.6.1.4.1.12196.13.0
     - 1.3.6.1.4.1.12196.13.1
     - 1.3.6.1.4.1.12196.13.2
-    - 1.3.6.1.4.1.2021.10.1.2
-    - 1.3.6.1.4.1.2021.10.1.5
-    - 1.3.6.1.4.1.2021.4
-    get:
-    - 1.3.6.1.4.1.2021.11.10.0
-    - 1.3.6.1.4.1.2021.11.11.0
-    - 1.3.6.1.4.1.2021.11.9.0
     metrics:
     - name: version
       oid: 1.3.6.1.4.1.12196.13.0.1
@@ -17694,166 +17368,6 @@ modules:
       indexes:
       - labelname: rSIdx
         type: gauge
-    - name: laNames
-      oid: 1.3.6.1.4.1.2021.10.1.2
-      type: DisplayString
-      help: The list of loadave names we're watching. - 1.3.6.1.4.1.2021.10.1.2
-      indexes:
-      - labelname: laIndex
-        type: gauge
-    - name: laLoadInt
-      oid: 1.3.6.1.4.1.2021.10.1.5
-      type: gauge
-      help: The 1,5 and 15 minute load averages as an integer - 1.3.6.1.4.1.2021.10.1.5
-      indexes:
-      - labelname: laIndex
-        type: gauge
-    - name: ssCpuSystem
-      oid: 1.3.6.1.4.1.2021.11.10
-      type: gauge
-      help: The percentage of CPU time spent processing system-level code, calculated
-        over the last minute - 1.3.6.1.4.1.2021.11.10
-    - name: ssCpuIdle
-      oid: 1.3.6.1.4.1.2021.11.11
-      type: gauge
-      help: The percentage of processor time spent idle, calculated over the last
-        minute - 1.3.6.1.4.1.2021.11.11
-    - name: ssCpuUser
-      oid: 1.3.6.1.4.1.2021.11.9
-      type: gauge
-      help: The percentage of CPU time spent processing user-level code, calculated
-        over the last minute - 1.3.6.1.4.1.2021.11.9
-    - name: memIndex
-      oid: 1.3.6.1.4.1.2021.4.1
-      type: gauge
-      help: Bogus Index - 1.3.6.1.4.1.2021.4.1
-    - name: memErrorName
-      oid: 1.3.6.1.4.1.2021.4.2
-      type: DisplayString
-      help: Bogus Name - 1.3.6.1.4.1.2021.4.2
-    - name: memTotalSwap
-      oid: 1.3.6.1.4.1.2021.4.3
-      type: gauge
-      help: The total amount of swap space configured for this host. - 1.3.6.1.4.1.2021.4.3
-    - name: memAvailSwap
-      oid: 1.3.6.1.4.1.2021.4.4
-      type: gauge
-      help: The amount of swap space currently unused or available. - 1.3.6.1.4.1.2021.4.4
-    - name: memTotalReal
-      oid: 1.3.6.1.4.1.2021.4.5
-      type: gauge
-      help: The total amount of real/physical memory installed on this host. - 1.3.6.1.4.1.2021.4.5
-    - name: memAvailReal
-      oid: 1.3.6.1.4.1.2021.4.6
-      type: gauge
-      help: The amount of real/physical memory currently unused or available. - 1.3.6.1.4.1.2021.4.6
-    - name: memTotalSwapTXT
-      oid: 1.3.6.1.4.1.2021.4.7
-      type: gauge
-      help: The total amount of swap space or virtual memory allocated for text pages
-        on this host - 1.3.6.1.4.1.2021.4.7
-    - name: memAvailSwapTXT
-      oid: 1.3.6.1.4.1.2021.4.8
-      type: gauge
-      help: The amount of swap space or virtual memory currently being used by text
-        pages on this host - 1.3.6.1.4.1.2021.4.8
-    - name: memTotalRealTXT
-      oid: 1.3.6.1.4.1.2021.4.9
-      type: gauge
-      help: The total amount of real/physical memory allocated for text pages on this
-        host - 1.3.6.1.4.1.2021.4.9
-    - name: memAvailRealTXT
-      oid: 1.3.6.1.4.1.2021.4.10
-      type: gauge
-      help: The amount of real/physical memory currently being used by text pages
-        on this host - 1.3.6.1.4.1.2021.4.10
-    - name: memTotalFree
-      oid: 1.3.6.1.4.1.2021.4.11
-      type: gauge
-      help: The total amount of memory free or available for use on this host - 1.3.6.1.4.1.2021.4.11
-    - name: memMinimumSwap
-      oid: 1.3.6.1.4.1.2021.4.12
-      type: gauge
-      help: The minimum amount of swap space expected to be kept free or available
-        during normal operation of this host - 1.3.6.1.4.1.2021.4.12
-    - name: memShared
-      oid: 1.3.6.1.4.1.2021.4.13
-      type: gauge
-      help: The total amount of real or virtual memory currently allocated for use
-        as shared memory - 1.3.6.1.4.1.2021.4.13
-    - name: memBuffer
-      oid: 1.3.6.1.4.1.2021.4.14
-      type: gauge
-      help: The total amount of real or virtual memory currently allocated for use
-        as memory buffers - 1.3.6.1.4.1.2021.4.14
-    - name: memCached
-      oid: 1.3.6.1.4.1.2021.4.15
-      type: gauge
-      help: The total amount of real or virtual memory currently allocated for use
-        as cached memory - 1.3.6.1.4.1.2021.4.15
-    - name: memUsedSwapTXT
-      oid: 1.3.6.1.4.1.2021.4.16
-      type: gauge
-      help: The amount of swap space or virtual memory currently being used by text
-        pages on this host - 1.3.6.1.4.1.2021.4.16
-    - name: memUsedRealTXT
-      oid: 1.3.6.1.4.1.2021.4.17
-      type: gauge
-      help: The amount of real/physical memory currently being used by text pages
-        on this host - 1.3.6.1.4.1.2021.4.17
-    - name: memTotalSwapX
-      oid: 1.3.6.1.4.1.2021.4.18
-      type: counter
-      help: The total amount of swap space configured for this host. - 1.3.6.1.4.1.2021.4.18
-    - name: memAvailSwapX
-      oid: 1.3.6.1.4.1.2021.4.19
-      type: counter
-      help: The amount of swap space currently unused or available. - 1.3.6.1.4.1.2021.4.19
-    - name: memTotalRealX
-      oid: 1.3.6.1.4.1.2021.4.20
-      type: counter
-      help: The total amount of real/physical memory installed on this host. - 1.3.6.1.4.1.2021.4.20
-    - name: memAvailRealX
-      oid: 1.3.6.1.4.1.2021.4.21
-      type: counter
-      help: The amount of real/physical memory currently unused or available. - 1.3.6.1.4.1.2021.4.21
-    - name: memTotalFreeX
-      oid: 1.3.6.1.4.1.2021.4.22
-      type: counter
-      help: The total amount of memory free or available for use on this host - 1.3.6.1.4.1.2021.4.22
-    - name: memMinimumSwapX
-      oid: 1.3.6.1.4.1.2021.4.23
-      type: counter
-      help: The minimum amount of swap space expected to be kept free or available
-        during normal operation of this host - 1.3.6.1.4.1.2021.4.23
-    - name: memSharedX
-      oid: 1.3.6.1.4.1.2021.4.24
-      type: counter
-      help: The total amount of real or virtual memory currently allocated for use
-        as shared memory - 1.3.6.1.4.1.2021.4.24
-    - name: memBufferX
-      oid: 1.3.6.1.4.1.2021.4.25
-      type: counter
-      help: The total amount of real or virtual memory currently allocated for use
-        as memory buffers - 1.3.6.1.4.1.2021.4.25
-    - name: memCachedX
-      oid: 1.3.6.1.4.1.2021.4.26
-      type: counter
-      help: The total amount of real or virtual memory currently allocated for use
-        as cached memory - 1.3.6.1.4.1.2021.4.26
-    - name: memSwapError
-      oid: 1.3.6.1.4.1.2021.4.100
-      type: gauge
-      help: Indicates whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
-        is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.100
-      enum_values:
-        0: noError
-        1: error
-    - name: memSwapErrorMsg
-      oid: 1.3.6.1.4.1.2021.4.101
-      type: DisplayString
-      help: Describes whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
-        is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.101
   liebert_pdu:
     walk:
     - 1.3.6.1.4.1.476.1.42.3.8.20
@@ -20364,8 +19878,6 @@ modules:
     walk:
     - 1.3.6.1.2.1.31.1.1.1.1
     - 1.3.6.1.4.1.14988
-    - 1.3.6.1.4.1.2021.10.1.1
-    - 1.3.6.1.4.1.2021.10.1.2
     get:
     - 1.3.6.1.2.1.1.1.0
     metrics:
@@ -23436,21 +22948,6 @@ modules:
       indexes:
       - labelname: mtxrIkeSAIndex
         type: gauge
-    - name: laIndex
-      oid: 1.3.6.1.4.1.2021.10.1.1
-      type: gauge
-      help: reference index/row number for each observed loadave. - 1.3.6.1.4.1.2021.10.1.1
-      indexes:
-      - labelname: laIndex
-        type: gauge
-      lookups:
-      - labels:
-        - laIndex
-        labelname: laNames
-        oid: 1.3.6.1.4.1.2021.10.1.2
-        type: DisplayString
-      - labels: []
-        labelname: laIndex
   nec_ix:
     walk:
     - 1.3.6.1.4.1.119.2.3.84.11
@@ -30337,9 +29834,6 @@ modules:
         23: conflict
   synology:
     walk:
-    - 1.3.6.1.4.1.2021.10.1.2
-    - 1.3.6.1.4.1.2021.10.1.5
-    - 1.3.6.1.4.1.2021.4
     - 1.3.6.1.4.1.6574.1
     - 1.3.6.1.4.1.6574.101
     - 1.3.6.1.4.1.6574.102
@@ -30349,187 +29843,7 @@ modules:
     - 1.3.6.1.4.1.6574.4
     - 1.3.6.1.4.1.6574.5
     - 1.3.6.1.4.1.6574.6
-    get:
-    - 1.3.6.1.4.1.2021.11.10.0
-    - 1.3.6.1.4.1.2021.11.11.0
-    - 1.3.6.1.4.1.2021.11.9.0
     metrics:
-    - name: laNames
-      oid: 1.3.6.1.4.1.2021.10.1.2
-      type: DisplayString
-      help: The list of loadave names we're watching. - 1.3.6.1.4.1.2021.10.1.2
-      indexes:
-      - labelname: laIndex
-        type: gauge
-      lookups:
-      - labels:
-        - laIndex
-        labelname: laNames
-        oid: 1.3.6.1.4.1.2021.10.1.2
-        type: DisplayString
-      - labels: []
-        labelname: laIndex
-    - name: laLoadInt
-      oid: 1.3.6.1.4.1.2021.10.1.5
-      type: gauge
-      help: The 1,5 and 15 minute load averages as an integer - 1.3.6.1.4.1.2021.10.1.5
-      indexes:
-      - labelname: laIndex
-        type: gauge
-      lookups:
-      - labels:
-        - laIndex
-        labelname: laNames
-        oid: 1.3.6.1.4.1.2021.10.1.2
-        type: DisplayString
-      - labels: []
-        labelname: laIndex
-    - name: ssCpuSystem
-      oid: 1.3.6.1.4.1.2021.11.10
-      type: gauge
-      help: The percentage of CPU time spent processing system-level code, calculated
-        over the last minute - 1.3.6.1.4.1.2021.11.10
-    - name: ssCpuIdle
-      oid: 1.3.6.1.4.1.2021.11.11
-      type: gauge
-      help: The percentage of processor time spent idle, calculated over the last
-        minute - 1.3.6.1.4.1.2021.11.11
-    - name: ssCpuUser
-      oid: 1.3.6.1.4.1.2021.11.9
-      type: gauge
-      help: The percentage of CPU time spent processing user-level code, calculated
-        over the last minute - 1.3.6.1.4.1.2021.11.9
-    - name: memIndex
-      oid: 1.3.6.1.4.1.2021.4.1
-      type: gauge
-      help: Bogus Index - 1.3.6.1.4.1.2021.4.1
-    - name: memErrorName
-      oid: 1.3.6.1.4.1.2021.4.2
-      type: DisplayString
-      help: Bogus Name - 1.3.6.1.4.1.2021.4.2
-    - name: memTotalSwap
-      oid: 1.3.6.1.4.1.2021.4.3
-      type: gauge
-      help: The total amount of swap space configured for this host. - 1.3.6.1.4.1.2021.4.3
-    - name: memAvailSwap
-      oid: 1.3.6.1.4.1.2021.4.4
-      type: gauge
-      help: The amount of swap space currently unused or available. - 1.3.6.1.4.1.2021.4.4
-    - name: memTotalReal
-      oid: 1.3.6.1.4.1.2021.4.5
-      type: gauge
-      help: The total amount of real/physical memory installed on this host. - 1.3.6.1.4.1.2021.4.5
-    - name: memAvailReal
-      oid: 1.3.6.1.4.1.2021.4.6
-      type: gauge
-      help: The amount of real/physical memory currently unused or available. - 1.3.6.1.4.1.2021.4.6
-    - name: memTotalSwapTXT
-      oid: 1.3.6.1.4.1.2021.4.7
-      type: gauge
-      help: The total amount of swap space or virtual memory allocated for text pages
-        on this host - 1.3.6.1.4.1.2021.4.7
-    - name: memAvailSwapTXT
-      oid: 1.3.6.1.4.1.2021.4.8
-      type: gauge
-      help: The amount of swap space or virtual memory currently being used by text
-        pages on this host - 1.3.6.1.4.1.2021.4.8
-    - name: memTotalRealTXT
-      oid: 1.3.6.1.4.1.2021.4.9
-      type: gauge
-      help: The total amount of real/physical memory allocated for text pages on this
-        host - 1.3.6.1.4.1.2021.4.9
-    - name: memAvailRealTXT
-      oid: 1.3.6.1.4.1.2021.4.10
-      type: gauge
-      help: The amount of real/physical memory currently being used by text pages
-        on this host - 1.3.6.1.4.1.2021.4.10
-    - name: memTotalFree
-      oid: 1.3.6.1.4.1.2021.4.11
-      type: gauge
-      help: The total amount of memory free or available for use on this host - 1.3.6.1.4.1.2021.4.11
-    - name: memMinimumSwap
-      oid: 1.3.6.1.4.1.2021.4.12
-      type: gauge
-      help: The minimum amount of swap space expected to be kept free or available
-        during normal operation of this host - 1.3.6.1.4.1.2021.4.12
-    - name: memShared
-      oid: 1.3.6.1.4.1.2021.4.13
-      type: gauge
-      help: The total amount of real or virtual memory currently allocated for use
-        as shared memory - 1.3.6.1.4.1.2021.4.13
-    - name: memBuffer
-      oid: 1.3.6.1.4.1.2021.4.14
-      type: gauge
-      help: The total amount of real or virtual memory currently allocated for use
-        as memory buffers - 1.3.6.1.4.1.2021.4.14
-    - name: memCached
-      oid: 1.3.6.1.4.1.2021.4.15
-      type: gauge
-      help: The total amount of real or virtual memory currently allocated for use
-        as cached memory - 1.3.6.1.4.1.2021.4.15
-    - name: memUsedSwapTXT
-      oid: 1.3.6.1.4.1.2021.4.16
-      type: gauge
-      help: The amount of swap space or virtual memory currently being used by text
-        pages on this host - 1.3.6.1.4.1.2021.4.16
-    - name: memUsedRealTXT
-      oid: 1.3.6.1.4.1.2021.4.17
-      type: gauge
-      help: The amount of real/physical memory currently being used by text pages
-        on this host - 1.3.6.1.4.1.2021.4.17
-    - name: memTotalSwapX
-      oid: 1.3.6.1.4.1.2021.4.18
-      type: counter
-      help: The total amount of swap space configured for this host. - 1.3.6.1.4.1.2021.4.18
-    - name: memAvailSwapX
-      oid: 1.3.6.1.4.1.2021.4.19
-      type: counter
-      help: The amount of swap space currently unused or available. - 1.3.6.1.4.1.2021.4.19
-    - name: memTotalRealX
-      oid: 1.3.6.1.4.1.2021.4.20
-      type: counter
-      help: The total amount of real/physical memory installed on this host. - 1.3.6.1.4.1.2021.4.20
-    - name: memAvailRealX
-      oid: 1.3.6.1.4.1.2021.4.21
-      type: counter
-      help: The amount of real/physical memory currently unused or available. - 1.3.6.1.4.1.2021.4.21
-    - name: memTotalFreeX
-      oid: 1.3.6.1.4.1.2021.4.22
-      type: counter
-      help: The total amount of memory free or available for use on this host - 1.3.6.1.4.1.2021.4.22
-    - name: memMinimumSwapX
-      oid: 1.3.6.1.4.1.2021.4.23
-      type: counter
-      help: The minimum amount of swap space expected to be kept free or available
-        during normal operation of this host - 1.3.6.1.4.1.2021.4.23
-    - name: memSharedX
-      oid: 1.3.6.1.4.1.2021.4.24
-      type: counter
-      help: The total amount of real or virtual memory currently allocated for use
-        as shared memory - 1.3.6.1.4.1.2021.4.24
-    - name: memBufferX
-      oid: 1.3.6.1.4.1.2021.4.25
-      type: counter
-      help: The total amount of real or virtual memory currently allocated for use
-        as memory buffers - 1.3.6.1.4.1.2021.4.25
-    - name: memCachedX
-      oid: 1.3.6.1.4.1.2021.4.26
-      type: counter
-      help: The total amount of real or virtual memory currently allocated for use
-        as cached memory - 1.3.6.1.4.1.2021.4.26
-    - name: memSwapError
-      oid: 1.3.6.1.4.1.2021.4.100
-      type: gauge
-      help: Indicates whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
-        is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.100
-      enum_values:
-        0: noError
-        1: error
-    - name: memSwapErrorMsg
-      oid: 1.3.6.1.4.1.2021.4.101
-      type: DisplayString
-      help: Describes whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
-        is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.101
     - name: systemStatus
       oid: 1.3.6.1.4.1.6574.1.1
       type: gauge
@@ -34452,3 +33766,329 @@ modules:
       oid: 1.3.6.1.4.1.41112.1.6.3.6
       type: DisplayString
       help: ' - 1.3.6.1.4.1.41112.1.6.3.6'
+  ucd_la_table:
+    walk:
+    - 1.3.6.1.4.1.2021.10.1.2
+    - 1.3.6.1.4.1.2021.10.1.5
+    - 1.3.6.1.4.1.2021.10.1.6
+    metrics:
+    - name: laNames
+      oid: 1.3.6.1.4.1.2021.10.1.2
+      type: DisplayString
+      help: The list of loadave names we're watching. - 1.3.6.1.4.1.2021.10.1.2
+      indexes:
+      - labelname: laIndex
+        type: gauge
+      lookups:
+      - labels:
+        - laIndex
+        labelname: laNames
+        oid: 1.3.6.1.4.1.2021.10.1.2
+        type: DisplayString
+      - labels: []
+        labelname: laIndex
+    - name: laLoadInt
+      oid: 1.3.6.1.4.1.2021.10.1.5
+      type: gauge
+      help: The 1,5 and 15 minute load averages as an integer - 1.3.6.1.4.1.2021.10.1.5
+      indexes:
+      - labelname: laIndex
+        type: gauge
+      lookups:
+      - labels:
+        - laIndex
+        labelname: laNames
+        oid: 1.3.6.1.4.1.2021.10.1.2
+        type: DisplayString
+      - labels: []
+        labelname: laIndex
+    - name: laLoadFloat
+      oid: 1.3.6.1.4.1.2021.10.1.6
+      type: Float
+      help: The 1,5 and 15 minute load averages as an opaquely wrapped floating point
+        number. - 1.3.6.1.4.1.2021.10.1.6
+      indexes:
+      - labelname: laIndex
+        type: gauge
+      lookups:
+      - labels:
+        - laIndex
+        labelname: laNames
+        oid: 1.3.6.1.4.1.2021.10.1.2
+        type: DisplayString
+      - labels: []
+        labelname: laIndex
+  ucd_memory:
+    walk:
+    - 1.3.6.1.4.1.2021.4
+    metrics:
+    - name: memIndex
+      oid: 1.3.6.1.4.1.2021.4.1
+      type: gauge
+      help: Bogus Index - 1.3.6.1.4.1.2021.4.1
+    - name: memErrorName
+      oid: 1.3.6.1.4.1.2021.4.2
+      type: DisplayString
+      help: Bogus Name - 1.3.6.1.4.1.2021.4.2
+    - name: memTotalSwap
+      oid: 1.3.6.1.4.1.2021.4.3
+      type: gauge
+      help: The total amount of swap space configured for this host. - 1.3.6.1.4.1.2021.4.3
+    - name: memAvailSwap
+      oid: 1.3.6.1.4.1.2021.4.4
+      type: gauge
+      help: The amount of swap space currently unused or available. - 1.3.6.1.4.1.2021.4.4
+    - name: memTotalReal
+      oid: 1.3.6.1.4.1.2021.4.5
+      type: gauge
+      help: The total amount of real/physical memory installed on this host. - 1.3.6.1.4.1.2021.4.5
+    - name: memAvailReal
+      oid: 1.3.6.1.4.1.2021.4.6
+      type: gauge
+      help: The amount of real/physical memory currently unused or available. - 1.3.6.1.4.1.2021.4.6
+    - name: memTotalSwapTXT
+      oid: 1.3.6.1.4.1.2021.4.7
+      type: gauge
+      help: The total amount of swap space or virtual memory allocated for text pages
+        on this host - 1.3.6.1.4.1.2021.4.7
+    - name: memAvailSwapTXT
+      oid: 1.3.6.1.4.1.2021.4.8
+      type: gauge
+      help: The amount of swap space or virtual memory currently being used by text
+        pages on this host - 1.3.6.1.4.1.2021.4.8
+    - name: memTotalRealTXT
+      oid: 1.3.6.1.4.1.2021.4.9
+      type: gauge
+      help: The total amount of real/physical memory allocated for text pages on this
+        host - 1.3.6.1.4.1.2021.4.9
+    - name: memAvailRealTXT
+      oid: 1.3.6.1.4.1.2021.4.10
+      type: gauge
+      help: The amount of real/physical memory currently being used by text pages
+        on this host - 1.3.6.1.4.1.2021.4.10
+    - name: memTotalFree
+      oid: 1.3.6.1.4.1.2021.4.11
+      type: gauge
+      help: The total amount of memory free or available for use on this host - 1.3.6.1.4.1.2021.4.11
+    - name: memMinimumSwap
+      oid: 1.3.6.1.4.1.2021.4.12
+      type: gauge
+      help: The minimum amount of swap space expected to be kept free or available
+        during normal operation of this host - 1.3.6.1.4.1.2021.4.12
+    - name: memShared
+      oid: 1.3.6.1.4.1.2021.4.13
+      type: gauge
+      help: The total amount of real or virtual memory currently allocated for use
+        as shared memory - 1.3.6.1.4.1.2021.4.13
+    - name: memBuffer
+      oid: 1.3.6.1.4.1.2021.4.14
+      type: gauge
+      help: The total amount of real or virtual memory currently allocated for use
+        as memory buffers - 1.3.6.1.4.1.2021.4.14
+    - name: memCached
+      oid: 1.3.6.1.4.1.2021.4.15
+      type: gauge
+      help: The total amount of real or virtual memory currently allocated for use
+        as cached memory - 1.3.6.1.4.1.2021.4.15
+    - name: memUsedSwapTXT
+      oid: 1.3.6.1.4.1.2021.4.16
+      type: gauge
+      help: The amount of swap space or virtual memory currently being used by text
+        pages on this host - 1.3.6.1.4.1.2021.4.16
+    - name: memUsedRealTXT
+      oid: 1.3.6.1.4.1.2021.4.17
+      type: gauge
+      help: The amount of real/physical memory currently being used by text pages
+        on this host - 1.3.6.1.4.1.2021.4.17
+    - name: memTotalSwapX
+      oid: 1.3.6.1.4.1.2021.4.18
+      type: counter
+      help: The total amount of swap space configured for this host. - 1.3.6.1.4.1.2021.4.18
+    - name: memAvailSwapX
+      oid: 1.3.6.1.4.1.2021.4.19
+      type: counter
+      help: The amount of swap space currently unused or available. - 1.3.6.1.4.1.2021.4.19
+    - name: memTotalRealX
+      oid: 1.3.6.1.4.1.2021.4.20
+      type: counter
+      help: The total amount of real/physical memory installed on this host. - 1.3.6.1.4.1.2021.4.20
+    - name: memAvailRealX
+      oid: 1.3.6.1.4.1.2021.4.21
+      type: counter
+      help: The amount of real/physical memory currently unused or available. - 1.3.6.1.4.1.2021.4.21
+    - name: memTotalFreeX
+      oid: 1.3.6.1.4.1.2021.4.22
+      type: counter
+      help: The total amount of memory free or available for use on this host - 1.3.6.1.4.1.2021.4.22
+    - name: memMinimumSwapX
+      oid: 1.3.6.1.4.1.2021.4.23
+      type: counter
+      help: The minimum amount of swap space expected to be kept free or available
+        during normal operation of this host - 1.3.6.1.4.1.2021.4.23
+    - name: memSharedX
+      oid: 1.3.6.1.4.1.2021.4.24
+      type: counter
+      help: The total amount of real or virtual memory currently allocated for use
+        as shared memory - 1.3.6.1.4.1.2021.4.24
+    - name: memBufferX
+      oid: 1.3.6.1.4.1.2021.4.25
+      type: counter
+      help: The total amount of real or virtual memory currently allocated for use
+        as memory buffers - 1.3.6.1.4.1.2021.4.25
+    - name: memCachedX
+      oid: 1.3.6.1.4.1.2021.4.26
+      type: counter
+      help: The total amount of real or virtual memory currently allocated for use
+        as cached memory - 1.3.6.1.4.1.2021.4.26
+    - name: memSwapError
+      oid: 1.3.6.1.4.1.2021.4.100
+      type: gauge
+      help: Indicates whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
+        is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.100
+      enum_values:
+        0: noError
+        1: error
+    - name: memSwapErrorMsg
+      oid: 1.3.6.1.4.1.2021.4.101
+      type: DisplayString
+      help: Describes whether the amount of available swap space (as reported by 'memAvailSwap(4)'),
+        is less than the desired minimum (specified by 'memMinimumSwap(12)'). - 1.3.6.1.4.1.2021.4.101
+  ucd_system_stats:
+    walk:
+    - 1.3.6.1.4.1.2021.11
+    metrics:
+    - name: ssIndex
+      oid: 1.3.6.1.4.1.2021.11.1
+      type: gauge
+      help: Bogus Index - 1.3.6.1.4.1.2021.11.1
+    - name: ssErrorName
+      oid: 1.3.6.1.4.1.2021.11.2
+      type: DisplayString
+      help: Bogus Name - 1.3.6.1.4.1.2021.11.2
+    - name: ssSwapIn
+      oid: 1.3.6.1.4.1.2021.11.3
+      type: gauge
+      help: The average amount of memory swapped in from disk, calculated over the
+        last minute. - 1.3.6.1.4.1.2021.11.3
+    - name: ssSwapOut
+      oid: 1.3.6.1.4.1.2021.11.4
+      type: gauge
+      help: The average amount of memory swapped out to disk, calculated over the
+        last minute. - 1.3.6.1.4.1.2021.11.4
+    - name: ssIOSent
+      oid: 1.3.6.1.4.1.2021.11.5
+      type: gauge
+      help: The average amount of data written to disk or other block device, calculated
+        over the last minute - 1.3.6.1.4.1.2021.11.5
+    - name: ssIOReceive
+      oid: 1.3.6.1.4.1.2021.11.6
+      type: gauge
+      help: The average amount of data read from disk or other block device, calculated
+        over the last minute - 1.3.6.1.4.1.2021.11.6
+    - name: ssSysInterrupts
+      oid: 1.3.6.1.4.1.2021.11.7
+      type: gauge
+      help: The average rate of interrupts processed (including the clock) calculated
+        over the last minute - 1.3.6.1.4.1.2021.11.7
+    - name: ssSysContext
+      oid: 1.3.6.1.4.1.2021.11.8
+      type: gauge
+      help: The average rate of context switches, calculated over the last minute
+        - 1.3.6.1.4.1.2021.11.8
+    - name: ssCpuUser
+      oid: 1.3.6.1.4.1.2021.11.9
+      type: gauge
+      help: The percentage of CPU time spent processing user-level code, calculated
+        over the last minute - 1.3.6.1.4.1.2021.11.9
+    - name: ssCpuSystem
+      oid: 1.3.6.1.4.1.2021.11.10
+      type: gauge
+      help: The percentage of CPU time spent processing system-level code, calculated
+        over the last minute - 1.3.6.1.4.1.2021.11.10
+    - name: ssCpuIdle
+      oid: 1.3.6.1.4.1.2021.11.11
+      type: gauge
+      help: The percentage of processor time spent idle, calculated over the last
+        minute - 1.3.6.1.4.1.2021.11.11
+    - name: ssCpuRawUser
+      oid: 1.3.6.1.4.1.2021.11.50
+      type: counter
+      help: The number of 'ticks' (typically 1/100s) spent processing user-level code
+        - 1.3.6.1.4.1.2021.11.50
+    - name: ssCpuRawNice
+      oid: 1.3.6.1.4.1.2021.11.51
+      type: counter
+      help: The number of 'ticks' (typically 1/100s) spent processing reduced-priority
+        code - 1.3.6.1.4.1.2021.11.51
+    - name: ssCpuRawSystem
+      oid: 1.3.6.1.4.1.2021.11.52
+      type: counter
+      help: The number of 'ticks' (typically 1/100s) spent processing system-level
+        code - 1.3.6.1.4.1.2021.11.52
+    - name: ssCpuRawIdle
+      oid: 1.3.6.1.4.1.2021.11.53
+      type: counter
+      help: The number of 'ticks' (typically 1/100s) spent idle - 1.3.6.1.4.1.2021.11.53
+    - name: ssCpuRawWait
+      oid: 1.3.6.1.4.1.2021.11.54
+      type: counter
+      help: The number of 'ticks' (typically 1/100s) spent waiting for IO - 1.3.6.1.4.1.2021.11.54
+    - name: ssCpuRawKernel
+      oid: 1.3.6.1.4.1.2021.11.55
+      type: counter
+      help: The number of 'ticks' (typically 1/100s) spent processing kernel-level
+        code - 1.3.6.1.4.1.2021.11.55
+    - name: ssCpuRawInterrupt
+      oid: 1.3.6.1.4.1.2021.11.56
+      type: counter
+      help: The number of 'ticks' (typically 1/100s) spent processing hardware interrupts
+        - 1.3.6.1.4.1.2021.11.56
+    - name: ssIORawSent
+      oid: 1.3.6.1.4.1.2021.11.57
+      type: counter
+      help: Number of blocks sent to a block device - 1.3.6.1.4.1.2021.11.57
+    - name: ssIORawReceived
+      oid: 1.3.6.1.4.1.2021.11.58
+      type: counter
+      help: Number of blocks received from a block device - 1.3.6.1.4.1.2021.11.58
+    - name: ssRawInterrupts
+      oid: 1.3.6.1.4.1.2021.11.59
+      type: counter
+      help: Number of interrupts processed - 1.3.6.1.4.1.2021.11.59
+    - name: ssRawContexts
+      oid: 1.3.6.1.4.1.2021.11.60
+      type: counter
+      help: Number of context switches - 1.3.6.1.4.1.2021.11.60
+    - name: ssCpuRawSoftIRQ
+      oid: 1.3.6.1.4.1.2021.11.61
+      type: counter
+      help: The number of 'ticks' (typically 1/100s) spent processing software interrupts
+        - 1.3.6.1.4.1.2021.11.61
+    - name: ssRawSwapIn
+      oid: 1.3.6.1.4.1.2021.11.62
+      type: counter
+      help: Number of blocks swapped in - 1.3.6.1.4.1.2021.11.62
+    - name: ssRawSwapOut
+      oid: 1.3.6.1.4.1.2021.11.63
+      type: counter
+      help: Number of blocks swapped out - 1.3.6.1.4.1.2021.11.63
+    - name: ssCpuRawSteal
+      oid: 1.3.6.1.4.1.2021.11.64
+      type: counter
+      help: The number of 'ticks' (typically 1/100s) spent by the hypervisor code
+        to run other VMs even though the CPU in the current VM had something runnable
+        - 1.3.6.1.4.1.2021.11.64
+    - name: ssCpuRawGuest
+      oid: 1.3.6.1.4.1.2021.11.65
+      type: counter
+      help: The number of 'ticks' (typically 1/100s) spent by the CPU to run a virtual
+        CPU (guest) - 1.3.6.1.4.1.2021.11.65
+    - name: ssCpuRawGuestNice
+      oid: 1.3.6.1.4.1.2021.11.66
+      type: counter
+      help: The number of 'ticks' (typically 1/100s) spent by the CPU to run a niced
+        virtual CPU (guest) - 1.3.6.1.4.1.2021.11.66
+    - name: ssCpuNumCpus
+      oid: 1.3.6.1.4.1.2021.11.67
+      type: gauge
+      help: The number of processors, as counted by the agent - 1.3.6.1.4.1.2021.11.67


### PR DESCRIPTION
Consolidate the use of UCD-SNMP-MIB into separate modules, rather than include them in individual device modules.