### PR TITLE
Bastischubert/add tplink ddm

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -62,6 +62,7 @@ READYNAS_URL      := https://www.downloads.netgear.com/files/ReadyNAS/READYNAS-M
 READYDATAOS_URL   := https://www.downloads.netgear.com/files/GDC/RD5200/READYDATA_MIB.zip
 SOPHOS_XG_URL     := https://docs.sophos.com/nsg/sophos-firewall/MIB/SOPHOS-XG-MIB.zip
 POWERCOM_URL      := https://www.upspowercom.com/pcm-img/Card-DA807/Upsmate_PCM.mib
+TPLINK_DDM        := https://static.tp-link.com/upload/software/2024/202402/20240229/L2-tplinkMibs.zip
 
 CYBERPOWER_VERSION := 2.11
 CYBERPOWER_URL     := https://dl4jz3rbrsfum.cloudfront.net/software/CyberPower_MIB_v$(CYBERPOWER_VERSION).MIB.zip
@@ -84,6 +85,7 @@ clean:
 		$(MIBDIR)/.synology \
 		$(MIBDIR)/.sophos_xg \
 		$(MIBDIR)/.kemp-lm \
+		$(MIBDIR)/.tplinkddm \
 		$(MIBDIR)/readynas \
 		$(MIBDIR)/readydataos
 
@@ -146,6 +148,7 @@ mibs: \
   $(MIBDIR)/servertech-sentry4-mib \
   $(MIBDIR)/.synology \
   $(MIBDIR)/.sophos_xg \
+  $(MIBDIR)/.tplinkddm \
   $(MIBDIR)/UBNT-UniFi-MIB \
   $(MIBDIR)/UBNT-AirFiber-MIB \
   $(MIBDIR)/UBNT-AirMAX-MIB.txt \
@@ -324,6 +327,15 @@ $(MIBDIR)/.synology:
 	@unzip -j -d $(MIBDIR) $(TMP)
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.synology
+
+$(MIBDIR)/.tplinkddm:
+	$(eval TMP := $(shell mktemp))
+	@echo ">> Downloading TPLINK Switch DDM to $(TMP)"
+	@curl $(CURL_OPTS) -o $(TMP) $(TPLINK_DDM)
+	@unzip -j -d $(MIBDIR) $(TMP) L2-tplinkMibs/tplink-ddmManage.mib  L2-tplinkMibs/tplink-ddmStatus.mib L2-tplinkMibs/tplink.mib
+	@mv $(MIBDIR)/tplink.mib $(MIBDIR)/tplink-main.mib # EAP.MIB contains another incompatible variant of the tplink enterprise mib with same name
+	@rm -v $(TMP)
+	@touch $(MIBDIR)/.tplinkddm
 
 $(MIBDIR)/UBNT-UniFi-MIB:
 	@echo ">> Downloading UBNT-UniFi-MIB"

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -837,3 +837,66 @@ modules:
       - 1.3.6.1.4.1.935.1.1.1.9.2.2   # upsEnvUnderTemperature
       - 1.3.6.1.4.1.935.1.1.1.9.2.3   # upsEnvOverHumidity
       - 1.3.6.1.4.1.935.1.1.1.9.2.4   # upsEnvUnderHumidity
+
+  # tplink ddm information for sfps
+  tplink-ddm:
+    walk:
+      - ddmStatusBiasCurrent
+      - ddmStatusLossSignal
+      - ddmStatusRxPow
+      - ddmStatusTemperature
+      - ddmStatusTxFault
+      - ddmStatusTxPow
+      - ddmStatusVoltage
+    lookups:
+      - source_indexes: [ifIndex]
+        lookup: ifAlias
+      - source_indexes: [ifIndex]
+        lookup: 1.3.6.1.2.1.31.1.1.1.1 # ifName
+    overrides:
+      ddmStatusBiasCurrent:
+        type: DisplayString
+        regex_extracts:
+          '':
+            - regex: '^(\d+\.\d+).*'
+              value: '$1'
+      ddmStatusLossSignal:
+        type: DisplayString
+        regex_extracts:
+          '':
+            - regex: 'False'
+              value: '0'
+            - regex: 'True'
+              value: '1'
+      ddmStatusRxPow:
+        type: DisplayString
+        regex_extracts:
+          '':
+            - regex: '^(\d+\.\d+).*'
+              value: '$1'
+      ddmStatusTemperature:
+        type: DisplayString
+        regex_extracts:
+          '':
+            - regex: '^(\d+\.\d+).*'
+              value: '$1'
+      ddmStatusTxFault:
+        type: DisplayString
+        regex_extracts:
+          '':
+            - regex: 'False'
+              value: '0'
+            - regex: 'True'
+              value: '1'
+      ddmStatusTxPow:
+        type: DisplayString
+        regex_extracts:
+          '':
+            - regex: '^(\d+\.\d+).*'
+              value: '$1'
+      ddmStatusVoltage:
+        type: DisplayString
+        regex_extracts:
+          '':
+            - regex: '^(\d+\.\d+).*'
+              value: '$1'

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -839,6 +839,11 @@ modules:
       - 1.3.6.1.4.1.935.1.1.1.9.2.4   # upsEnvUnderHumidity
 
   # tplink ddm information for sfps
+  # 
+  # Downloads can be found here:
+  # https://www.tp-link.com/en/support/download/tl-sg3428x/
+  #
+  # tested against TL SG3428X 
   tplink-ddm:
     walk:
       - ddmStatusBiasCurrent

--- a/snmp.yml
+++ b/snmp.yml
@@ -39829,6 +39829,178 @@ modules:
         type: DisplayString
       - labels: []
         labelname: serviceInfoIndex
+  tplink-ddm:
+    walk:
+    - 1.3.6.1.2.1.31.1.1.1.1
+    - 1.3.6.1.2.1.31.1.1.1.18
+    - 1.3.6.1.4.1.11863.6.96.1.7.1.1.2
+    - 1.3.6.1.4.1.11863.6.96.1.7.1.1.3
+    - 1.3.6.1.4.1.11863.6.96.1.7.1.1.4
+    - 1.3.6.1.4.1.11863.6.96.1.7.1.1.5
+    - 1.3.6.1.4.1.11863.6.96.1.7.1.1.6
+    - 1.3.6.1.4.1.11863.6.96.1.7.1.1.8
+    - 1.3.6.1.4.1.11863.6.96.1.7.1.1.9
+    metrics:
+    - name: ddmStatusTemperature
+      oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.2
+      type: DisplayString
+      help: This object indicates the temperature of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.2
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      regex_extracts:
+        "":
+        - value: $1
+          regex: ^(?:^(\d+\.\d+).*)$
+    - name: ddmStatusVoltage
+      oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.3
+      type: DisplayString
+      help: This object indicates the voltage of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.3
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      regex_extracts:
+        "":
+        - value: $1
+          regex: ^(?:^(\d+\.\d+).*)$
+    - name: ddmStatusBiasCurrent
+      oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.4
+      type: DisplayString
+      help: This object indicates the bias current of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.4
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      regex_extracts:
+        "":
+        - value: $1
+          regex: ^(?:^(\d+\.\d+).*)$
+    - name: ddmStatusTxPow
+      oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.5
+      type: DisplayString
+      help: This object indicates the tx power of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.5
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      regex_extracts:
+        "":
+        - value: $1
+          regex: ^(?:^(\d+\.\d+).*)$
+    - name: ddmStatusRxPow
+      oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.6
+      type: DisplayString
+      help: This object indicates the rx power of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.6
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      regex_extracts:
+        "":
+        - value: $1
+          regex: ^(?:^(\d+\.\d+).*)$
+    - name: ddmStatusLossSignal
+      oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.8
+      type: DisplayString
+      help: This object indicates whether local SFP reports signal loss or not. -
+        1.3.6.1.4.1.11863.6.96.1.7.1.1.8
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      regex_extracts:
+        "":
+        - value: "0"
+          regex: ^(?:False)$
+        - value: "1"
+          regex: ^(?:True)$
+    - name: ddmStatusTxFault
+      oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.9
+      type: DisplayString
+      help: This object indicates whether remote SFP reports signal loss or not. -
+        1.3.6.1.4.1.11863.6.96.1.7.1.1.9
+      indexes:
+      - labelname: ifIndex
+        type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
+      regex_extracts:
+        "":
+        - value: "0"
+          regex: ^(?:False)$
+        - value: "1"
+          regex: ^(?:True)$
   ubiquiti_airfiber:
     walk:
     - 1.3.6.1.4.1.41112.1.3


### PR DESCRIPTION
TPlink ddm monitoring 

tested against  TPLink  SG3428X

```
# HELP ddmStatusBiasCurrent This object indicates the bias current of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.4 (regex extracted)
# TYPE ddmStatusBiasCurrent gauge
ddmStatusBiasCurrent{ifAlias="promtest",ifIndex="49180",ifName="ten-gigabitEthernet 1/0/28"} 38.424
# HELP ddmStatusLossSignal This object indicates whether local SFP reports signal loss or not. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.8 (regex extracted)
# TYPE ddmStatusLossSignal gauge
ddmStatusLossSignal{ifAlias="promtest",ifIndex="49180",ifName="ten-gigabitEthernet 1/0/28"} 0
# HELP ddmStatusRxPow This object indicates the rx power of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.6 (regex extracted)
# TYPE ddmStatusRxPow gauge
ddmStatusRxPow{ifAlias="promtest",ifIndex="49180",ifName="ten-gigabitEthernet 1/0/28"} 0.0001
# HELP ddmStatusTemperature This object indicates the temperature of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.2 (regex extracted)
# TYPE ddmStatusTemperature gauge
ddmStatusTemperature{ifAlias="promtest",ifIndex="49180",ifName="ten-gigabitEthernet 1/0/28"} 41.328125
# HELP ddmStatusTxFault This object indicates whether remote SFP reports signal loss or not. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.9 (regex extracted)
# TYPE ddmStatusTxFault gauge
ddmStatusTxFault{ifAlias="promtest",ifIndex="49180",ifName="ten-gigabitEthernet 1/0/28"} 0
# HELP ddmStatusTxPow This object indicates the tx power of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.5 (regex extracted)
# TYPE ddmStatusTxPow gauge
ddmStatusTxPow{ifAlias="promtest",ifIndex="49180",ifName="ten-gigabitEthernet 1/0/28"} 0.5973
# HELP ddmStatusVoltage This object indicates the voltage of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.3 (regex extracted)
# TYPE ddmStatusVoltage gauge
ddmStatusVoltage{ifAlias="promtest",ifIndex="49180",ifName="ten-gigabitEthernet 1/0/28"} 3.2886

```