### PR TITLE
module update: add ignore to hrDevice/hrStorage; drop unused mikrotik lookups

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -724,10 +724,6 @@ modules:
       - source_indexes: [mtxrPartitionIndex]
         lookup: mtxrPartitionName
     overrides:
-      ifName:
-        ignore: true # Lookup metric
-      ifType:
-        type: EnumAsInfo
       # Remap enums where 1==true, 2==false to become 0==false, 1==true.
       hrDiskStorageRemoveble:
         scale: -1.0
@@ -762,13 +758,34 @@ modules:
     lookups:
       - source_indexes: [hrStorageIndex]
         lookup: hrStorageDescr
-        drop_source_indexes: true
+      - source_indexes: [hrStorageIndex]
+        lookup: hrStorageType
+    overrides:
+      hrStorageIndex:
+        ignore: true
+      hrStorageType:
+        ignore: true
+      hrStorageDescr:
+        ignore: true
   hrDevice:
     walk:
       - hrDevice
+    lookups:
+      - source_indexes: [hrDeviceIndex]
+        lookup: hrDeviceDescr
+      - source_indexes: [hrDeviceIndex]
+        lookup: hrDeviceType
     overrides:
       hrPrinterStatus:
         type: EnumAsStateSet
+      hrDeviceIndex:
+        ignore: true
+      hrDeviceType:
+        ignore: true
+      hrDeviceDescr:
+        ignore: true
+      hrProcessorFrwID:
+        ignore: true
   hrSWRun:
     walk:
       - hrSWRun

--- a/snmp.yml
+++ b/snmp.yml
@@ -20564,28 +20564,6 @@ modules:
     walk:
     - 1.3.6.1.2.1.25.3
     metrics:
-    - name: hrDeviceIndex
-      oid: 1.3.6.1.2.1.25.3.2.1.1
-      type: gauge
-      help: A unique value for each device contained by the host - 1.3.6.1.2.1.25.3.2.1.1
-      indexes:
-      - labelname: hrDeviceIndex
-        type: gauge
-    - name: hrDeviceType
-      oid: 1.3.6.1.2.1.25.3.2.1.2
-      type: OctetString
-      help: An indication of the type of device - 1.3.6.1.2.1.25.3.2.1.2
-      indexes:
-      - labelname: hrDeviceIndex
-        type: gauge
-    - name: hrDeviceDescr
-      oid: 1.3.6.1.2.1.25.3.2.1.3
-      type: DisplayString
-      help: A textual description of this device, including the device's manufacturer
-        and revision, and optionally, its serial number. - 1.3.6.1.2.1.25.3.2.1.3
-      indexes:
-      - labelname: hrDeviceIndex
-        type: gauge
     - name: hrDeviceID
       oid: 1.3.6.1.2.1.25.3.2.1.4
       type: OctetString
@@ -20593,6 +20571,17 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
     - name: hrDeviceStatus
       oid: 1.3.6.1.2.1.25.3.2.1.5
       type: gauge
@@ -20601,6 +20590,17 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
       enum_values:
         1: unknown
         2: running
@@ -20614,13 +20614,17 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
-    - name: hrProcessorFrwID
-      oid: 1.3.6.1.2.1.25.3.3.1.1
-      type: OctetString
-      help: The product ID of the firmware associated with the processor. - 1.3.6.1.2.1.25.3.3.1.1
-      indexes:
-      - labelname: hrDeviceIndex
-        type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
     - name: hrProcessorLoad
       oid: 1.3.6.1.2.1.25.3.3.1.2
       type: gauge
@@ -20629,6 +20633,17 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
     - name: hrNetworkIfIndex
       oid: 1.3.6.1.2.1.25.3.4.1.1
       type: gauge
@@ -20636,6 +20651,17 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
     - name: hrPrinterStatus
       oid: 1.3.6.1.2.1.25.3.5.1.1
       type: EnumAsStateSet
@@ -20643,6 +20669,17 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
       enum_values:
         1: other
         2: unknown
@@ -20657,6 +20694,17 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
     - name: hrDiskStorageAccess
       oid: 1.3.6.1.2.1.25.3.6.1.1
       type: gauge
@@ -20665,6 +20713,17 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
       enum_values:
         1: readWrite
         2: readOnly
@@ -20676,6 +20735,17 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
       enum_values:
         1: other
         2: unknown
@@ -20693,6 +20763,17 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
       enum_values:
         1: "true"
         2: "false"
@@ -20703,6 +20784,17 @@ modules:
       indexes:
       - labelname: hrDeviceIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
     - name: hrPartitionIndex
       oid: 1.3.6.1.2.1.25.3.7.1.1
       type: gauge
@@ -20712,6 +20804,17 @@ modules:
         type: gauge
       - labelname: hrPartitionIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
     - name: hrPartitionLabel
       oid: 1.3.6.1.2.1.25.3.7.1.2
       type: OctetString
@@ -20721,6 +20824,17 @@ modules:
         type: gauge
       - labelname: hrPartitionIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
     - name: hrPartitionID
       oid: 1.3.6.1.2.1.25.3.7.1.3
       type: OctetString
@@ -20731,6 +20845,17 @@ modules:
         type: gauge
       - labelname: hrPartitionIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
     - name: hrPartitionSize
       oid: 1.3.6.1.2.1.25.3.7.1.4
       type: gauge
@@ -20740,6 +20865,17 @@ modules:
         type: gauge
       - labelname: hrPartitionIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
     - name: hrPartitionFSIndex
       oid: 1.3.6.1.2.1.25.3.7.1.5
       type: gauge
@@ -20749,6 +20885,17 @@ modules:
         type: gauge
       - labelname: hrPartitionIndex
         type: gauge
+      lookups:
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceDescr
+        oid: 1.3.6.1.2.1.25.3.2.1.3
+        type: DisplayString
+      - labels:
+        - hrDeviceIndex
+        labelname: hrDeviceType
+        oid: 1.3.6.1.2.1.25.3.2.1.2
+        type: OctetString
     - name: hrFSIndex
       oid: 1.3.6.1.2.1.25.3.8.1.1
       type: gauge
@@ -20978,53 +21125,6 @@ modules:
       type: gauge
       help: The amount of physical read-write main memory, typically RAM, contained
         by the host. - 1.3.6.1.2.1.25.2.2
-    - name: hrStorageIndex
-      oid: 1.3.6.1.2.1.25.2.3.1.1
-      type: gauge
-      help: A unique value for each logical storage area contained by the host. -
-        1.3.6.1.2.1.25.2.3.1.1
-      indexes:
-      - labelname: hrStorageIndex
-        type: gauge
-      lookups:
-      - labels:
-        - hrStorageIndex
-        labelname: hrStorageDescr
-        oid: 1.3.6.1.2.1.25.2.3.1.3
-        type: DisplayString
-      - labels: []
-        labelname: hrStorageIndex
-    - name: hrStorageType
-      oid: 1.3.6.1.2.1.25.2.3.1.2
-      type: OctetString
-      help: The type of storage represented by this entry. - 1.3.6.1.2.1.25.2.3.1.2
-      indexes:
-      - labelname: hrStorageIndex
-        type: gauge
-      lookups:
-      - labels:
-        - hrStorageIndex
-        labelname: hrStorageDescr
-        oid: 1.3.6.1.2.1.25.2.3.1.3
-        type: DisplayString
-      - labels: []
-        labelname: hrStorageIndex
-    - name: hrStorageDescr
-      oid: 1.3.6.1.2.1.25.2.3.1.3
-      type: DisplayString
-      help: A description of the type and instance of the storage described by this
-        entry. - 1.3.6.1.2.1.25.2.3.1.3
-      indexes:
-      - labelname: hrStorageIndex
-        type: gauge
-      lookups:
-      - labels:
-        - hrStorageIndex
-        labelname: hrStorageDescr
-        oid: 1.3.6.1.2.1.25.2.3.1.3
-        type: DisplayString
-      - labels: []
-        labelname: hrStorageIndex
     - name: hrStorageAllocationUnits
       oid: 1.3.6.1.2.1.25.2.3.1.4
       type: gauge
@@ -21038,8 +21138,11 @@ modules:
         labelname: hrStorageDescr
         oid: 1.3.6.1.2.1.25.2.3.1.3
         type: DisplayString
-      - labels: []
-        labelname: hrStorageIndex
+      - labels:
+        - hrStorageIndex
+        labelname: hrStorageType
+        oid: 1.3.6.1.2.1.25.2.3.1.2
+        type: OctetString
     - name: hrStorageSize
       oid: 1.3.6.1.2.1.25.2.3.1.5
       type: gauge
@@ -21054,8 +21157,11 @@ modules:
         labelname: hrStorageDescr
         oid: 1.3.6.1.2.1.25.2.3.1.3
         type: DisplayString
-      - labels: []
-        labelname: hrStorageIndex
+      - labels:
+        - hrStorageIndex
+        labelname: hrStorageType
+        oid: 1.3.6.1.2.1.25.2.3.1.2
+        type: OctetString
     - name: hrStorageUsed
       oid: 1.3.6.1.2.1.25.2.3.1.6
       type: gauge
@@ -21070,8 +21176,11 @@ modules:
         labelname: hrStorageDescr
         oid: 1.3.6.1.2.1.25.2.3.1.3
         type: DisplayString
-      - labels: []
-        labelname: hrStorageIndex
+      - labels:
+        - hrStorageIndex
+        labelname: hrStorageType
+        oid: 1.3.6.1.2.1.25.2.3.1.2
+        type: OctetString
     - name: hrStorageAllocationFailures
       oid: 1.3.6.1.2.1.25.2.3.1.7
       type: counter
@@ -21086,8 +21195,11 @@ modules:
         labelname: hrStorageDescr
         oid: 1.3.6.1.2.1.25.2.3.1.3
         type: DisplayString
-      - labels: []
-        labelname: hrStorageIndex
+      - labels:
+        - hrStorageIndex
+        labelname: hrStorageType
+        oid: 1.3.6.1.2.1.25.2.3.1.2
+        type: OctetString
   hrSystem:
     walk:
     - 1.3.6.1.2.1.25.1


### PR DESCRIPTION
module update: 
- add ignore to hrDevice/hrStorage; 
- drop unused mikrotik lookups
- do not drop hrStorageIndex as hrStorageDescr may be not unique, giving error
- add storageType to lookup so it is easiert to filter specific device types (i.e. memory).

example output from mikrotik (hrStorage,hrDevice):
```
# HELP hrMemorySize The amount of physical read-write main memory, typically RAM, contained by the host. - 1.3.6.1.2.1.25.2.2
# TYPE hrMemorySize gauge
hrMemorySize 1.555068e+06
# HELP hrProcessorLoad The average, over the last minute, of the percentage of time that this processor was not idle - 1.3.6.1.2.1.25.3.3.1.2
# TYPE hrProcessorLoad gauge
hrProcessorLoad{hrDeviceDescr="",hrDeviceIndex="1",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 23
hrProcessorLoad{hrDeviceDescr="",hrDeviceIndex="2",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 40
# HELP hrStorageAllocationFailures The number of requests for storage represented by this entry that could not be honored due to not enough storage - 1.3.6.1.2.1.25.2.3.1.7
# TYPE hrStorageAllocationFailures counter
hrStorageAllocationFailures{hrStorageDescr="main memory",hrStorageIndex="65536",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 0
hrStorageAllocationFailures{hrStorageDescr="system disk",hrStorageIndex="131072",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 0
# HELP hrStorageAllocationUnits The size, in bytes, of the data objects allocated from this pool - 1.3.6.1.2.1.25.2.3.1.4
# TYPE hrStorageAllocationUnits gauge
hrStorageAllocationUnits{hrStorageDescr="main memory",hrStorageIndex="65536",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 1024
hrStorageAllocationUnits{hrStorageDescr="system disk",hrStorageIndex="131072",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 1024
# HELP hrStorageSize The size of the storage represented by this entry, in units of hrStorageAllocationUnits - 1.3.6.1.2.1.25.2.3.1.5
# TYPE hrStorageSize gauge
hrStorageSize{hrStorageDescr="main memory",hrStorageIndex="65536",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 1.555068e+06
hrStorageSize{hrStorageDescr="system disk",hrStorageIndex="131072",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 131072
# HELP hrStorageUsed The amount of the storage represented by this entry that is allocated, in units of hrStorageAllocationUnits. - 1.3.6.1.2.1.25.2.3.1.6
# TYPE hrStorageUsed gauge
hrStorageUsed{hrStorageDescr="main memory",hrStorageIndex="65536",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 37324
hrStorageUsed{hrStorageDescr="system disk",hrStorageIndex="131072",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 39148
# HELP snmp_scrape_duration_seconds Total SNMP time scrape took (walk and processing).
# TYPE snmp_scrape_duration_seconds gauge
snmp_scrape_duration_seconds{module="hrDevice"} 0.026523584
snmp_scrape_duration_seconds{module="hrStorage"} 0.009326375
# HELP snmp_scrape_packets_retried Packets retried for get, bulkget, and walk.
# TYPE snmp_scrape_packets_retried gauge
snmp_scrape_packets_retried{module="hrDevice"} 0
snmp_scrape_packets_retried{module="hrStorage"} 0
# HELP snmp_scrape_packets_sent Packets sent for get, bulkget, and walk; including retries.
# TYPE snmp_scrape_packets_sent gauge
snmp_scrape_packets_sent{module="hrDevice"} 1
snmp_scrape_packets_sent{module="hrStorage"} 1
# HELP snmp_scrape_pdus_returned PDUs returned from get, bulkget, and walk.
# TYPE snmp_scrape_pdus_returned gauge
snmp_scrape_pdus_returned{module="hrDevice"} 8
snmp_scrape_pdus_returned{module="hrStorage"} 15
# HELP snmp_scrape_walk_duration_seconds Time SNMP walk/bulkwalk took.
# TYPE snmp_scrape_walk_duration_seconds gauge
snmp_scrape_walk_duration_seconds{module="hrDevice"} 0.026377
snmp_scrape_walk_duration_seconds{module="hrStorage"} 0.009165417
```

arista switch (hrStorage,hrDevice):
```
# HELP hrDeviceErrors The number of errors detected on this device - 1.3.6.1.2.1.25.3.2.1.6
# TYPE hrDeviceErrors counter
hrDeviceErrors{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor",hrDeviceIndex="1",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrDeviceErrors{hrDeviceDescr="Core 1",hrDeviceIndex="2",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrDeviceErrors{hrDeviceDescr="Core 2",hrDeviceIndex="3",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
# HELP hrDeviceID The product ID for this device. - 1.3.6.1.2.1.25.3.2.1.4
# TYPE hrDeviceID gauge
hrDeviceID{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor",hrDeviceID="0.0",hrDeviceIndex="1",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceID{hrDeviceDescr="Core 1",hrDeviceID="0.0",hrDeviceIndex="2",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceID{hrDeviceDescr="Core 2",hrDeviceID="0.0",hrDeviceIndex="3",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
# HELP hrDeviceStatus The current operational state of the device described by this row of the table - 1.3.6.1.2.1.25.3.2.1.5
# TYPE hrDeviceStatus gauge
hrDeviceStatus{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor",hrDeviceIndex="1",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
hrDeviceStatus{hrDeviceDescr="Core 1",hrDeviceIndex="2",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
hrDeviceStatus{hrDeviceDescr="Core 2",hrDeviceIndex="3",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
# HELP hrMemorySize The amount of physical read-write main memory, typically RAM, contained by the host. - 1.3.6.1.2.1.25.2.2
# TYPE hrMemorySize gauge
hrMemorySize 4.017108e+06
# HELP hrProcessorLoad The average, over the last minute, of the percentage of time that this processor was not idle - 1.3.6.1.2.1.25.3.3.1.2
# TYPE hrProcessorLoad gauge
hrProcessorLoad{hrDeviceDescr="AMD Turion(tm) II Neo N41H Dual-Core Processor",hrDeviceIndex="1",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 43
hrProcessorLoad{hrDeviceDescr="Core 1",hrDeviceIndex="2",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 47
hrProcessorLoad{hrDeviceDescr="Core 2",hrDeviceIndex="3",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 40
# HELP hrStorageAllocationFailures The number of requests for storage represented by this entry that could not be honored due to not enough storage - 1.3.6.1.2.1.25.2.3.1.7
# TYPE hrStorageAllocationFailures counter
hrStorageAllocationFailures{hrStorageDescr="Core",hrStorageIndex="8",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 0
hrStorageAllocationFailures{hrStorageDescr="Flash",hrStorageIndex="4",hrStorageType="1.3.6.1.2.1.25.2.1.9"} 0
hrStorageAllocationFailures{hrStorageDescr="Log",hrStorageIndex="7",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 0
hrStorageAllocationFailures{hrStorageDescr="RAM",hrStorageIndex="1",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 0
hrStorageAllocationFailures{hrStorageDescr="RAM (Buffers)",hrStorageIndex="2",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 0
hrStorageAllocationFailures{hrStorageDescr="RAM (Cache)",hrStorageIndex="3",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 0
hrStorageAllocationFailures{hrStorageDescr="Root",hrStorageIndex="6",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 0
hrStorageAllocationFailures{hrStorageDescr="Tmp",hrStorageIndex="5",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 0
# HELP hrStorageAllocationUnits The size, in bytes, of the data objects allocated from this pool - 1.3.6.1.2.1.25.2.3.1.4
# TYPE hrStorageAllocationUnits gauge
hrStorageAllocationUnits{hrStorageDescr="Core",hrStorageIndex="8",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 4096
hrStorageAllocationUnits{hrStorageDescr="Flash",hrStorageIndex="4",hrStorageType="1.3.6.1.2.1.25.2.1.9"} 4096
hrStorageAllocationUnits{hrStorageDescr="Log",hrStorageIndex="7",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 4096
hrStorageAllocationUnits{hrStorageDescr="RAM",hrStorageIndex="1",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 1024
hrStorageAllocationUnits{hrStorageDescr="RAM (Buffers)",hrStorageIndex="2",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 1024
hrStorageAllocationUnits{hrStorageDescr="RAM (Cache)",hrStorageIndex="3",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 1024
hrStorageAllocationUnits{hrStorageDescr="Root",hrStorageIndex="6",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 4096
hrStorageAllocationUnits{hrStorageDescr="Tmp",hrStorageIndex="5",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 4096
# HELP hrStorageSize The size of the storage represented by this entry, in units of hrStorageAllocationUnits - 1.3.6.1.2.1.25.2.3.1.5
# TYPE hrStorageSize gauge
hrStorageSize{hrStorageDescr="Core",hrStorageIndex="8",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 99815
hrStorageSize{hrStorageDescr="Flash",hrStorageIndex="4",hrStorageType="1.3.6.1.2.1.25.2.1.9"} 439122
hrStorageSize{hrStorageDescr="Log",hrStorageIndex="7",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 99815
hrStorageSize{hrStorageDescr="RAM",hrStorageIndex="1",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 4.017108e+06
hrStorageSize{hrStorageDescr="RAM (Buffers)",hrStorageIndex="2",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 4.017108e+06
hrStorageSize{hrStorageDescr="RAM (Cache)",hrStorageIndex="3",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 4.017108e+06
hrStorageSize{hrStorageDescr="Root",hrStorageIndex="6",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 149722
hrStorageSize{hrStorageDescr="Tmp",hrStorageIndex="5",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 16384
# HELP hrStorageUsed The amount of the storage represented by this entry that is allocated, in units of hrStorageAllocationUnits. - 1.3.6.1.2.1.25.2.3.1.6
# TYPE hrStorageUsed gauge
hrStorageUsed{hrStorageDescr="Core",hrStorageIndex="8",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 0
hrStorageUsed{hrStorageDescr="Flash",hrStorageIndex="4",hrStorageType="1.3.6.1.2.1.25.2.1.9"} 361168
hrStorageUsed{hrStorageDescr="Log",hrStorageIndex="7",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 4077
hrStorageUsed{hrStorageDescr="RAM",hrStorageIndex="1",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 2.09222e+06
hrStorageUsed{hrStorageDescr="RAM (Buffers)",hrStorageIndex="2",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 171640
hrStorageUsed{hrStorageDescr="RAM (Cache)",hrStorageIndex="3",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 1.384228e+06
hrStorageUsed{hrStorageDescr="Root",hrStorageIndex="6",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 1521
hrStorageUsed{hrStorageDescr="Tmp",hrStorageIndex="5",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 130
# HELP snmp_scrape_duration_seconds Total SNMP time scrape took (walk and processing).
# TYPE snmp_scrape_duration_seconds gauge
snmp_scrape_duration_seconds{module="hrDevice"} 0.052289958
snmp_scrape_duration_seconds{module="hrStorage"} 0.030115084
# HELP snmp_scrape_packets_retried Packets retried for get, bulkget, and walk.
# TYPE snmp_scrape_packets_retried gauge
snmp_scrape_packets_retried{module="hrDevice"} 0
snmp_scrape_packets_retried{module="hrStorage"} 0
# HELP snmp_scrape_packets_sent Packets sent for get, bulkget, and walk; including retries.
# TYPE snmp_scrape_packets_sent gauge
snmp_scrape_packets_sent{module="hrDevice"} 1
snmp_scrape_packets_sent{module="hrStorage"} 3
# HELP snmp_scrape_pdus_returned PDUs returned from get, bulkget, and walk.
# TYPE snmp_scrape_pdus_returned gauge
snmp_scrape_pdus_returned{module="hrDevice"} 24
snmp_scrape_pdus_returned{module="hrStorage"} 57
# HELP snmp_scrape_walk_duration_seconds Time SNMP walk/bulkwalk took.
# TYPE snmp_scrape_walk_duration_seconds gauge
snmp_scrape_walk_duration_seconds{module="hrDevice"} 0.05186775
snmp_scrape_walk_duration_seconds{module="hrStorage"} 0.02982225
```

windows:
```
# HELP hrDeviceErrors The number of errors detected on this device - 1.3.6.1.2.1.25.3.2.1.6
# TYPE hrDeviceErrors counter
hrDeviceErrors{hrDeviceDescr="BASP Virtual Adapter",hrDeviceIndex="29",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="BASP Virtual Adapter-QoS Packet Scheduler-0000",hrDeviceIndex="35",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="BASP Virtual Adapter-WFP LightWeight Filter-0000",hrDeviceIndex="36",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet",hrDeviceIndex="19",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet #2",hrDeviceIndex="25",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet #2-WFP LightWeight Filter-00",hrDeviceIndex="33",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet-WFP LightWeight Filter-0000",hrDeviceIndex="34",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="COM1:",hrDeviceIndex="40",hrDeviceType="1.3.6.1.2.1.25.3.1.17"} 0
hrDeviceErrors{hrDeviceDescr="COM2:",hrDeviceIndex="41",hrDeviceType="1.3.6.1.2.1.25.3.1.17"} 0
hrDeviceErrors{hrDeviceDescr="D:\\",hrDeviceIndex="37",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 0
hrDeviceErrors{hrDeviceDescr="Fixed Disk",hrDeviceIndex="38",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 0
hrDeviceErrors{hrDeviceDescr="IBM USB Remote NDIS Network Device",hrDeviceIndex="27",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="IBM enhanced (101- or 102-key) keyboard, Subtype=(0)",hrDeviceIndex="39",hrDeviceType="1.3.6.1.2.1.25.3.1.13"} 0
hrDeviceErrors{hrDeviceDescr="Intel(R) Ethernet Server Adapter I340-T2",hrDeviceIndex="21",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="Intel(R) Ethernet Server Adapter I340-T2 #2",hrDeviceIndex="23",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="Microsoft ISATAP Adapter",hrDeviceIndex="20",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="Microsoft ISATAP Adapter #2",hrDeviceIndex="22",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="Microsoft ISATAP Adapter #3",hrDeviceIndex="24",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="Microsoft ISATAP Adapter #4",hrDeviceIndex="26",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="Microsoft ISATAP Adapter #5",hrDeviceIndex="28",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="RAS Async Adapter",hrDeviceIndex="17",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="Software Loopback Interface 1",hrDeviceIndex="9",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="1",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrDeviceErrors{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="2",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrDeviceErrors{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="3",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrDeviceErrors{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="4",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrDeviceErrors{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="5",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrDeviceErrors{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="6",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrDeviceErrors{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="7",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrDeviceErrors{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="8",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrDeviceErrors{hrDeviceDescr="WAN Miniport (IKEv2)",hrDeviceIndex="18",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="WAN Miniport (IP)",hrDeviceIndex="16",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="WAN Miniport (IP)-QoS Packet Scheduler-0000",hrDeviceIndex="31",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="WAN Miniport (IPv6)",hrDeviceIndex="14",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="WAN Miniport (IPv6)-QoS Packet Scheduler-0000",hrDeviceIndex="32",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="WAN Miniport (L2TP)",hrDeviceIndex="11",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="WAN Miniport (Network Monitor)",hrDeviceIndex="15",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="WAN Miniport (Network Monitor)-QoS Packet Scheduler-0000",hrDeviceIndex="30",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="WAN Miniport (PPPOE)",hrDeviceIndex="13",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="WAN Miniport (PPTP)",hrDeviceIndex="12",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="WAN Miniport (SSTP)",hrDeviceIndex="10",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
# HELP hrDeviceID The product ID for this device. - 1.3.6.1.2.1.25.3.2.1.4
# TYPE hrDeviceID gauge
hrDeviceID{hrDeviceDescr="BASP Virtual Adapter",hrDeviceID="0.0",hrDeviceIndex="29",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="BASP Virtual Adapter-QoS Packet Scheduler-0000",hrDeviceID="0.0",hrDeviceIndex="35",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="BASP Virtual Adapter-WFP LightWeight Filter-0000",hrDeviceID="0.0",hrDeviceIndex="36",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet",hrDeviceID="0.0",hrDeviceIndex="19",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet #2",hrDeviceID="0.0",hrDeviceIndex="25",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet #2-WFP LightWeight Filter-00",hrDeviceID="0.0",hrDeviceIndex="33",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet-WFP LightWeight Filter-0000",hrDeviceID="0.0",hrDeviceIndex="34",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="COM1:",hrDeviceID="0.0",hrDeviceIndex="40",hrDeviceType="1.3.6.1.2.1.25.3.1.17"} 1
hrDeviceID{hrDeviceDescr="COM2:",hrDeviceID="0.0",hrDeviceIndex="41",hrDeviceType="1.3.6.1.2.1.25.3.1.17"} 1
hrDeviceID{hrDeviceDescr="D:\\",hrDeviceID="0.0",hrDeviceIndex="37",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 1
hrDeviceID{hrDeviceDescr="Fixed Disk",hrDeviceID="0.0",hrDeviceIndex="38",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 1
hrDeviceID{hrDeviceDescr="IBM USB Remote NDIS Network Device",hrDeviceID="0.0",hrDeviceIndex="27",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="IBM enhanced (101- or 102-key) keyboard, Subtype=(0)",hrDeviceID="0.0",hrDeviceIndex="39",hrDeviceType="1.3.6.1.2.1.25.3.1.13"} 1
hrDeviceID{hrDeviceDescr="Intel(R) Ethernet Server Adapter I340-T2",hrDeviceID="0.0",hrDeviceIndex="21",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="Intel(R) Ethernet Server Adapter I340-T2 #2",hrDeviceID="0.0",hrDeviceIndex="23",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="Microsoft ISATAP Adapter",hrDeviceID="0.0",hrDeviceIndex="20",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="Microsoft ISATAP Adapter #2",hrDeviceID="0.0",hrDeviceIndex="22",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="Microsoft ISATAP Adapter #3",hrDeviceID="0.0",hrDeviceIndex="24",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="Microsoft ISATAP Adapter #4",hrDeviceID="0.0",hrDeviceIndex="26",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="Microsoft ISATAP Adapter #5",hrDeviceID="0.0",hrDeviceIndex="28",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="RAS Async Adapter",hrDeviceID="0.0",hrDeviceIndex="17",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="Software Loopback Interface 1",hrDeviceID="0.0",hrDeviceIndex="9",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="Unknown Processor Type",hrDeviceID="0.0",hrDeviceIndex="1",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceID{hrDeviceDescr="Unknown Processor Type",hrDeviceID="0.0",hrDeviceIndex="2",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceID{hrDeviceDescr="Unknown Processor Type",hrDeviceID="0.0",hrDeviceIndex="3",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceID{hrDeviceDescr="Unknown Processor Type",hrDeviceID="0.0",hrDeviceIndex="4",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceID{hrDeviceDescr="Unknown Processor Type",hrDeviceID="0.0",hrDeviceIndex="5",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceID{hrDeviceDescr="Unknown Processor Type",hrDeviceID="0.0",hrDeviceIndex="6",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceID{hrDeviceDescr="Unknown Processor Type",hrDeviceID="0.0",hrDeviceIndex="7",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceID{hrDeviceDescr="Unknown Processor Type",hrDeviceID="0.0",hrDeviceIndex="8",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceID{hrDeviceDescr="WAN Miniport (IKEv2)",hrDeviceID="0.0",hrDeviceIndex="18",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="WAN Miniport (IP)",hrDeviceID="0.0",hrDeviceIndex="16",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="WAN Miniport (IP)-QoS Packet Scheduler-0000",hrDeviceID="0.0",hrDeviceIndex="31",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="WAN Miniport (IPv6)",hrDeviceID="0.0",hrDeviceIndex="14",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="WAN Miniport (IPv6)-QoS Packet Scheduler-0000",hrDeviceID="0.0",hrDeviceIndex="32",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="WAN Miniport (L2TP)",hrDeviceID="0.0",hrDeviceIndex="11",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="WAN Miniport (Network Monitor)",hrDeviceID="0.0",hrDeviceIndex="15",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="WAN Miniport (Network Monitor)-QoS Packet Scheduler-0000",hrDeviceID="0.0",hrDeviceIndex="30",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="WAN Miniport (PPPOE)",hrDeviceID="0.0",hrDeviceIndex="13",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="WAN Miniport (PPTP)",hrDeviceID="0.0",hrDeviceIndex="12",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="WAN Miniport (SSTP)",hrDeviceID="0.0",hrDeviceIndex="10",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
# HELP hrDeviceStatus The current operational state of the device described by this row of the table - 1.3.6.1.2.1.25.3.2.1.5
# TYPE hrDeviceStatus gauge
hrDeviceStatus{hrDeviceDescr="BASP Virtual Adapter",hrDeviceIndex="29",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="BASP Virtual Adapter-QoS Packet Scheduler-0000",hrDeviceIndex="35",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="BASP Virtual Adapter-WFP LightWeight Filter-0000",hrDeviceIndex="36",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet",hrDeviceIndex="19",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet #2",hrDeviceIndex="25",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet #2-WFP LightWeight Filter-00",hrDeviceIndex="33",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet-WFP LightWeight Filter-0000",hrDeviceIndex="34",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="COM1:",hrDeviceIndex="40",hrDeviceType="1.3.6.1.2.1.25.3.1.17"} 1
hrDeviceStatus{hrDeviceDescr="COM2:",hrDeviceIndex="41",hrDeviceType="1.3.6.1.2.1.25.3.1.17"} 1
hrDeviceStatus{hrDeviceDescr="D:\\",hrDeviceIndex="37",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 1
hrDeviceStatus{hrDeviceDescr="Fixed Disk",hrDeviceIndex="38",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 2
hrDeviceStatus{hrDeviceDescr="IBM USB Remote NDIS Network Device",hrDeviceIndex="27",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="IBM enhanced (101- or 102-key) keyboard, Subtype=(0)",hrDeviceIndex="39",hrDeviceType="1.3.6.1.2.1.25.3.1.13"} 2
hrDeviceStatus{hrDeviceDescr="Intel(R) Ethernet Server Adapter I340-T2",hrDeviceIndex="21",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="Intel(R) Ethernet Server Adapter I340-T2 #2",hrDeviceIndex="23",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="Microsoft ISATAP Adapter",hrDeviceIndex="20",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="Microsoft ISATAP Adapter #2",hrDeviceIndex="22",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="Microsoft ISATAP Adapter #3",hrDeviceIndex="24",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="Microsoft ISATAP Adapter #4",hrDeviceIndex="26",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="Microsoft ISATAP Adapter #5",hrDeviceIndex="28",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="RAS Async Adapter",hrDeviceIndex="17",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="Software Loopback Interface 1",hrDeviceIndex="9",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="1",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
hrDeviceStatus{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="2",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
hrDeviceStatus{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="3",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
hrDeviceStatus{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="4",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
hrDeviceStatus{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="5",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
hrDeviceStatus{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="6",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
hrDeviceStatus{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="7",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
hrDeviceStatus{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="8",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
hrDeviceStatus{hrDeviceDescr="WAN Miniport (IKEv2)",hrDeviceIndex="18",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="WAN Miniport (IP)",hrDeviceIndex="16",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="WAN Miniport (IP)-QoS Packet Scheduler-0000",hrDeviceIndex="31",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="WAN Miniport (IPv6)",hrDeviceIndex="14",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="WAN Miniport (IPv6)-QoS Packet Scheduler-0000",hrDeviceIndex="32",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="WAN Miniport (L2TP)",hrDeviceIndex="11",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="WAN Miniport (Network Monitor)",hrDeviceIndex="15",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="WAN Miniport (Network Monitor)-QoS Packet Scheduler-0000",hrDeviceIndex="30",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="WAN Miniport (PPPOE)",hrDeviceIndex="13",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="WAN Miniport (PPTP)",hrDeviceIndex="12",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceStatus{hrDeviceDescr="WAN Miniport (SSTP)",hrDeviceIndex="10",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
# HELP hrDiskStorageAccess An indication if this long-term storage device is readable and writable or only readable - 1.3.6.1.2.1.25.3.6.1.1
# TYPE hrDiskStorageAccess gauge
hrDiskStorageAccess{hrDeviceDescr="D:\\",hrDeviceIndex="37",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 2
hrDiskStorageAccess{hrDeviceDescr="Fixed Disk",hrDeviceIndex="38",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 1
# HELP hrDiskStorageCapacity The total size for this long-term storage device - 1.3.6.1.2.1.25.3.6.1.4
# TYPE hrDiskStorageCapacity gauge
hrDiskStorageCapacity{hrDeviceDescr="D:\\",hrDeviceIndex="37",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 0
hrDiskStorageCapacity{hrDeviceDescr="Fixed Disk",hrDeviceIndex="38",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 2.582431e+06
# HELP hrDiskStorageMedia An indication of the type of media used in this long- term storage device. - 1.3.6.1.2.1.25.3.6.1.2
# TYPE hrDiskStorageMedia gauge
hrDiskStorageMedia{hrDeviceDescr="D:\\",hrDeviceIndex="37",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 5
hrDiskStorageMedia{hrDeviceDescr="Fixed Disk",hrDeviceIndex="38",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 3
# HELP hrDiskStorageRemoveble Denotes whether or not the disk media may be removed from the drive. - 1.3.6.1.2.1.25.3.6.1.3
# TYPE hrDiskStorageRemoveble gauge
hrDiskStorageRemoveble{hrDeviceDescr="D:\\",hrDeviceIndex="37",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 1
hrDiskStorageRemoveble{hrDeviceDescr="Fixed Disk",hrDeviceIndex="38",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 0
# HELP hrFSAccess An indication if this file system is logically configured by the operating system to be readable and writable or only readable - 1.3.6.1.2.1.25.3.8.1.5
# TYPE hrFSAccess gauge
hrFSAccess{hrFSIndex="1"} 1
hrFSAccess{hrFSIndex="2"} 2
# HELP hrFSBootable A flag indicating whether this file system is bootable. - 1.3.6.1.2.1.25.3.8.1.6
# TYPE hrFSBootable gauge
hrFSBootable{hrFSIndex="1"} 0
hrFSBootable{hrFSIndex="2"} 0
# HELP hrFSIndex A unique value for each file system local to this host - 1.3.6.1.2.1.25.3.8.1.1
# TYPE hrFSIndex gauge
hrFSIndex{hrFSIndex="1"} 1
hrFSIndex{hrFSIndex="2"} 2
# HELP hrFSLastFullBackupDate The last date at which this complete file system was copied to another storage device for backup - 1.3.6.1.2.1.25.3.8.1.8
# TYPE hrFSLastFullBackupDate gauge
hrFSLastFullBackupDate{hrFSIndex="1"} -6.21672192e+10
hrFSLastFullBackupDate{hrFSIndex="2"} -6.21672192e+10
# HELP hrFSLastPartialBackupDate The last date at which a portion of this file system was copied to another storage device for backup - 1.3.6.1.2.1.25.3.8.1.9
# TYPE hrFSLastPartialBackupDate gauge
hrFSLastPartialBackupDate{hrFSIndex="1"} -6.21672192e+10
hrFSLastPartialBackupDate{hrFSIndex="2"} -6.21672192e+10
# HELP hrFSMountPoint The path name of the root of this file system. - 1.3.6.1.2.1.25.3.8.1.2
# TYPE hrFSMountPoint gauge
hrFSMountPoint{hrFSIndex="1",hrFSMountPoint=""} 1
hrFSMountPoint{hrFSIndex="2",hrFSMountPoint=""} 1
# HELP hrFSRemoteMountPoint A description of the name and/or address of the server that this file system is mounted from - 1.3.6.1.2.1.25.3.8.1.3
# TYPE hrFSRemoteMountPoint gauge
hrFSRemoteMountPoint{hrFSIndex="1",hrFSRemoteMountPoint=""} 1
hrFSRemoteMountPoint{hrFSIndex="2",hrFSRemoteMountPoint=""} 1
# HELP hrFSStorageIndex The index of the hrStorageEntry that represents information about this file system - 1.3.6.1.2.1.25.3.8.1.7
# TYPE hrFSStorageIndex gauge
hrFSStorageIndex{hrFSIndex="1"} 1
hrFSStorageIndex{hrFSIndex="2"} 2
# HELP hrFSType The value of this object identifies the type of this file system. - 1.3.6.1.2.1.25.3.8.1.4
# TYPE hrFSType gauge
hrFSType{hrFSIndex="1",hrFSType="1.3.6.1.2.1.25.3.9.2"} 1
hrFSType{hrFSIndex="2",hrFSType="1.3.6.1.2.1.25.3.9.5"} 1
# HELP hrMemorySize The amount of physical read-write main memory, typically RAM, contained by the host. - 1.3.6.1.2.1.25.2.2
# TYPE hrMemorySize gauge
hrMemorySize 1.6608984e+07
# HELP hrNetworkIfIndex The value of ifIndex which corresponds to this network device - 1.3.6.1.2.1.25.3.4.1.1
# TYPE hrNetworkIfIndex gauge
hrNetworkIfIndex{hrDeviceDescr="BASP Virtual Adapter",hrDeviceIndex="29",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 21
hrNetworkIfIndex{hrDeviceDescr="BASP Virtual Adapter-QoS Packet Scheduler-0000",hrDeviceIndex="35",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 27
hrNetworkIfIndex{hrDeviceDescr="BASP Virtual Adapter-WFP LightWeight Filter-0000",hrDeviceIndex="36",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 28
hrNetworkIfIndex{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet",hrDeviceIndex="19",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 11
hrNetworkIfIndex{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet #2",hrDeviceIndex="25",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 17
hrNetworkIfIndex{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet #2-WFP LightWeight Filter-00",hrDeviceIndex="33",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 25
hrNetworkIfIndex{hrDeviceDescr="Broadcom NetXtreme Gigabit Ethernet-WFP LightWeight Filter-0000",hrDeviceIndex="34",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 26
hrNetworkIfIndex{hrDeviceDescr="IBM USB Remote NDIS Network Device",hrDeviceIndex="27",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 19
hrNetworkIfIndex{hrDeviceDescr="Intel(R) Ethernet Server Adapter I340-T2",hrDeviceIndex="21",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 13
hrNetworkIfIndex{hrDeviceDescr="Intel(R) Ethernet Server Adapter I340-T2 #2",hrDeviceIndex="23",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 15
hrNetworkIfIndex{hrDeviceDescr="Microsoft ISATAP Adapter",hrDeviceIndex="20",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 12
hrNetworkIfIndex{hrDeviceDescr="Microsoft ISATAP Adapter #2",hrDeviceIndex="22",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 14
hrNetworkIfIndex{hrDeviceDescr="Microsoft ISATAP Adapter #3",hrDeviceIndex="24",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 16
hrNetworkIfIndex{hrDeviceDescr="Microsoft ISATAP Adapter #4",hrDeviceIndex="26",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 18
hrNetworkIfIndex{hrDeviceDescr="Microsoft ISATAP Adapter #5",hrDeviceIndex="28",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 20
hrNetworkIfIndex{hrDeviceDescr="RAS Async Adapter",hrDeviceIndex="17",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 9
hrNetworkIfIndex{hrDeviceDescr="Software Loopback Interface 1",hrDeviceIndex="9",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrNetworkIfIndex{hrDeviceDescr="WAN Miniport (IKEv2)",hrDeviceIndex="18",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 10
hrNetworkIfIndex{hrDeviceDescr="WAN Miniport (IP)",hrDeviceIndex="16",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 8
hrNetworkIfIndex{hrDeviceDescr="WAN Miniport (IP)-QoS Packet Scheduler-0000",hrDeviceIndex="31",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 23
hrNetworkIfIndex{hrDeviceDescr="WAN Miniport (IPv6)",hrDeviceIndex="14",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 6
hrNetworkIfIndex{hrDeviceDescr="WAN Miniport (IPv6)-QoS Packet Scheduler-0000",hrDeviceIndex="32",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 24
hrNetworkIfIndex{hrDeviceDescr="WAN Miniport (L2TP)",hrDeviceIndex="11",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 3
hrNetworkIfIndex{hrDeviceDescr="WAN Miniport (Network Monitor)",hrDeviceIndex="15",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 7
hrNetworkIfIndex{hrDeviceDescr="WAN Miniport (Network Monitor)-QoS Packet Scheduler-0000",hrDeviceIndex="30",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 22
hrNetworkIfIndex{hrDeviceDescr="WAN Miniport (PPPOE)",hrDeviceIndex="13",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 5
hrNetworkIfIndex{hrDeviceDescr="WAN Miniport (PPTP)",hrDeviceIndex="12",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 4
hrNetworkIfIndex{hrDeviceDescr="WAN Miniport (SSTP)",hrDeviceIndex="10",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 2
# HELP hrProcessorLoad The average, over the last minute, of the percentage of time that this processor was not idle - 1.3.6.1.2.1.25.3.3.1.2
# TYPE hrProcessorLoad gauge
hrProcessorLoad{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="1",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrProcessorLoad{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="2",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrProcessorLoad{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="3",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrProcessorLoad{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="4",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrProcessorLoad{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="5",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrProcessorLoad{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="6",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrProcessorLoad{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="7",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrProcessorLoad{hrDeviceDescr="Unknown Processor Type",hrDeviceIndex="8",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
# HELP hrStorageAllocationFailures The number of requests for storage represented by this entry that could not be honored due to not enough storage - 1.3.6.1.2.1.25.2.3.1.7
# TYPE hrStorageAllocationFailures counter
hrStorageAllocationFailures{hrStorageDescr="C:\\ Label:  Serial Number 62ef1ef6",hrStorageIndex="1",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 0
hrStorageAllocationFailures{hrStorageDescr="D:\\",hrStorageIndex="2",hrStorageType="1.3.6.1.2.1.25.2.1.7"} 0
hrStorageAllocationFailures{hrStorageDescr="Physical Memory",hrStorageIndex="4",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 0
hrStorageAllocationFailures{hrStorageDescr="Virtual Memory",hrStorageIndex="3",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 0
# HELP hrStorageAllocationUnits The size, in bytes, of the data objects allocated from this pool - 1.3.6.1.2.1.25.2.3.1.4
# TYPE hrStorageAllocationUnits gauge
hrStorageAllocationUnits{hrStorageDescr="C:\\ Label:  Serial Number 62ef1ef6",hrStorageIndex="1",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 4096
hrStorageAllocationUnits{hrStorageDescr="D:\\",hrStorageIndex="2",hrStorageType="1.3.6.1.2.1.25.2.1.7"} 0
hrStorageAllocationUnits{hrStorageDescr="Physical Memory",hrStorageIndex="4",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 65536
hrStorageAllocationUnits{hrStorageDescr="Virtual Memory",hrStorageIndex="3",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 65536
# HELP hrStorageSize The size of the storage represented by this entry, in units of hrStorageAllocationUnits - 1.3.6.1.2.1.25.2.3.1.5
# TYPE hrStorageSize gauge
hrStorageSize{hrStorageDescr="C:\\ Label:  Serial Number 62ef1ef6",hrStorageIndex="1",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 7.2913407e+07
hrStorageSize{hrStorageDescr="D:\\",hrStorageIndex="2",hrStorageType="1.3.6.1.2.1.25.2.1.7"} 0
hrStorageSize{hrStorageDescr="Physical Memory",hrStorageIndex="4",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 259515
hrStorageSize{hrStorageDescr="Virtual Memory",hrStorageIndex="3",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 519001
# HELP hrStorageUsed The amount of the storage represented by this entry that is allocated, in units of hrStorageAllocationUnits. - 1.3.6.1.2.1.25.2.3.1.6
# TYPE hrStorageUsed gauge
hrStorageUsed{hrStorageDescr="C:\\ Label:  Serial Number 62ef1ef6",hrStorageIndex="1",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 9.490311e+06
hrStorageUsed{hrStorageDescr="D:\\",hrStorageIndex="2",hrStorageType="1.3.6.1.2.1.25.2.1.7"} 0
hrStorageUsed{hrStorageDescr="Physical Memory",hrStorageIndex="4",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 61969
hrStorageUsed{hrStorageDescr="Virtual Memory",hrStorageIndex="3",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 62835
# HELP snmp_scrape_duration_seconds Total SNMP time scrape took (walk and processing).
# TYPE snmp_scrape_duration_seconds gauge
snmp_scrape_duration_seconds{module="hrDevice"} 0.116041208
snmp_scrape_duration_seconds{module="hrStorage"} 0.010762833
# HELP snmp_scrape_packets_retried Packets retried for get, bulkget, and walk.
# TYPE snmp_scrape_packets_retried gauge
snmp_scrape_packets_retried{module="hrDevice"} 0
snmp_scrape_packets_retried{module="hrStorage"} 0
# HELP snmp_scrape_packets_sent Packets sent for get, bulkget, and walk; including retries.
# TYPE snmp_scrape_packets_sent gauge
snmp_scrape_packets_sent{module="hrDevice"} 13
snmp_scrape_packets_sent{module="hrStorage"} 2
# HELP snmp_scrape_pdus_returned PDUs returned from get, bulkget, and walk.
# TYPE snmp_scrape_pdus_returned gauge
snmp_scrape_pdus_returned{module="hrDevice"} 316
snmp_scrape_pdus_returned{module="hrStorage"} 29
# HELP snmp_scrape_walk_duration_seconds Time SNMP walk/bulkwalk took.
# TYPE snmp_scrape_walk_duration_seconds gauge
snmp_scrape_walk_duration_seconds{module="hrDevice"} 0.113119125
snmp_scrape_walk_duration_seconds{module="hrStorage"} 0.010419958
```

linux:
```
# HELP hrDeviceErrors The number of errors detected on this device - 1.3.6.1.2.1.25.3.2.1.6
# TYPE hrDeviceErrors counter
hrDeviceErrors{hrDeviceDescr="lj",hrDeviceIndex="1280",hrDeviceType="1.3.6.1.2.1.25.3.1.5"} 0
hrDeviceErrors{hrDeviceDescr="ljc",hrDeviceIndex="1281",hrDeviceType="1.3.6.1.2.1.25.3.1.5"} 0
hrDeviceErrors{hrDeviceDescr="network interface eth0",hrDeviceIndex="1026",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
hrDeviceErrors{hrDeviceDescr="network interface lo",hrDeviceIndex="1025",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 0
# HELP hrDeviceID The product ID for this device. - 1.3.6.1.2.1.25.3.2.1.4
# TYPE hrDeviceID gauge
hrDeviceID{hrDeviceDescr="GenuineIntel: Intel(R) Pentium(R) 4 CPU 3.00GHz",hrDeviceID="0.0",hrDeviceIndex="768",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceID{hrDeviceDescr="GenuineIntel: Intel(R) Pentium(R) 4 CPU 3.00GHz",hrDeviceID="0.0",hrDeviceIndex="769",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 1
hrDeviceID{hrDeviceDescr="Guessing that there's a floating point co-processor",hrDeviceID="0.0",hrDeviceIndex="3072",hrDeviceType="1.3.6.1.2.1.25.3.1.12"} 1
hrDeviceID{hrDeviceDescr="LITE-ON COMBO SOHC-4832K",hrDeviceID="0.0",hrDeviceIndex="1537",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 1
hrDeviceID{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceID="0.0",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 1
hrDeviceID{hrDeviceDescr="SCSI disk (/dev/sdb)",hrDeviceID="0.0",hrDeviceIndex="1553",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 1
hrDeviceID{hrDeviceDescr="lj",hrDeviceID="0.0",hrDeviceIndex="1280",hrDeviceType="1.3.6.1.2.1.25.3.1.5"} 1
hrDeviceID{hrDeviceDescr="ljc",hrDeviceID="0.0",hrDeviceIndex="1281",hrDeviceType="1.3.6.1.2.1.25.3.1.5"} 1
hrDeviceID{hrDeviceDescr="network interface eth0",hrDeviceID="0.0",hrDeviceIndex="1026",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
hrDeviceID{hrDeviceDescr="network interface lo",hrDeviceID="0.0",hrDeviceIndex="1025",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
# HELP hrDeviceStatus The current operational state of the device described by this row of the table - 1.3.6.1.2.1.25.3.2.1.5
# TYPE hrDeviceStatus gauge
hrDeviceStatus{hrDeviceDescr="GenuineIntel: Intel(R) Pentium(R) 4 CPU 3.00GHz",hrDeviceIndex="768",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
hrDeviceStatus{hrDeviceDescr="GenuineIntel: Intel(R) Pentium(R) 4 CPU 3.00GHz",hrDeviceIndex="769",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 2
hrDeviceStatus{hrDeviceDescr="lj",hrDeviceIndex="1280",hrDeviceType="1.3.6.1.2.1.25.3.1.5"} 1
hrDeviceStatus{hrDeviceDescr="ljc",hrDeviceIndex="1281",hrDeviceType="1.3.6.1.2.1.25.3.1.5"} 1
hrDeviceStatus{hrDeviceDescr="network interface eth0",hrDeviceIndex="1026",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 2
hrDeviceStatus{hrDeviceDescr="network interface lo",hrDeviceIndex="1025",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 2
# HELP hrDiskStorageAccess An indication if this long-term storage device is readable and writable or only readable - 1.3.6.1.2.1.25.3.6.1.1
# TYPE hrDiskStorageAccess gauge
hrDiskStorageAccess{hrDeviceDescr="LITE-ON COMBO SOHC-4832K",hrDeviceIndex="1537",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 1
hrDiskStorageAccess{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 1
hrDiskStorageAccess{hrDeviceDescr="SCSI disk (/dev/sdb)",hrDeviceIndex="1553",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 1
# HELP hrDiskStorageCapacity The total size for this long-term storage device - 1.3.6.1.2.1.25.3.6.1.4
# TYPE hrDiskStorageCapacity gauge
hrDiskStorageCapacity{hrDeviceDescr="LITE-ON COMBO SOHC-4832K",hrDeviceIndex="1537",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 0
hrDiskStorageCapacity{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 7.8150744e+07
hrDiskStorageCapacity{hrDeviceDescr="SCSI disk (/dev/sdb)",hrDeviceIndex="1553",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 3.90711384e+08
# HELP hrDiskStorageMedia An indication of the type of media used in this long- term storage device. - 1.3.6.1.2.1.25.3.6.1.2
# TYPE hrDiskStorageMedia gauge
hrDiskStorageMedia{hrDeviceDescr="LITE-ON COMBO SOHC-4832K",hrDeviceIndex="1537",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 2
hrDiskStorageMedia{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 2
hrDiskStorageMedia{hrDeviceDescr="SCSI disk (/dev/sdb)",hrDeviceIndex="1553",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 2
# HELP hrDiskStorageRemoveble Denotes whether or not the disk media may be removed from the drive. - 1.3.6.1.2.1.25.3.6.1.3
# TYPE hrDiskStorageRemoveble gauge
hrDiskStorageRemoveble{hrDeviceDescr="LITE-ON COMBO SOHC-4832K",hrDeviceIndex="1537",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 1
hrDiskStorageRemoveble{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 2
hrDiskStorageRemoveble{hrDeviceDescr="SCSI disk (/dev/sdb)",hrDeviceIndex="1553",hrDeviceType="1.3.6.1.2.1.25.3.1.6"} 2
# HELP hrFSAccess An indication if this file system is logically configured by the operating system to be readable and writable or only readable - 1.3.6.1.2.1.25.3.8.1.5
# TYPE hrFSAccess gauge
hrFSAccess{hrFSIndex="1"} 1
hrFSAccess{hrFSIndex="2"} 1
hrFSAccess{hrFSIndex="3"} 1
# HELP hrFSBootable A flag indicating whether this file system is bootable. - 1.3.6.1.2.1.25.3.8.1.6
# TYPE hrFSBootable gauge
hrFSBootable{hrFSIndex="1"} 1
hrFSBootable{hrFSIndex="2"} 2
hrFSBootable{hrFSIndex="3"} 2
# HELP hrFSIndex A unique value for each file system local to this host - 1.3.6.1.2.1.25.3.8.1.1
# TYPE hrFSIndex gauge
hrFSIndex{hrFSIndex="1"} 1
hrFSIndex{hrFSIndex="2"} 2
hrFSIndex{hrFSIndex="3"} 3
# HELP hrFSLastFullBackupDate The last date at which this complete file system was copied to another storage device for backup - 1.3.6.1.2.1.25.3.8.1.8
# TYPE hrFSLastFullBackupDate gauge
hrFSLastFullBackupDate{hrFSIndex="1"} -6.21672192e+10
hrFSLastFullBackupDate{hrFSIndex="2"} -6.21672192e+10
hrFSLastFullBackupDate{hrFSIndex="3"} -6.21672192e+10
# HELP hrFSLastPartialBackupDate The last date at which a portion of this file system was copied to another storage device for backup - 1.3.6.1.2.1.25.3.8.1.9
# TYPE hrFSLastPartialBackupDate gauge
hrFSLastPartialBackupDate{hrFSIndex="1"} -6.21672192e+10
hrFSLastPartialBackupDate{hrFSIndex="2"} -6.21672192e+10
hrFSLastPartialBackupDate{hrFSIndex="3"} -6.21672192e+10
# HELP hrFSMountPoint The path name of the root of this file system. - 1.3.6.1.2.1.25.3.8.1.2
# TYPE hrFSMountPoint gauge
hrFSMountPoint{hrFSIndex="1",hrFSMountPoint="0x2F"} 1
hrFSMountPoint{hrFSIndex="2",hrFSMountPoint="0x2F7573722F6C6F63616C"} 1
hrFSMountPoint{hrFSIndex="3",hrFSMountPoint="0x2F6578706F7274"} 1
# HELP hrFSRemoteMountPoint A description of the name and/or address of the server that this file system is mounted from - 1.3.6.1.2.1.25.3.8.1.3
# TYPE hrFSRemoteMountPoint gauge
hrFSRemoteMountPoint{hrFSIndex="1",hrFSRemoteMountPoint=""} 1
hrFSRemoteMountPoint{hrFSIndex="2",hrFSRemoteMountPoint=""} 1
hrFSRemoteMountPoint{hrFSIndex="3",hrFSRemoteMountPoint=""} 1
# HELP hrFSStorageIndex The index of the hrStorageEntry that represents information about this file system - 1.3.6.1.2.1.25.3.8.1.7
# TYPE hrFSStorageIndex gauge
hrFSStorageIndex{hrFSIndex="1"} 31
hrFSStorageIndex{hrFSIndex="2"} 32
hrFSStorageIndex{hrFSIndex="3"} 33
# HELP hrFSType The value of this object identifies the type of this file system. - 1.3.6.1.2.1.25.3.8.1.4
# TYPE hrFSType gauge
hrFSType{hrFSIndex="1",hrFSType="1.3.6.1.2.1.25.3.9.23"} 1
hrFSType{hrFSIndex="2",hrFSType="1.3.6.1.2.1.25.3.9.23"} 1
hrFSType{hrFSIndex="3",hrFSType="1.3.6.1.2.1.25.3.9.23"} 1
# HELP hrMemorySize The amount of physical read-write main memory, typically RAM, contained by the host. - 1.3.6.1.2.1.25.2.2
# TYPE hrMemorySize gauge
hrMemorySize 1.021976e+06
# HELP hrNetworkIfIndex The value of ifIndex which corresponds to this network device - 1.3.6.1.2.1.25.3.4.1.1
# TYPE hrNetworkIfIndex gauge
hrNetworkIfIndex{hrDeviceDescr="network interface eth0",hrDeviceIndex="1026",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 2
hrNetworkIfIndex{hrDeviceDescr="network interface lo",hrDeviceIndex="1025",hrDeviceType="1.3.6.1.2.1.25.3.1.4"} 1
# HELP hrPartitionFSIndex The index of the file system mounted on this partition - 1.3.6.1.2.1.25.3.7.1.5
# TYPE hrPartitionFSIndex gauge
hrPartitionFSIndex{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="1"} 1
hrPartitionFSIndex{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="2"} 0
hrPartitionFSIndex{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="3"} 2
hrPartitionFSIndex{hrDeviceDescr="SCSI disk (/dev/sdb)",hrDeviceIndex="1553",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="1"} 3
# HELP hrPartitionID A descriptor which uniquely represents this partition to the responsible operating system - 1.3.6.1.2.1.25.3.7.1.3
# TYPE hrPartitionID gauge
hrPartitionID{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionID="0x3078383031",hrPartitionIndex="1"} 1
hrPartitionID{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionID="0x3078383032",hrPartitionIndex="2"} 1
hrPartitionID{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionID="0x3078383033",hrPartitionIndex="3"} 1
hrPartitionID{hrDeviceDescr="SCSI disk (/dev/sdb)",hrDeviceIndex="1553",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionID="0x3078383131",hrPartitionIndex="1"} 1
# HELP hrPartitionIndex A unique value for each partition on this long-term storage device - 1.3.6.1.2.1.25.3.7.1.1
# TYPE hrPartitionIndex gauge
hrPartitionIndex{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="1"} 1
hrPartitionIndex{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="2"} 2
hrPartitionIndex{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="3"} 3
hrPartitionIndex{hrDeviceDescr="SCSI disk (/dev/sdb)",hrDeviceIndex="1553",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="1"} 1
# HELP hrPartitionLabel A textual description of this partition. - 1.3.6.1.2.1.25.3.7.1.2
# TYPE hrPartitionLabel gauge
hrPartitionLabel{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="1",hrPartitionLabel="0x2F6465762F73646131"} 1
hrPartitionLabel{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="2",hrPartitionLabel="0x2F6465762F73646132"} 1
hrPartitionLabel{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="3",hrPartitionLabel="0x2F6465762F73646133"} 1
hrPartitionLabel{hrDeviceDescr="SCSI disk (/dev/sdb)",hrDeviceIndex="1553",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="1",hrPartitionLabel="0x2F6465762F73646231"} 1
# HELP hrPartitionSize The size of this partition. - 1.3.6.1.2.1.25.3.7.1.4
# TYPE hrPartitionSize gauge
hrPartitionSize{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="1"} 8.657308e+06
hrPartitionSize{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="2"} 0
hrPartitionSize{hrDeviceDescr="SCSI disk (/dev/sda)",hrDeviceIndex="1552",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="3"} 6.729106e+07
hrPartitionSize{hrDeviceDescr="SCSI disk (/dev/sdb)",hrDeviceIndex="1553",hrDeviceType="1.3.6.1.2.1.25.3.1.6",hrPartitionIndex="1"} 3.84578164e+08
# HELP hrPrinterStatus The current status of this printer device. - 1.3.6.1.2.1.25.3.5.1.1 (EnumAsStateSet)
# TYPE hrPrinterStatus gauge
hrPrinterStatus{hrDeviceDescr="lj",hrDeviceIndex="1280",hrDeviceType="1.3.6.1.2.1.25.3.1.5",hrPrinterStatus="idle"} 0
hrPrinterStatus{hrDeviceDescr="lj",hrDeviceIndex="1280",hrDeviceType="1.3.6.1.2.1.25.3.1.5",hrPrinterStatus="other"} 0
hrPrinterStatus{hrDeviceDescr="lj",hrDeviceIndex="1280",hrDeviceType="1.3.6.1.2.1.25.3.1.5",hrPrinterStatus="printing"} 0
hrPrinterStatus{hrDeviceDescr="lj",hrDeviceIndex="1280",hrDeviceType="1.3.6.1.2.1.25.3.1.5",hrPrinterStatus="unknown"} 1
hrPrinterStatus{hrDeviceDescr="lj",hrDeviceIndex="1280",hrDeviceType="1.3.6.1.2.1.25.3.1.5",hrPrinterStatus="warmup"} 0
hrPrinterStatus{hrDeviceDescr="ljc",hrDeviceIndex="1281",hrDeviceType="1.3.6.1.2.1.25.3.1.5",hrPrinterStatus="idle"} 0
hrPrinterStatus{hrDeviceDescr="ljc",hrDeviceIndex="1281",hrDeviceType="1.3.6.1.2.1.25.3.1.5",hrPrinterStatus="other"} 0
hrPrinterStatus{hrDeviceDescr="ljc",hrDeviceIndex="1281",hrDeviceType="1.3.6.1.2.1.25.3.1.5",hrPrinterStatus="printing"} 0
hrPrinterStatus{hrDeviceDescr="ljc",hrDeviceIndex="1281",hrDeviceType="1.3.6.1.2.1.25.3.1.5",hrPrinterStatus="unknown"} 1
hrPrinterStatus{hrDeviceDescr="ljc",hrDeviceIndex="1281",hrDeviceType="1.3.6.1.2.1.25.3.1.5",hrPrinterStatus="warmup"} 0
# HELP hrProcessorLoad The average, over the last minute, of the percentage of time that this processor was not idle - 1.3.6.1.2.1.25.3.3.1.2
# TYPE hrProcessorLoad gauge
hrProcessorLoad{hrDeviceDescr="GenuineIntel: Intel(R) Pentium(R) 4 CPU 3.00GHz",hrDeviceIndex="768",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
hrProcessorLoad{hrDeviceDescr="GenuineIntel: Intel(R) Pentium(R) 4 CPU 3.00GHz",hrDeviceIndex="769",hrDeviceType="1.3.6.1.2.1.25.3.1.3"} 0
# HELP hrStorageAllocationUnits The size, in bytes, of the data objects allocated from this pool - 1.3.6.1.2.1.25.2.3.1.4
# TYPE hrStorageAllocationUnits gauge
hrStorageAllocationUnits{hrStorageDescr="/",hrStorageIndex="31",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 4096
hrStorageAllocationUnits{hrStorageDescr="/export",hrStorageIndex="33",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 4096
hrStorageAllocationUnits{hrStorageDescr="/usr/local",hrStorageIndex="32",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 4096
hrStorageAllocationUnits{hrStorageDescr="Cached memory",hrStorageIndex="7",hrStorageType="1.3.6.1.2.1.25.2.1.1"} 1024
hrStorageAllocationUnits{hrStorageDescr="Memory buffers",hrStorageIndex="6",hrStorageType="1.3.6.1.2.1.25.2.1.1"} 1024
hrStorageAllocationUnits{hrStorageDescr="Physical memory",hrStorageIndex="1",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 1024
hrStorageAllocationUnits{hrStorageDescr="Swap space",hrStorageIndex="10",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 1024
hrStorageAllocationUnits{hrStorageDescr="Virtual memory",hrStorageIndex="3",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 1024
# HELP hrStorageSize The size of the storage represented by this entry, in units of hrStorageAllocationUnits - 1.3.6.1.2.1.25.2.3.1.5
# TYPE hrStorageSize gauge
hrStorageSize{hrStorageDescr="/",hrStorageIndex="31",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 2.164327e+06
hrStorageSize{hrStorageDescr="/export",hrStorageIndex="33",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 9.6144541e+07
hrStorageSize{hrStorageDescr="/usr/local",hrStorageIndex="32",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 1.6822765e+07
hrStorageSize{hrStorageDescr="Cached memory",hrStorageIndex="7",hrStorageType="1.3.6.1.2.1.25.2.1.1"} 207040
hrStorageSize{hrStorageDescr="Memory buffers",hrStorageIndex="6",hrStorageType="1.3.6.1.2.1.25.2.1.1"} 1.021976e+06
hrStorageSize{hrStorageDescr="Physical memory",hrStorageIndex="1",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 1.021976e+06
hrStorageSize{hrStorageDescr="Swap space",hrStorageIndex="10",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 987988
hrStorageSize{hrStorageDescr="Virtual memory",hrStorageIndex="3",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 2.009964e+06
# HELP hrStorageUsed The amount of the storage represented by this entry that is allocated, in units of hrStorageAllocationUnits. - 1.3.6.1.2.1.25.2.3.1.6
# TYPE hrStorageUsed gauge
hrStorageUsed{hrStorageDescr="/",hrStorageIndex="31",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 1.667935e+06
hrStorageUsed{hrStorageDescr="/export",hrStorageIndex="33",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 9.0601816e+07
hrStorageUsed{hrStorageDescr="/usr/local",hrStorageIndex="32",hrStorageType="1.3.6.1.2.1.25.2.1.4"} 1.3299705e+07
hrStorageUsed{hrStorageDescr="Cached memory",hrStorageIndex="7",hrStorageType="1.3.6.1.2.1.25.2.1.1"} 207040
hrStorageUsed{hrStorageDescr="Memory buffers",hrStorageIndex="6",hrStorageType="1.3.6.1.2.1.25.2.1.1"} 23900
hrStorageUsed{hrStorageDescr="Physical memory",hrStorageIndex="1",hrStorageType="1.3.6.1.2.1.25.2.1.2"} 958176
hrStorageUsed{hrStorageDescr="Swap space",hrStorageIndex="10",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 27432
hrStorageUsed{hrStorageDescr="Virtual memory",hrStorageIndex="3",hrStorageType="1.3.6.1.2.1.25.2.1.3"} 985608
# HELP snmp_scrape_duration_seconds Total SNMP time scrape took (walk and processing).
# TYPE snmp_scrape_duration_seconds gauge
snmp_scrape_duration_seconds{module="hrDevice"} 0.051153125
snmp_scrape_duration_seconds{module="hrStorage"} 0.010678458
# HELP snmp_scrape_packets_retried Packets retried for get, bulkget, and walk.
# TYPE snmp_scrape_packets_retried gauge
snmp_scrape_packets_retried{module="hrDevice"} 0
snmp_scrape_packets_retried{module="hrStorage"} 0
# HELP snmp_scrape_packets_sent Packets sent for get, bulkget, and walk; including retries.
# TYPE snmp_scrape_packets_sent gauge
snmp_scrape_packets_sent{module="hrDevice"} 5
snmp_scrape_packets_sent{module="hrStorage"} 2
# HELP snmp_scrape_pdus_returned PDUs returned from get, bulkget, and walk.
# TYPE snmp_scrape_pdus_returned gauge
snmp_scrape_pdus_returned{module="hrDevice"} 117
snmp_scrape_pdus_returned{module="hrStorage"} 49
# HELP snmp_scrape_walk_duration_seconds Time SNMP walk/bulkwalk took.
# TYPE snmp_scrape_walk_duration_seconds gauge
snmp_scrape_walk_duration_seconds{module="hrDevice"} 0.048113417
snmp_scrape_walk_duration_seconds{module="hrStorage"} 0.010128542
```