### PR TITLE
Fix Sophos mibs unpack

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -300,7 +300,7 @@ $(MIBDIR)/.sophos_xg:
 	$(eval TMP := $(shell mktemp))
 	@echo ">> Downloading Sophos XG to $(TMP)"
 	@curl $(CURL_OPTS) -o $(TMP) $(SOPHOS_XG_URL)
-	@unzip -j -d $(MIBDIR) $(TMP) SOPHOS-XG-MIB20.txt
+	@unzip -j -d $(MIBDIR) $(TMP) sophos-xg-mib/SOPHOS-XG-MIB20.txt
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.sophos_xg
 


### PR DESCRIPTION
Seems Sophos mibs archive now has subdir inside

```
$ make mibs
>> Downloading Sophos XG to /var/folders/yv/7rwk3zg15fb4f2n4trqfm0080000gn/T/tmp.dsXtCG981W
Archive:  /var/folders/yv/7rwk3zg15fb4f2n4trqfm0080000gn/T/tmp.dsXtCG981W
caution: filename not matched:  SOPHOS-XG-MIB20.txt
make: *** [mibs/.sophos_xg] Error 11
```

```
$ unzip -l /var/folders/yv/7rwk3zg15fb4f2n4trqfm0080000gn/T/tmp.kfLy6DoeUG
Archive:  /var/folders/yv/7rwk3zg15fb4f2n4trqfm0080000gn/T/tmp.kfLy6DoeUG
  Length      Date    Time    Name
---------  ---------- -----   ----
        0  10-03-2024 15:15   sophos-xg-mib/
    14784  10-03-2024 15:15   sophos-xg-mib/SOPHOS-XG-MIB17.txt
    34924  10-03-2024 15:15   sophos-xg-mib/SOPHOS-XG-MIB18.txt
    34924  10-03-2024 15:15   sophos-xg-mib/SOPHOS-XG-MIB19.txt
    36036  10-03-2024 15:15   sophos-xg-mib/SOPHOS-XG-MIB20.txt
    36036  10-03-2024 15:15   sophos-xg-mib/SOPHOS-XG-MIB21.txt
---------                     -------
   156704                     6 files
```