### PR TITLE
chore: fix dashboard mixins that fail due beeing editable

### DIFF
--- a/snmp-mixin/dashboards/snmp_ubiquiti_access_point.json
+++ b/snmp-mixin/dashboards/snmp_ubiquiti_access_point.json
@@ -77,7 +77,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
   "id": 6,

--- a/snmp-mixin/dashboards/snmp_ubiquiti_wifi.json
+++ b/snmp-mixin/dashboards/snmp_ubiquiti_wifi.json
@@ -77,7 +77,7 @@
       }
     ]
   },
-  "editable": true,
+  "editable": false,
   "gnetId": null,
   "graphTooltip": 1,
   "id": 7,


### PR DESCRIPTION
fixing mixin dashboard after this change in the upstream linter: https://github.com/grafana/dashboard-linter/commit/df1b122b0849e515b53f0fbaf8c5ea9d75ba3039 