### PR TITLE
Improve config error message

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,7 +217,8 @@ func main() {
 	err := sc.ReloadConfig(*configFile, *expandEnvVars)
 	if err != nil {
 		logger.Error("Error parsing config file", "err", err)
-		logger.Error("Possible old config file, see https://github.com/prometheus/snmp_exporter/blob/main/auth-split-migration.md")
+		logger.Error("Possible version missmatch between generator and snmp_exporter. Make sure generator and snmp_exporter are the same version.")
+		logger.Error("See also: https://github.com/prometheus/snmp_exporter/blob/main/auth-split-migration.md")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Improve config parsing error message for cases where the generator is built from a commit that supports newer features than the deployed exporter.