### PR TITLE
Add NTPTimeStamp type

### DIFF
--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -644,6 +644,29 @@ func TestGetPduLargeValue(t *testing.T) {
 	}
 }
 
+func TestNtpTimestamp(t *testing.T) {
+	cases := []struct {
+		pdu    *gosnmp.SnmpPDU
+		result float64
+		err    error
+	}{
+		{
+			pdu:    &gosnmp.SnmpPDU{Value: []byte{235, 6, 119, 246, 48, 209, 11, 59}},
+			result: 1.734080886e+09,
+			err:    nil,
+		},
+	}
+	for _, c := range cases {
+		got, err := parseNtpTimestamp(c.pdu)
+		if !reflect.DeepEqual(err, c.err) {
+			t.Errorf("parseNtpTimestamp(%v) error: got %v, want %v", c.pdu, err, c.err)
+		}
+		if !reflect.DeepEqual(got, c.result) {
+			t.Errorf("parseNtpTimestamp(%v) result: got %v, want %v", c.pdu, got, c.result)
+		}
+	}
+}
+
 func TestOidToList(t *testing.T) {
 	cases := []struct {
 		oid    string

--- a/generator/README.md
+++ b/generator/README.md
@@ -175,6 +175,7 @@ modules:
                              #   OctetString: A bit string, rendered as 0xff34.
                              #   DateAndTime: An RFC 2579 DateAndTime byte sequence. If the device has no time zone data, UTC is used.
                              #   ParseDateAndTime: Parse a DisplayString and return the timestamp. See datetime_pattern config option
+                             #   NTPTimeStamp: Parse the NTP timestamp (RFC-1305, March 1992, Section 3.1) and return Unix timestamp as float.
                              #   DisplayString: An ASCII or UTF-8 string.
                              #   PhysAddress48: A 48 bit MAC address, rendered as 00:01:02:03:04:ff.
                              #   Float: A 32 bit floating-point value with type gauge.

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -136,6 +136,9 @@ func prepareTree(nodes *Node, logger *slog.Logger) map[string]*Node {
 		if n.TextualConvention == "ParseDateAndTime" {
 			n.Type = "ParseDateAndTime"
 		}
+		if n.TextualConvention == "NTPTimeStamp" {
+			n.Type = "NTPTimeStamp"
+		}
 		// Convert RFC 4001 InetAddress types textual convention to type.
 		if n.TextualConvention == "InetAddressIPv4" || n.TextualConvention == "InetAddressIPv6" || n.TextualConvention == "InetAddress" {
 			n.Type = n.TextualConvention
@@ -169,6 +172,8 @@ func metricType(t string) (string, bool) {
 	case "DateAndTime":
 		return t, true
 	case "ParseDateAndTime":
+		return t, true
+	case "NTPTimeStamp":
 		return t, true
 	case "EnumAsInfo", "EnumAsStateSet":
 		return t, true

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -148,6 +148,11 @@ func TestTreePrepare(t *testing.T) {
 			in:  &Node{Oid: "1", Type: "OctectString", TextualConvention: "InetAddress"},
 			out: &Node{Oid: "1", Type: "InetAddress", TextualConvention: "InetAddress"},
 		},
+		// NTPTimeStamp
+		{
+			in:  &Node{Oid: "1", Type: "OctectString", TextualConvention: "NTPTimeStamp"},
+			out: &Node{Oid: "1", Type: "NTPTimeStamp", TextualConvention: "NTPTimeStamp"},
+		},
 	}
 	for i, c := range cases {
 		// Indexes always end up initialized.
@@ -346,6 +351,7 @@ func TestGenerateConfigModule(t *testing.T) {
 					{Oid: "1.203", Access: "ACCESS_READONLY", Label: "InetAddressIPv4", Type: "OCTETSTR", TextualConvention: "InetAddressIPv4"},
 					{Oid: "1.204", Access: "ACCESS_READONLY", Label: "InetAddressIPv6", Type: "OCTETSTR", TextualConvention: "InetAddressIPv6"},
 					{Oid: "1.205", Access: "ACCESS_READONLY", Label: "ParseDateAndTime", Type: "DisplayString", TextualConvention: "ParseDateAndTime"},
+					{Oid: "1.206", Access: "ACCESS_READONLY", Label: "NTPTimeStamp", Type: "NTPTimeStamp", TextualConvention: "NTPTimeStamp"},
 				}},
 			cfg: &ModuleConfig{
 				Walk: []string{"root", "1.3"},
@@ -472,6 +478,12 @@ func TestGenerateConfigModule(t *testing.T) {
 						Oid:  "1.205",
 						Type: "ParseDateAndTime",
 						Help: " - 1.205",
+					},
+					{
+						Name: "NTPTimeStamp",
+						Oid:  "1.206",
+						Type: "NTPTimeStamp",
+						Help: " - 1.206",
 					},
 				},
 			},


### PR DESCRIPTION
Parse the ntp timestamp and convert it to an unix timestamp.

Used in different MIBs

* Cisco: https://github.com/cisco/cisco-mibs/blob/26b38ac1b25a38510b6bb308465dd068e79df64b/v2/CISCO-NTP-MIB.my#L196
* Juniper: https://github.com/pgmillon/observium/blob/604a21c8abceeea9b24a264220082c4ca9b15dd8/mibs/junose/juniSystemClock.mi2#L133
* DELL: https://github.com/pgmillon/observium/blob/604a21c8abceeea9b24a264220082c4ca9b15dd8/mibs/dell/RADLAN-TIMESYNCHRONIZATION-MIB#L34
* https://github.com/pgmillon/observium/blob/604a21c8abceeea9b24a264220082c4ca9b15dd8/mibs/aos/TIMETRA-NTP-MIB#L98

At the moment I have tested it with some Cisco devices.

I have tried to add some tests, but I don't know if something is missing.
