### PR TITLE
hrDevice module: add hrDeviceDescr lookup to hrDevice; add hrDeviceStatus as enum

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -773,6 +773,8 @@ modules:
     overrides:
       hrPrinterStatus:
         type: EnumAsStateSet
+      hrDeviceStatus:
+        type: EnumAsStateSet
   hrSWRun:
     walk:
       - hrSWRun

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -766,6 +766,10 @@ modules:
   hrDevice:
     walk:
       - hrDevice
+    lookups:
+      - source_indexes: [hrDeviceIndex]
+        lookup: hrDeviceDescr
+        drop_source_indexes: true
     overrides:
       hrPrinterStatus:
         type: EnumAsStateSet

--- a/snmp.yml
+++ b/snmp.yml
@@ -20627,7 +20627,7 @@ modules:
         labelname: hrDeviceIndex
     - name: hrDeviceStatus
       oid: 1.3.6.1.2.1.25.3.2.1.5
-      type: gauge
+      type: EnumAsStateSet
       help: The current operational state of the device described by this row of the
         table - 1.3.6.1.2.1.25.3.2.1.5
       indexes:

--- a/snmp.yml
+++ b/snmp.yml
@@ -20571,6 +20571,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrDeviceType
       oid: 1.3.6.1.2.1.25.3.2.1.2
       type: OctetString
@@ -20578,6 +20586,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrDeviceDescr
       oid: 1.3.6.1.2.1.25.3.2.1.3
       type: DisplayString
@@ -20586,6 +20602,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrDeviceID
       oid: 1.3.6.1.2.1.25.3.2.1.4
       type: OctetString
@@ -20593,6 +20617,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrDeviceStatus
       oid: 1.3.6.1.2.1.25.3.2.1.5
       type: gauge
@@ -20601,6 +20633,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
       enum_values:
         1: unknown
         2: running
@@ -20614,6 +20654,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrProcessorFrwID
       oid: 1.3.6.1.2.1.25.3.3.1.1
       type: OctetString
@@ -20621,6 +20669,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrProcessorLoad
       oid: 1.3.6.1.2.1.25.3.3.1.2
       type: gauge
@@ -20629,6 +20685,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrNetworkIfIndex
       oid: 1.3.6.1.2.1.25.3.4.1.1
       type: gauge
@@ -20636,6 +20700,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrPrinterStatus
       oid: 1.3.6.1.2.1.25.3.5.1.1
       type: EnumAsStateSet
@@ -20643,6 +20715,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
       enum_values:
         1: other
         2: unknown
@@ -20657,6 +20737,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrDiskStorageAccess
       oid: 1.3.6.1.2.1.25.3.6.1.1
       type: gauge
@@ -20665,6 +20753,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
       enum_values:
         1: readWrite
         2: readOnly
@@ -20676,6 +20772,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
       enum_values:
         1: other
         2: unknown
@@ -20693,6 +20797,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
       enum_values:
         1: "true"
         2: "false"
@@ -20703,6 +20815,14 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrPartitionIndex
       oid: 1.3.6.1.2.1.25.3.7.1.1
       type: gauge
@@ -20712,6 +20832,14 @@ modules:
         type: gauge
       - labelname: hrPartitionIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrPartitionLabel
       oid: 1.3.6.1.2.1.25.3.7.1.2
       type: OctetString
@@ -20721,6 +20849,14 @@ modules:
         type: gauge
       - labelname: hrPartitionIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrPartitionID
       oid: 1.3.6.1.2.1.25.3.7.1.3
       type: OctetString
@@ -20731,6 +20867,14 @@ modules:
         type: gauge
       - labelname: hrPartitionIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrPartitionSize
       oid: 1.3.6.1.2.1.25.3.7.1.4
       type: gauge
@@ -20740,6 +20884,14 @@ modules:
         type: gauge
       - labelname: hrPartitionIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrPartitionFSIndex
       oid: 1.3.6.1.2.1.25.3.7.1.5
       type: gauge
@@ -20749,6 +20901,14 @@ modules:
         type: gauge
       - labelname: hrPartitionIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels: []
+        labelname: hrDeviceIndex
     - name: hrFSIndex
       oid: 1.3.6.1.2.1.25.3.8.1.1
       type: gauge


### PR DESCRIPTION
Sample output with this change, otherwise it is only indexes.
```
# HELP hrDeviceDescr A textual description of this device, including the device's manufacturer and revision, and optionally, its serial number. - 1.3.6.1.2.1.25.3.2.1.3
# TYPE hrDeviceDescr gauge
hrDeviceDescr{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor"} 1
hrDeviceDescr{hrDeviceDescr="Core 1"} 1
hrDeviceDescr{hrDeviceDescr="Core 2"} 1
# HELP hrDeviceErrors The number of errors detected on this device - 1.3.6.1.2.1.25.3.2.1.6
# TYPE hrDeviceErrors counter
hrDeviceErrors{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor"} 0
hrDeviceErrors{hrDeviceDescr="Core 1"} 0
hrDeviceErrors{hrDeviceDescr="Core 2"} 0
# HELP hrDeviceID The product ID for this device. - 1.3.6.1.2.1.25.3.2.1.4
# TYPE hrDeviceID gauge
hrDeviceID{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor",hrDeviceID="0.0"} 1
hrDeviceID{hrDeviceDescr="Core 1",hrDeviceID="0.0"} 1
hrDeviceID{hrDeviceDescr="Core 2",hrDeviceID="0.0"} 1
# HELP hrDeviceIndex A unique value for each device contained by the host - 1.3.6.1.2.1.25.3.2.1.1
# TYPE hrDeviceIndex gauge
hrDeviceIndex{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor"} 1
hrDeviceIndex{hrDeviceDescr="Core 1"} 2
hrDeviceIndex{hrDeviceDescr="Core 2"} 3
# HELP hrDeviceStatus The current operational state of the device described by this row of the table - 1.3.6.1.2.1.25.3.2.1.5 (EnumAsStateSet)
# TYPE hrDeviceStatus gauge
hrDeviceStatus{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor",hrDeviceStatus="down"} 0
hrDeviceStatus{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor",hrDeviceStatus="running"} 1
hrDeviceStatus{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor",hrDeviceStatus="testing"} 0
hrDeviceStatus{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor",hrDeviceStatus="unknown"} 0
hrDeviceStatus{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor",hrDeviceStatus="warning"} 0
hrDeviceStatus{hrDeviceDescr="Core 1",hrDeviceStatus="down"} 0
hrDeviceStatus{hrDeviceDescr="Core 1",hrDeviceStatus="running"} 1
hrDeviceStatus{hrDeviceDescr="Core 1",hrDeviceStatus="testing"} 0
hrDeviceStatus{hrDeviceDescr="Core 1",hrDeviceStatus="unknown"} 0
hrDeviceStatus{hrDeviceDescr="Core 1",hrDeviceStatus="warning"} 0
hrDeviceStatus{hrDeviceDescr="Core 2",hrDeviceStatus="down"} 0
hrDeviceStatus{hrDeviceDescr="Core 2",hrDeviceStatus="running"} 1
hrDeviceStatus{hrDeviceDescr="Core 2",hrDeviceStatus="testing"} 0
hrDeviceStatus{hrDeviceDescr="Core 2",hrDeviceStatus="unknown"} 0
hrDeviceStatus{hrDeviceDescr="Core 2",hrDeviceStatus="warning"} 0
# HELP hrDeviceType An indication of the type of device - 1.3.6.1.2.1.25.3.2.1.2
# TYPE hrDeviceType gauge
hrDeviceType{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceType{hrDeviceDescr="Core 1",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceType{hrDeviceDescr="Core 2",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
# HELP hrProcessorFrwID The product ID of the firmware associated with the processor. - 1.3.6.1.2.1.25.3.3.1.1
# TYPE hrProcessorFrwID gauge
hrProcessorFrwID{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor",hrProcessorFrwID="0.0"} 1
hrProcessorFrwID{hrDeviceDescr="Core 1",hrProcessorFrwID="0.0"} 1
hrProcessorFrwID{hrDeviceDescr="Core 2",hrProcessorFrwID="0.0"} 1
# HELP hrProcessorLoad The average, over the last minute, of the percentage of time that this processor was not idle - 1.3.6.1.2.1.25.3.3.1.2
# TYPE hrProcessorLoad gauge
hrProcessorLoad{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor"} 43
hrProcessorLoad{hrDeviceDescr="Core 1"} 47
hrProcessorLoad{hrDeviceDescr="Core 2"} 40
# HELP snmp_scrape_duration_seconds Total SNMP time scrape took (walk and processing).
# TYPE snmp_scrape_duration_seconds gauge
snmp_scrape_duration_seconds{module="hrDevice"} 0.031709625
# HELP snmp_scrape_packets_retried Packets retried for get, bulkget, and walk.
# TYPE snmp_scrape_packets_retried gauge
snmp_scrape_packets_retried{module="hrDevice"} 0
# HELP snmp_scrape_packets_sent Packets sent for get, bulkget, and walk; including retries.
# TYPE snmp_scrape_packets_sent gauge
snmp_scrape_packets_sent{module="hrDevice"} 1
# HELP snmp_scrape_pdus_returned PDUs returned from get, bulkget, and walk.
# TYPE snmp_scrape_pdus_returned gauge
snmp_scrape_pdus_returned{module="hrDevice"} 24
# HELP snmp_scrape_walk_duration_seconds Time SNMP walk/bulkwalk took.
# TYPE snmp_scrape_walk_duration_seconds gauge
snmp_scrape_walk_duration_seconds{module="hrDevice"} 0.03130875
```