### PR TITLE
feat: allow module-qualified labels in generator.yml

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -13,11 +13,11 @@ modules:
       - source_indexes: [ifIndex]
         lookup: ifAlias
       - source_indexes: [ifIndex]
-        # Uis OID to avoid conflict with PaloAlto PAN-COMMON-MIB.
-        lookup: 1.3.6.1.2.1.2.2.1.2 # ifDescr
+        # Disambiguate from PaloAlto PAN-COMMON-MIB::ifDescr.
+        lookup: "IF-MIB::ifDescr"
       - source_indexes: [ifIndex]
-        # Use OID to avoid conflict with Netscaler NS-ROOT-MIB.
-        lookup: 1.3.6.1.2.1.31.1.1.1.1 # ifName
+        # Disambiguate from Netscaler NS-ROOT-MIB::ifName.
+        lookup: "IF-MIB::ifName"
     overrides:
       ifAlias:
         ignore: true # Lookup metric
@@ -856,7 +856,7 @@ modules:
       - source_indexes: [ifIndex]
         lookup: ifAlias
       - source_indexes: [ifIndex]
-        lookup: 1.3.6.1.2.1.31.1.1.1.1 # ifName
+        lookup: "IF-MIB::ifName"
     overrides:
       ddmStatusBiasCurrent:
         type: DisplayString

--- a/generator/main.go
+++ b/generator/main.go
@@ -62,6 +62,9 @@ func generateConfig(nodes *Node, nameToNode map[string]*Node, logger *slog.Logge
 		walkNode(mNodes, func(n *Node) {
 			mNameToNode[n.Oid] = n
 			mNameToNode[n.Label] = n
+			if n.Module != "" {
+				mNameToNode[n.Module+"::"+n.Label] = n
+			}
 		})
 		out, err := generateConfigModule(m, mNodes, mNameToNode, logger)
 		if err != nil {

--- a/generator/net_snmp.go
+++ b/generator/net_snmp.go
@@ -79,6 +79,7 @@ import (
 type Node struct {
 	Oid               string
 	subid             int64
+	Module            string
 	Label             string
 	Augments          string
 	Children          []*Node
@@ -222,6 +223,9 @@ func buildMIBTree(t *C.struct_tree, n *Node, oid string) {
 		n.Oid = fmt.Sprintf("%s.%d", oid, t.subid)
 	} else {
 		n.Oid = fmt.Sprintf("%d", t.subid)
+	}
+	if m := C.find_module(t.modid); m != nil {
+		n.Module = C.GoString(m.name)
 	}
 	n.Label = C.GoString(t.label)
 	if typ, ok := netSnmptypeMap[int(t._type)]; ok {


### PR DESCRIPTION
Currently, some labels such as `ifName` and `ifDescr` are defined in multiple modules and must be specified using OID.  This patch avails such OIDs under both its bare label and module-qualified labels, e.g. both `ifName` and `IF-MIB::ifName`.

@bastischubert could you please take a look?