### PR TITLE
Add args to serve application behind a route prefix/external URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -17,14 +17,15 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
-	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"path"
 	"strings"
 	"sync"
 	"syscall"
 
 	"github.com/alecthomas/kingpin/v2"
+
 	"github.com/prometheus/client_golang/prometheus"
 	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -50,11 +51,9 @@ var (
 	concurrency   = kingpin.Flag("snmp.module-concurrency", "The number of modules to fetch concurrently per scrape").Default("1").Int()
 	debugSNMP     = kingpin.Flag("snmp.debug-packets", "Include a full debug trace of SNMP packet traffics.").Default("false").Bool()
 	expandEnvVars = kingpin.Flag("config.expand-environment-variables", "Expand environment variables to source secrets").Default("false").Bool()
-	metricsPath   = kingpin.Flag(
-		"web.telemetry-path",
-		"Path under which to expose metrics.",
-	).Default("/metrics").String()
-	toolkitFlags = webflag.AddFlags(kingpin.CommandLine, ":9116")
+	routePrefix   = toolkitFlags.WebRoutePrefix
+	metricsPath   = toolkitFlags.WebMetricsPath
+	toolkitFlags  = webflag.AddFlags(kingpin.CommandLine, ":9116")
 
 	// Metrics about the SNMP exporter itself.
 	snmpRequestErrors = promauto.NewCounter(
@@ -293,23 +292,16 @@ func main() {
 		),
 	}
 
-	http.Handle(*metricsPath, promhttp.Handler()) // Normal metrics endpoint for SNMP exporter itself.
-	// Endpoint to do SNMP scrapes.
-	http.HandleFunc(proberPath, func(w http.ResponseWriter, r *http.Request) {
-		handler(w, r, logger, exporterMetrics)
-	})
-	http.HandleFunc("/-/reload", updateConfiguration) // Endpoint to reload configuration.
-	// Endpoint to respond to health checks
-	http.HandleFunc("/-/healthy", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-		w.Write([]byte("Healthy"))
-	})
-
 	if *metricsPath != "/" && *metricsPath != "" {
 		landingConfig := web.LandingConfig{
-			Name:        "SNMP Exporter",
-			Description: "Prometheus Exporter for SNMP targets",
-			Version:     version.Info(),
+			Name:             "SNMP Exporter",
+			Description:      "Prometheus Exporter for SNMP targets",
+			Version:          version.Info(),
+			RoutePrefix:      *routePrefix,
+			ExternalURL:      *toolkitFlags.WebExternalURL,
+			ListenAddresses:  *toolkitFlags.WebListenAddresses,
+			UseSystemdSocket: *toolkitFlags.WebSystemdSocket,
+			Logger:           logger,
 			Form: web.LandingForm{
 				Action: proberPath,
 				Inputs: []web.LandingFormInput{
@@ -347,15 +339,25 @@ func main() {
 				},
 			},
 		}
-		landingPage, err := web.NewLandingPage(landingConfig)
+		landingPage, processedRoutePrefix, err := web.NewLandingPage(landingConfig)
 		if err != nil {
 			logger.Error("Error creating landing page", "err", err)
 			os.Exit(1)
 		}
-		http.Handle("/", landingPage)
+		*routePrefix = processedRoutePrefix
+		http.Handle(*routePrefix, landingPage)
 	}
 
-	http.HandleFunc(configPath, func(w http.ResponseWriter, r *http.Request) {
+	http.Handle(path.Join(*routePrefix, *metricsPath), promhttp.Handler()) // Normal metrics endpoint for SNMP exporter itself.
+
+	// Endpoint to do SNMP scrapes.
+	http.HandleFunc(path.Join(*routePrefix, proberPath), func(w http.ResponseWriter, r *http.Request) {
+		handler(w, r, logger, exporterMetrics)
+	})
+
+	http.HandleFunc(path.Join(*routePrefix, "/-/reload"), updateConfiguration) // Endpoint to reload configuration.
+
+	http.HandleFunc(path.Join(*routePrefix, configPath), func(w http.ResponseWriter, r *http.Request) {
 		sc.RLock()
 		c, err := yaml.Marshal(sc.C)
 		sc.RUnlock()


### PR DESCRIPTION
This is a duplicate of #1328
Sorry for the duplicate. Didn't realize deleting my branch would auto-close the pull request. Anyways... 🤦‍♂️ 

Add feature to serve application behind a route prefix or external URL by supplying args --web.external-url/--web.route-prefix, in the same way as blackbox_exporter or other exporters.

I am also submitting a pull request for exporter-toolkit so that this will actually work. Currently you cannot serve the landing page on anything other than root ("/"), so the tests are going to fail initially.

I would consider these additional args to be "must-have" features to bring snmp_exporter closer to feature parity with the other exporters. I needed to serve this exporter behind a prefix like I'm doing with the other exporters, so I figured I would make an attempt at this update myself, as it does appear to be something other people have been wanting for quite some time. See: #648