### PR TITLE
Support for passing community as an env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ using SNMP v2 GETBULK.
 The `--config.file` parameter can be used multiple times to load more than one file.
 It also supports [glob filename matching](https://pkg.go.dev/path/filepath#Glob), e.g. `snmp*.yml`.
 
-The `--config.expand-environment-variables` parameter allows passing environment variables into some fields of the configuration file. The `username`, `password` & `priv_password` fields in the auths section are supported. Defaults to disabled.
+The `--config.expand-environment-variables` parameter allows passing environment variables into some fields of the configuration file. The `username`, `password`, `priv_password`, & `community` fields in the auths section are supported. Defaults to disabled.
 
 Duplicate `module` or `auth` entries are treated as invalid and can not be loaded.
 
@@ -162,7 +162,7 @@ scrape_configs:
       - targets: ['localhost:9116']
 ```
 
-You could pass `username`, `password` & `priv_password` via environment variables of your choice in below format. 
+You could pass `username`, `password`, `priv_password` & `community` via environment variables of your choice in below format.
 If the variables exist in the environment, they are resolved on the fly otherwise the string in the config file is passed as-is.
 
 This requires the `--config.expand-environment-variables` flag be set.
@@ -170,7 +170,7 @@ This requires the `--config.expand-environment-variables` flag be set.
 ```YAML
 auths:
   example_with_envs:
-    community: mysecret
+    community: ${ARISTA_COMMUNITY}
     security_level: SomethingReadOnly
     username: ${ARISTA_USERNAME}
     password: ${ARISTA_PASSWORD}

--- a/README.md
+++ b/README.md
@@ -169,14 +169,17 @@ This requires the `--config.expand-environment-variables` flag be set.
 
 ```YAML
 auths:
-  example_with_envs:
-    community: ${ARISTA_COMMUNITY}
-    security_level: SomethingReadOnly
+  v3_example_with_envs:
+    version: 3
+    security_level: authPriv
     username: ${ARISTA_USERNAME}
     password: ${ARISTA_PASSWORD}
     auth_protocol: SHA256
     priv_protocol: AES
     priv_password: ${ARISTA_PRIV_PASSWORD}
+  v2_example_with_env:
+    version: 2
+    community: ${ARISTA_COMMUNITY}
 ```
 
 Similarly to [blackbox_exporter](https://github.com/prometheus/blackbox_exporter),

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,13 @@ func LoadFile(paths []string, expandEnvVars bool) (*Config, error) {
 				}
 				cfg.Auths[i].PrivPassword.Set(privPassword)
 			}
+			if auth.Community != "" {
+				community, err := substituteEnvVariables(string(auth.Community))
+				if err != nil {
+					return nil, err
+				}
+				cfg.Auths[i].Community.Set(community)
+			}
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -73,6 +73,7 @@ func TestEnvSecrets(t *testing.T) {
 	t.Setenv("ENV_USERNAME", "snmp_username")
 	t.Setenv("ENV_PASSWORD", "snmp_password")
 	t.Setenv("ENV_PRIV_PASSWORD", "snmp_priv_password")
+	t.Setenv("ENV_COMMUNITY", "snmp_community")
 
 	sc := &SafeConfig{}
 	err := sc.ReloadConfig([]string{"testdata/snmp-auth-envvars.yml"}, true)
@@ -88,13 +89,13 @@ func TestEnvSecrets(t *testing.T) {
 		t.Errorf("Error marshaling config: %v", err)
 	}
 
-	if strings.Contains(string(c), "mysecret") {
+	if strings.Contains(string(c), "snmp_community") {
 		t.Fatal("config's String method reveals authentication credentials.")
 	}
 
 	// we check whether vars we set are resolved correctly in config
 	for i := range sc.C.Auths {
-		if sc.C.Auths[i].Username != "snmp_username" || sc.C.Auths[i].Password != "snmp_password" || sc.C.Auths[i].PrivPassword != "snmp_priv_password" {
+		if sc.C.Auths[i].Username != "snmp_username" || sc.C.Auths[i].Password != "snmp_password" || sc.C.Auths[i].PrivPassword != "snmp_priv_password" || sc.C.Auths[i].Community != "snmp_community" {
 			t.Fatal("failed to resolve secrets from env vars")
 		}
 	}
@@ -104,6 +105,7 @@ func TestEnvSecrets(t *testing.T) {
 func TestEnvSecretsMissing(t *testing.T) {
 	t.Setenv("ENV_PASSWORD", "snmp_password")
 	t.Setenv("ENV_PRIV_PASSWORD", "snmp_priv_password")
+	t.Setenv("ENV_COMMUNITY", "snmp_community")
 
 	sc := &SafeConfig{}
 	err := sc.ReloadConfig([]string{"testdata/snmp-auth-envvars.yml"}, true)

--- a/testdata/snmp-auth-envvars.yml
+++ b/testdata/snmp-auth-envvars.yml
@@ -1,9 +1,14 @@
 auths:
-  with_secret:
-    community: mysecret
+  with_env_secret:
+    community: ${ENV_COMMUNITY}
     security_level: SomethingReadOnly
     username: ${ENV_USERNAME}
     password: ${ENV_PASSWORD}
     auth_protocol: SHA256
     priv_protocol: AES
     priv_password: ${ENV_PRIV_PASSWORD}
+  with_plain_secret:
+    community: snmp_community
+    username: snmp_username
+    password: snmp_password
+    priv_password: snmp_priv_password

--- a/testdata/snmp-auth-v2nocreds.yml
+++ b/testdata/snmp-auth-v2nocreds.yml
@@ -1,4 +1,3 @@
 auths:
   v2_without_secret:
-    community: mysecret
     version: 2


### PR DESCRIPTION
This follows the work of @harshavmb in #1074 and adds support for using environment variable substitution for `community` strings. Also includes a small fix for the generator makefile so that tests are passing.

@SuperQ