### PR TITLE
Add module for system stats

### DIFF
--- a/generator/FORMAT.md
+++ b/generator/FORMAT.md
@@ -13,8 +13,8 @@ modules:
   module_name:
     walk:
       # List of OID subtrees to walk.
-      - 1.3.6.1.2.1.2
-      - 1.3.6.1.2.1.31.1.1
+      - "IF-MIB::interfaces" # 1.3.6.1.2.1.2 from IF-MIB
+      - ifXTable             # 1.3.6.1.2.1.31.1.1 from IF-MIB
     get:
       # List of OIDs to get directly.
       - 1.3.6.1.2.1.1.3

--- a/generator/README.md
+++ b/generator/README.md
@@ -109,9 +109,11 @@ auths:
 
 modules:
   module_name:  # The module name. You can have as many modules as you want.
-    walk:       # List of OIDs to walk. Can also be SNMP object names or specific instances.
+    # List of OIDs to walk. Can also be SNMP object names or specific instances.
+    # Object names can be fully-qualified with the MIB name separated by `::`.
+    walk:
       - 1.3.6.1.2.1.2              # Same as "interfaces"
-      - sysUpTime                  # Same as "1.3.6.1.2.1.1.3"
+      - "SNMPv2-MIB::sysUpTime"    # Same as "1.3.6.1.2.1.1.3"
       - 1.3.6.1.2.1.31.1.1.1.6.40  # Instance of "ifHCInOctets" with index "40"
       - 1.3.6.1.2.1.2.2.1.4        # Same as ifMtu (used for filter example)
       - bsnDot11EssSsid            # Same as 1.3.6.1.4.1.14179.2.1.1.1.2 (used for filter example)

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -6,12 +6,21 @@ auths:
     version: 2
 
 modules:
+  # SNMPv2-MIB for things like sysDescr, sysUpTime, etc.
+  system:
+    walk:
+      - "SNMPv2-MIB::system"
+    lookups:
+      - source_indexes: [sysORIndex]
+        lookup: "SNMPv2-MIB::sysORDescr"
   # Default IF-MIB interfaces table with ifIndex.
   if_mib:
-    walk: [sysUpTime, interfaces, ifXTable]
+    walk:
+      - "IF-MIB::interfaces"
+      - "IF-MIB::ifXTable"
     lookups:
       - source_indexes: [ifIndex]
-        lookup: ifAlias
+        lookup: "IF-MIB::ifAlias"
       - source_indexes: [ifIndex]
         # Disambiguate from PaloAlto PAN-COMMON-MIB::ifDescr.
         lookup: "IF-MIB::ifDescr"
@@ -66,7 +75,6 @@ modules:
 # HPE MIBs
   hpe:
     walk:
-      - sysUpTime
       - 1.3.6.1.4.1.232.1.2.2.1.1     # CPU
       - 1.3.6.1.4.1.232.11            # Firmware version
       - 1.3.6.1.4.1.232.14            # Asmd agent IDE/SATA
@@ -692,8 +700,7 @@ modules:
 # http://download2.mikrotik.com/Mikrotik.mib
   mikrotik:
     walk:
-      - sysDescr
-      - mikrotik
+      - "MIKROTIK-MIB::mikrotik"
     lookups:
       - source_indexes: [ifIndex]
         lookup: ifName

--- a/snmp.yml
+++ b/snmp.yml
@@ -13051,14 +13051,7 @@ modules:
     - 1.3.6.1.4.1.232.6.2.6.8.1
     - 1.3.6.1.4.1.232.6.2.9
     - 1.3.6.1.4.1.232.9.2.2
-    get:
-    - 1.3.6.1.2.1.1.3.0
     metrics:
-    - name: sysUpTime
-      oid: 1.3.6.1.2.1.1.3
-      type: gauge
-      help: The time (in hundredths of a second) since the network management portion
-        of the system was last re-initialized. - 1.3.6.1.2.1.1.3
     - name: cpqSeCpuUnitIndex
       oid: 1.3.6.1.4.1.232.1.2.2.1.1.1
       type: gauge
@@ -21135,14 +21128,7 @@ modules:
     walk:
     - 1.3.6.1.2.1.2
     - 1.3.6.1.2.1.31.1.1
-    get:
-    - 1.3.6.1.2.1.1.3.0
     metrics:
-    - name: sysUpTime
-      oid: 1.3.6.1.2.1.1.3
-      type: gauge
-      help: The time (in hundredths of a second) since the network management portion
-        of the system was last re-initialized. - 1.3.6.1.2.1.1.3
     - name: ifNumber
       oid: 1.3.6.1.2.1.2.1
       type: gauge
@@ -27477,13 +27463,7 @@ modules:
     walk:
     - 1.3.6.1.2.1.31.1.1.1.1
     - 1.3.6.1.4.1.14988
-    get:
-    - 1.3.6.1.2.1.1.1.0
     metrics:
-    - name: sysDescr
-      oid: 1.3.6.1.2.1.1.1
-      type: DisplayString
-      help: A textual description of the entity - 1.3.6.1.2.1.1.1
     - name: mtxrWlStatIndex
       oid: 1.3.6.1.4.1.14988.1.1.1.1.1.1
       type: gauge
@@ -39896,6 +39876,105 @@ modules:
         type: DisplayString
       - labels: []
         labelname: serviceInfoIndex
+  system:
+    walk:
+    - 1.3.6.1.2.1.1
+    metrics:
+    - name: sysDescr
+      oid: 1.3.6.1.2.1.1.1
+      type: DisplayString
+      help: A textual description of the entity - 1.3.6.1.2.1.1.1
+    - name: sysObjectID
+      oid: 1.3.6.1.2.1.1.2
+      type: OctetString
+      help: The vendor's authoritative identification of the network management subsystem
+        contained in the entity - 1.3.6.1.2.1.1.2
+    - name: sysUpTime
+      oid: 1.3.6.1.2.1.1.3
+      type: gauge
+      help: The time (in hundredths of a second) since the network management portion
+        of the system was last re-initialized. - 1.3.6.1.2.1.1.3
+    - name: sysContact
+      oid: 1.3.6.1.2.1.1.4
+      type: DisplayString
+      help: The textual identification of the contact person for this managed node,
+        together with information on how to contact this person - 1.3.6.1.2.1.1.4
+    - name: sysName
+      oid: 1.3.6.1.2.1.1.5
+      type: DisplayString
+      help: An administratively-assigned name for this managed node - 1.3.6.1.2.1.1.5
+    - name: sysLocation
+      oid: 1.3.6.1.2.1.1.6
+      type: DisplayString
+      help: The physical location of this node (e.g., 'telephone closet, 3rd floor')
+        - 1.3.6.1.2.1.1.6
+    - name: sysServices
+      oid: 1.3.6.1.2.1.1.7
+      type: gauge
+      help: A value which indicates the set of services that this entity may potentially
+        offer - 1.3.6.1.2.1.1.7
+    - name: sysORLastChange
+      oid: 1.3.6.1.2.1.1.8
+      type: gauge
+      help: The value of sysUpTime at the time of the most recent change in state
+        or value of any instance of sysORID. - 1.3.6.1.2.1.1.8
+    - name: sysORIndex
+      oid: 1.3.6.1.2.1.1.9.1.1
+      type: gauge
+      help: The auxiliary variable used for identifying instances of the columnar
+        objects in the sysORTable. - 1.3.6.1.2.1.1.9.1.1
+      indexes:
+      - labelname: sysORIndex
+        type: gauge
+      lookups:
+      - labels:
+        - sysORIndex
+        labelname: sysORDescr
+        oid: 1.3.6.1.2.1.1.9.1.3
+        type: DisplayString
+    - name: sysORID
+      oid: 1.3.6.1.2.1.1.9.1.2
+      type: OctetString
+      help: An authoritative identification of a capabilities statement with respect
+        to various MIB modules supported by the local SNMP application acting as a
+        command responder. - 1.3.6.1.2.1.1.9.1.2
+      indexes:
+      - labelname: sysORIndex
+        type: gauge
+      lookups:
+      - labels:
+        - sysORIndex
+        labelname: sysORDescr
+        oid: 1.3.6.1.2.1.1.9.1.3
+        type: DisplayString
+    - name: sysORDescr
+      oid: 1.3.6.1.2.1.1.9.1.3
+      type: DisplayString
+      help: A textual description of the capabilities identified by the corresponding
+        instance of sysORID. - 1.3.6.1.2.1.1.9.1.3
+      indexes:
+      - labelname: sysORIndex
+        type: gauge
+      lookups:
+      - labels:
+        - sysORIndex
+        labelname: sysORDescr
+        oid: 1.3.6.1.2.1.1.9.1.3
+        type: DisplayString
+    - name: sysORUpTime
+      oid: 1.3.6.1.2.1.1.9.1.4
+      type: gauge
+      help: The value of sysUpTime at the time this conceptual row was last instantiated.
+        - 1.3.6.1.2.1.1.9.1.4
+      indexes:
+      - labelname: sysORIndex
+        type: gauge
+      lookups:
+      - labels:
+        - sysORIndex
+        labelname: sysORDescr
+        oid: 1.3.6.1.2.1.1.9.1.3
+        type: DisplayString
   tplink-ddm:
     walk:
     - 1.3.6.1.2.1.31.1.1.1.1


### PR DESCRIPTION
Refactor SNMPv2-MIB walks into a dedicated `system` module.
* Use more fully-qualified OIDs for walks.
* Add more documentation around the fully-qualified OID syntax.