### PR TITLE
Add Feature to Override Metric Name in Generator

### DIFF
--- a/generator/README.md
+++ b/generator/README.md
@@ -159,6 +159,7 @@ modules:
       metricName:
         ignore: true # Drops the metric from the output.
         help: "string" # Override the generated HELP text provided by the MIB Description.
+        name: "string" # Override the OID name provided in the MIB Description.
         regex_extracts:
           Temp: # A new metric will be created appending this to the metricName to become metricNameTemp.
             - regex: '(.*)' # Regex to extract a value from the returned SNMP walks's value.

--- a/generator/config.go
+++ b/generator/config.go
@@ -35,6 +35,7 @@ type MetricOverrides struct {
 	Scale           float64                           `yaml:"scale,omitempty"`
 	Type            string                            `yaml:"type,omitempty"`
 	Help            string                            `yaml:"help,omitempty"`
+	Name            string                            `yaml:"name,omitempty"`
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface.

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -542,6 +542,9 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 				if params.Help != "" {
 					metric.Help = params.Help
 				}
+				if params.Name != "" {
+					metric.Name = params.Name
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Description  
This PR introduces a feature to the `snmp_exporter` generator, enabling users to override metric names directly in the `generator.yml` file. The new `name` parameter in the override section allows for custom metric names to be output in the `snmp.yml` file, streamlining monitoring of devices with similar metrics but differing MIB OID names.

#### Key Changes:  
1. **Code Changes**:  
   - **`generator/config.go`**: Added support for the optional `name` parameter in the override section.  
   - **`generator/tree.go`**: Ensures the `name` parameter, if specified and non-empty, replaces the default MIB-based metric name.  

2. **Documentation**:  
   - **`generator/README.md`**: Updated to describe the `name` parameter and its usage in the `generator.yml` override section.  

### Example Usage  
The following example demonstrates how to configure custom metric names for two types of power supplies in `generator.yml`:

```yml
# Emerson/Vertiv netsure Power Supply
  vertiv_netsure:
    walk:
    - psTemperature1
    - psInputLineAVoltage
    - systemVoltage
    - systemCurrent
    - psTotalBatteryCurrent
    overrides:
      psTemperature1:
        scale: 0.001
        name: pfuTemperature
        help: "System Temperature in Celsius"
      psInputLineAVoltage:
        scale: 0.001
        name: pfuInputVoltage
        help: "AC Input Voltage in Volts"
      systemVoltage:
        scale: 0.001
        name: pfuOutputVoltage
        help: "DC Output Voltage in Volts"
      systemCurrent:
        scale: 0.001
        name: pfuOutputCurrent
        help: "DC Output Current in Amperes"
      psTotalBatteryCurrent:
        scale: 0.001
        name: pfuBatteryCurrent
        help: "Battery Current in Amperes"

# Compas (Alpha Innovations) Power Supply
  compas:
    walk:
    - es1DcSys1DataBatMeasurementsTemp
    - es1DcSys1DataACInputsGlobalAverageVoltage
    - es1DcSys1DataConvertersOutVoltage
    - es1DcSys1DataConvertersOutCurrent
    - es1DcSys1DataBatMeasurementsInputCurrent
    overrides:
      es1DcSys1DataBatMeasurementsTemp:
        name: pfuTemperature
        help: "System Temperature in Celsius"
      es1DcSys1DataACInputsGlobalAverageVoltage:
        name: pfuInputVoltage
        help: "AC Input Voltage in Volts"
      es1DcSys1DataConvertersOutVoltage:
        name: pfuOutputVoltage
        help: "DC Output Voltage in Volts"
      es1DcSys1DataConvertersOutCurrent:
        name: pfuOutputCurrent
        help: "DC Output Current in Amperes"
      es1DcSys1DataBatMeasurementsInputCurrent:
        name: pfuBatteryCurrent
        help: "Battery Current in Amperes"
```

### Justification  
This feature was implemented to address the need to monitor -48 VDC power systems from multiple vendors. Although these systems share the same types of metrics (e.g., input/output electrical values, battery status), their MIB-based names differ. With this feature, metric names can be normalized at the generator step, eliminating the need for relabeling or recording rules in the main prometheus.yml.  

### Testing  
- Verified that the `name` parameter correctly overrides the default metric name when specified.  
- Tested with real-world configurations for multiple devices to ensure consistent and expected behavior.  

### Checklist  
- [x] The feature is backward-compatible and does not affect existing configurations.  
- [x] Documentation has been updated to reflect the new functionality.  