### PR TITLE
Add DELL networking devices module

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -37,6 +37,7 @@ CISCO_URL         := https://raw.githubusercontent.com/cisco/cisco-mibs/f55dc443
 DELL_URL          := https://dl.dell.com/FOLDER11196144M/1/Dell-OM-MIBS-11010_A00.zip
 DLINK_URL         := https://ftp.dlink.de/des/des-3200-18/driver_software/DES-3200-18_mib_revC_4-04_all_en_20130603.zip
 ELTEX_MES_URL     := https://eltex-co.com/upload/iblock/93c/80760x03yv4m8crugf0b8ab5yo8tel34/mibs_10.3.6.6.zip
+DELL_NETWORK_URL  := https://supportkb.dell.com/attachment/ka02R000000I7TFQA0/Current_MIBs_pkb_en_US_1.zip
 HPE_URL           := https://downloads.hpe.com/pub/softlib2/software1/pubsw-linux/p1580676047/v229101/upd11.85mib.tar.gz
 IANA_CHARSET_URL  := https://www.iana.org/assignments/ianacharset-mib/ianacharset-mib
 IANA_IFTYPE_URL   := https://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib
@@ -90,6 +91,7 @@ clean:
 		$(MIBDIR)/.cisco_imc \
 		$(MIBDIR)/.dell \
 		$(MIBDIR)/.dlink-mibs \
+		$(MIBDIR)/.dell-network \
 		$(MIBDIR)/.hpe-mib \
 		$(MIBDIR)/.net-snmp \
 		$(MIBDIR)/.paloalto_panos \
@@ -177,7 +179,8 @@ mibs: \
   $(MIBDIR)/FROGFOOT-RESOURCES-MIB \
   $(MIBDIR)/.dlink-mibs \
   $(MIBDIR)/.eltex-mes \
-  $(MIBDIR)/.juniper
+  $(MIBDIR)/.juniper \
+  $(MIBDIR)/.dell-network
 
 $(MIBDIR)/apc-powernet-mib:
 	@echo ">> Downloading apc-powernet-mib" 
@@ -489,3 +492,16 @@ $(MIBDIR)/.juniper:
 		JuniperMibs/mib-jnx-subscriber.txt
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.juniper
+
+$(MIBDIR)/.dell-network:
+	$(eval TMP := $(shell mktemp))
+	@echo ">> Downloading Dell network mibs to $(TMP)"
+	@curl $(CURL_OPTS) -o $(TMP) $(DELL_NETWORK_URL)
+	@unzip -j -d $(MIBDIR)/dell $(TMP) DELL-NETWORKING-MIB-9.14.2.1.zip
+	@unzip -j -d $(MIBDIR) $(MIBDIR)/dell/DELL-NETWORKING-MIB-9.14.2.1.zip \
+		DELL-NETWORKING-CHASSIS-MIB.mib \
+		DELL-NETWORKING-TC.mib \
+		DELL-NETWORKING-SMI.mib
+	@rm -rfv $(TMP) $(MIBDIR)/dell
+	@touch $(MIBDIR)/.dell-network
+

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -71,6 +71,16 @@ modules:
       - 1.3.6.1.4.1.674.10892.5.2 # statusGroup
       - 1.3.6.1.4.1.674.10892.5.4 # systemDetailsGroup
       - 1.3.6.1.4.1.674.10892.5.5 # storageDetailsGroup
+# Dell network (Force10)
+  dell_network:
+    walk:
+      - DELL-NETWORKING-CHASSIS-MIB::dellNetCpuUtilTable
+      - DELL-NETWORKING-CHASSIS-MIB::dellNetPowerSupplyTable
+      - DELL-NETWORKING-CHASSIS-MIB::dellNetSwModuleTable
+      - DELL-NETWORKING-CHASSIS-MIB::dellNetFlashStorageTable
+    overrides:
+      dellNetPowerSupplyIndex:
+        ignore: true
 
 # D-Link managed switches (DES-3200)
   dlink:

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -81,6 +81,13 @@ modules:
     overrides:
       dellNetPowerSupplyIndex:
         ignore: true
+      dellNetFanDeviceType:
+        type: EnumAsInfo
+      dellNetPowerDeviceType:
+        type: EnumAsInfo
+      dellNetProcessorDeviceType:
+        type: EnumAsInfo
+
 
 # D-Link managed switches (DES-3200)
   dlink:

--- a/snmp.yml
+++ b/snmp.yml
@@ -13027,6 +13027,465 @@ modules:
       indexes:
       - labelname: virtualDiskNumber
         type: gauge
+  dell_network:
+    walk:
+    - 1.3.6.1.4.1.6027.3.26.1.4.4
+    - 1.3.6.1.4.1.6027.3.26.1.4.5
+    - 1.3.6.1.4.1.6027.3.26.1.4.6
+    - 1.3.6.1.4.1.6027.3.26.1.4.8
+    metrics:
+    - name: dellNetCpuUtil5Sec
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.4.1.1
+      type: gauge
+      help: CPU utilization in percentage for last 5 seconds. - 1.3.6.1.4.1.6027.3.26.1.4.4.1.1
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+      - labelname: dellNetProcessorIndex
+        type: gauge
+    - name: dellNetCpuUtil1Min
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.4.1.4
+      type: gauge
+      help: CPU utilization in percentage for last 1 minute. - 1.3.6.1.4.1.6027.3.26.1.4.4.1.4
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+      - labelname: dellNetProcessorIndex
+        type: gauge
+    - name: dellNetCpuUtil5Min
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.4.1.5
+      type: gauge
+      help: CPU utilization in percentage for last 5 minutes. - 1.3.6.1.4.1.6027.3.26.1.4.4.1.5
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+      - labelname: dellNetProcessorIndex
+        type: gauge
+    - name: dellNetCpuUtilMemUsage
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.4.1.6
+      type: gauge
+      help: Total Memory usage in percentage. - 1.3.6.1.4.1.6027.3.26.1.4.4.1.6
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+      - labelname: dellNetProcessorIndex
+        type: gauge
+    - name: dellNetCpuFlashUsage
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.4.1.7
+      type: gauge
+      help: Total flash usage in percentage. - 1.3.6.1.4.1.6027.3.26.1.4.4.1.7
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+      - labelname: dellNetProcessorIndex
+        type: gauge
+    - name: dellNetSwModuleRuntimeImgVersion
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.5.1.1
+      type: DisplayString
+      help: Current Dell Networking OS image version running in the system - 1.3.6.1.4.1.6027.3.26.1.4.5.1.1
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+    - name: dellNetSwModuleRuntimeImgDate
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.5.1.2
+      type: OctetString
+      help: The release date of this software module. - 1.3.6.1.4.1.6027.3.26.1.4.5.1.2
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+    - name: dellNetSwModuleBootFlashImgVersion
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.5.1.3
+      type: DisplayString
+      help: This provides the Grub image version that is currently running in the
+        processor. - 1.3.6.1.4.1.6027.3.26.1.4.5.1.3
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+    - name: dellNetSwModuleBootSelectorImgVersion
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.5.1.4
+      type: DisplayString
+      help: This provides the BIOS image version that is currently running in the
+        processor. - 1.3.6.1.4.1.6027.3.26.1.4.5.1.4
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+    - name: dellNetSwModuleNextRebootImage
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.5.1.5
+      type: gauge
+      help: The image selection, when the chassis is rebooted - 1.3.6.1.4.1.6027.3.26.1.4.5.1.5
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+      enum_values:
+        1: partitionA
+        2: partitionB
+        3: networkBoot
+    - name: dellNetSwModuleCurrentBootImage
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.5.1.6
+      type: gauge
+      help: The current image is booted from - 1.3.6.1.4.1.6027.3.26.1.4.5.1.6
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+      enum_values:
+        1: partitionA
+        2: partitionB
+        3: networkBoot
+    - name: dellNetSwModuleInPartitionAImgVers
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.5.1.7
+      type: DisplayString
+      help: 'This provides the Dell Networking OS system image version that is stored
+        in partition A: and The version string has Major and Minor release numbers
+        - 1.3.6.1.4.1.6027.3.26.1.4.5.1.7'
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+    - name: dellNetSwModuleInPartitionBImgVers
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.5.1.8
+      type: DisplayString
+      help: 'This provides the Dell Networking OS system image version that is stored
+        in partition B: and The version string has Major and Minor release numbers
+        - 1.3.6.1.4.1.6027.3.26.1.4.5.1.8'
+      indexes:
+      - labelname: dellNetProcessorDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetProcessorDeviceIndex
+        type: gauge
+    - name: dellNetPowerDeviceType
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.6.1.1
+      type: EnumAsInfo
+      help: Identify the type of device the power supply units reside (chassis,port
+        extender etc..) - 1.3.6.1.4.1.6027.3.26.1.4.6.1.1
+      indexes:
+      - labelname: dellNetPowerDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetPowerDeviceIndex
+        type: gauge
+      - labelname: dellNetPowerSupplyIndex
+        type: gauge
+      enum_values:
+        1: chassis
+        2: stack
+        3: rpm
+        4: supervisor
+        5: linecard
+        6: port-extender
+    - name: dellNetPowerDeviceIndex
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.6.1.2
+      type: gauge
+      help: A unique device index within the device type. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.2
+      indexes:
+      - labelname: dellNetPowerDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetPowerDeviceIndex
+        type: gauge
+      - labelname: dellNetPowerSupplyIndex
+        type: gauge
+    - name: dellNetPowerSupplyOperStatus
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.6.1.4
+      type: gauge
+      help: The status of the power supply. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.4
+      indexes:
+      - labelname: dellNetPowerDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetPowerDeviceIndex
+        type: gauge
+      - labelname: dellNetPowerSupplyIndex
+        type: gauge
+      enum_values:
+        1: up
+        2: down
+        3: absent
+    - name: dellNetPowerSupplyType
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.6.1.5
+      type: gauge
+      help: The type of the power supply. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.5
+      indexes:
+      - labelname: dellNetPowerDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetPowerDeviceIndex
+        type: gauge
+      - labelname: dellNetPowerSupplyIndex
+        type: gauge
+      enum_values:
+        1: unknown
+        2: ac
+        3: dc
+    - name: dellNetPowerSupplyPiecePartID
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.6.1.6
+      type: DisplayString
+      help: The power supply's piece part id. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.6
+      indexes:
+      - labelname: dellNetPowerDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetPowerDeviceIndex
+        type: gauge
+      - labelname: dellNetPowerSupplyIndex
+        type: gauge
+    - name: dellNetPowerSupplyPPIDRevision
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.6.1.7
+      type: DisplayString
+      help: The power supply's PPID revision. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.7
+      indexes:
+      - labelname: dellNetPowerDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetPowerDeviceIndex
+        type: gauge
+      - labelname: dellNetPowerSupplyIndex
+        type: gauge
+    - name: dellNetPowerSupplyServiceTag
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.6.1.8
+      type: DisplayString
+      help: The power supply's service tag. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.8
+      indexes:
+      - labelname: dellNetPowerDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetPowerDeviceIndex
+        type: gauge
+      - labelname: dellNetPowerSupplyIndex
+        type: gauge
+    - name: dellNetPowerSupplyExpressServiceCode
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.6.1.9
+      type: DisplayString
+      help: The power supply's express service code. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.9
+      indexes:
+      - labelname: dellNetPowerDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetPowerDeviceIndex
+        type: gauge
+      - labelname: dellNetPowerSupplyIndex
+        type: gauge
+    - name: dellNetPowerSupplyUsage
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.6.1.10
+      type: gauge
+      help: Power usage of this Power Supply in Watts. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.10
+      indexes:
+      - labelname: dellNetPowerDeviceType
+        type: EnumAsInfo
+        enum_values:
+          1: chassis
+          2: stack
+          3: rpm
+          4: supervisor
+          5: linecard
+          6: port-extender
+      - labelname: dellNetPowerDeviceIndex
+        type: gauge
+      - labelname: dellNetPowerSupplyIndex
+        type: gauge
+    - name: dellNetFlashPartitionNumber
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.8.1.1
+      type: gauge
+      help: Partition number. - 1.3.6.1.4.1.6027.3.26.1.4.8.1.1
+      indexes:
+      - labelname: dellNetFlashPartitionNumber
+        type: gauge
+    - name: dellNetFlashPartitionName
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.8.1.2
+      type: DisplayString
+      help: The partition name on the flash. - 1.3.6.1.4.1.6027.3.26.1.4.8.1.2
+      indexes:
+      - labelname: dellNetFlashPartitionNumber
+        type: gauge
+    - name: dellNetFlashPartitionSize
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.8.1.3
+      type: gauge
+      help: The size of the parition. - 1.3.6.1.4.1.6027.3.26.1.4.8.1.3
+      indexes:
+      - labelname: dellNetFlashPartitionNumber
+        type: gauge
+    - name: dellNetFlashPartitionUsed
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.8.1.4
+      type: gauge
+      help: The used space on the specified parition. - 1.3.6.1.4.1.6027.3.26.1.4.8.1.4
+      indexes:
+      - labelname: dellNetFlashPartitionNumber
+        type: gauge
+    - name: dellNetFlashPartitionFree
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.8.1.5
+      type: gauge
+      help: The free space on the specified parition - 1.3.6.1.4.1.6027.3.26.1.4.8.1.5
+      indexes:
+      - labelname: dellNetFlashPartitionNumber
+        type: gauge
+    - name: dellNetFlashPartitionMountPoint
+      oid: 1.3.6.1.4.1.6027.3.26.1.4.8.1.6
+      type: DisplayString
+      help: The mount point for the partition on the flash. - 1.3.6.1.4.1.6027.3.26.1.4.8.1.6
+      indexes:
+      - labelname: dellNetFlashPartitionNumber
+        type: gauge
   dlink:
     walk:
     - 1.3.6.1.4.1.171.12.1.1.6


### PR DESCRIPTION
With CPU/memory, powersupport status, software versions used.

sample output from Dell Force MXL-10:

```
# HELP dellNetCpuFlashUsage Total flash usage in percentage. - 1.3.6.1.4.1.6027.3.26.1.4.4.1.7
# TYPE dellNetCpuFlashUsage gauge
dellNetCpuFlashUsage{dellNetProcessorDeviceIndex="0",dellNetProcessorDeviceType="2",dellNetProcessorIndex="1"} 0
# HELP dellNetCpuUtil1Min CPU utilization in percentage for last 1 minute. - 1.3.6.1.4.1.6027.3.26.1.4.4.1.4
# TYPE dellNetCpuUtil1Min gauge
dellNetCpuUtil1Min{dellNetProcessorDeviceIndex="0",dellNetProcessorDeviceType="2",dellNetProcessorIndex="1"} 0
# HELP dellNetCpuUtil5Min CPU utilization in percentage for last 5 minutes. - 1.3.6.1.4.1.6027.3.26.1.4.4.1.5
# TYPE dellNetCpuUtil5Min gauge
dellNetCpuUtil5Min{dellNetProcessorDeviceIndex="0",dellNetProcessorDeviceType="2",dellNetProcessorIndex="1"} 0
# HELP dellNetCpuUtil5Sec CPU utilization in percentage for last 5 seconds. - 1.3.6.1.4.1.6027.3.26.1.4.4.1.1
# TYPE dellNetCpuUtil5Sec gauge
dellNetCpuUtil5Sec{dellNetProcessorDeviceIndex="0",dellNetProcessorDeviceType="2",dellNetProcessorIndex="1"} 1
# HELP dellNetCpuUtilMemUsage Total Memory usage in percentage. - 1.3.6.1.4.1.6027.3.26.1.4.4.1.6
# TYPE dellNetCpuUtilMemUsage gauge
dellNetCpuUtilMemUsage{dellNetProcessorDeviceIndex="0",dellNetProcessorDeviceType="2",dellNetProcessorIndex="1"} 42
# HELP dellNetPowerSupplyExpressServiceCode The power supply's express service code. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.9
# TYPE dellNetPowerSupplyExpressServiceCode gauge
dellNetPowerSupplyExpressServiceCode{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyExpressServiceCode="",dellNetPowerSupplyIndex="1"} 1
dellNetPowerSupplyExpressServiceCode{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyExpressServiceCode="",dellNetPowerSupplyIndex="2"} 1
# HELP dellNetPowerSupplyIndex The unique index of the power supply. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.3
# TYPE dellNetPowerSupplyIndex gauge
dellNetPowerSupplyIndex{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="1"} 1
dellNetPowerSupplyIndex{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="2"} 2
# HELP dellNetPowerSupplyOperStatus The status of the power supply. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.4
# TYPE dellNetPowerSupplyOperStatus gauge
dellNetPowerSupplyOperStatus{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="1"} 0
dellNetPowerSupplyOperStatus{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="2"} 0
# HELP dellNetPowerSupplyPPIDRevision The power supply's PPID revision. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.7
# TYPE dellNetPowerSupplyPPIDRevision gauge
dellNetPowerSupplyPPIDRevision{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="1",dellNetPowerSupplyPPIDRevision=""} 1
dellNetPowerSupplyPPIDRevision{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="2",dellNetPowerSupplyPPIDRevision=""} 1
# HELP dellNetPowerSupplyPiecePartID The power supply's piece part id. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.6
# TYPE dellNetPowerSupplyPiecePartID gauge
dellNetPowerSupplyPiecePartID{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="1",dellNetPowerSupplyPiecePartID=""} 1
dellNetPowerSupplyPiecePartID{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="2",dellNetPowerSupplyPiecePartID=""} 1
# HELP dellNetPowerSupplyServiceTag The power supply's service tag. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.8
# TYPE dellNetPowerSupplyServiceTag gauge
dellNetPowerSupplyServiceTag{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="1",dellNetPowerSupplyServiceTag=""} 1
dellNetPowerSupplyServiceTag{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="2",dellNetPowerSupplyServiceTag=""} 1
# HELP dellNetPowerSupplyType The type of the power supply. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.5
# TYPE dellNetPowerSupplyType gauge
dellNetPowerSupplyType{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="1"} 1
dellNetPowerSupplyType{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="2"} 1
# HELP dellNetPowerSupplyUsage Power usage of this Power Supply in Watts. - 1.3.6.1.4.1.6027.3.26.1.4.6.1.10
# TYPE dellNetPowerSupplyUsage gauge
dellNetPowerSupplyUsage{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="1"} 0
dellNetPowerSupplyUsage{dellNetPowerDeviceIndex="0",dellNetPowerDeviceType="2",dellNetPowerSupplyIndex="2"} 0
# HELP dellNetSwModuleBootFlashImgVersion This provides the Grub image version that is currently running in the processor. - 1.3.6.1.4.1.6027.3.26.1.4.5.1.3
# TYPE dellNetSwModuleBootFlashImgVersion gauge
dellNetSwModuleBootFlashImgVersion{dellNetProcessorDeviceIndex="1",dellNetProcessorDeviceType="2",dellNetSwModuleBootFlashImgVersion="4.0.1.3"} 1
# HELP dellNetSwModuleBootSelectorImgVersion This provides the BIOS image version that is currently running in the processor. - 1.3.6.1.4.1.6027.3.26.1.4.5.1.4
# TYPE dellNetSwModuleBootSelectorImgVersion gauge
dellNetSwModuleBootSelectorImgVersion{dellNetProcessorDeviceIndex="1",dellNetProcessorDeviceType="2",dellNetSwModuleBootSelectorImgVersion="4.0.0.2"} 1
# HELP dellNetSwModuleCurrentBootImage The current image is booted from - 1.3.6.1.4.1.6027.3.26.1.4.5.1.6
# TYPE dellNetSwModuleCurrentBootImage gauge
dellNetSwModuleCurrentBootImage{dellNetProcessorDeviceIndex="1",dellNetProcessorDeviceType="2"} 2
# HELP dellNetSwModuleInPartitionAImgVers This provides the Dell Networking OS system image version that is stored in partition A: and The version string has Major and Minor release numbers - 1.3.6.1.4.1.6027.3.26.1.4.5.1.7
# TYPE dellNetSwModuleInPartitionAImgVers gauge
dellNetSwModuleInPartitionAImgVers{dellNetProcessorDeviceIndex="1",dellNetProcessorDeviceType="2",dellNetSwModuleInPartitionAImgVers="9.9(0.0)"} 1
# HELP dellNetSwModuleInPartitionBImgVers This provides the Dell Networking OS system image version that is stored in partition B: and The version string has Major and Minor release numbers - 1.3.6.1.4.1.6027.3.26.1.4.5.1.8
# TYPE dellNetSwModuleInPartitionBImgVers gauge
dellNetSwModuleInPartitionBImgVers{dellNetProcessorDeviceIndex="1",dellNetProcessorDeviceType="2",dellNetSwModuleInPartitionBImgVers="9.10(0.1P3)"} 1
# HELP dellNetSwModuleNextRebootImage The image selection, when the chassis is rebooted - 1.3.6.1.4.1.6027.3.26.1.4.5.1.5
# TYPE dellNetSwModuleNextRebootImage gauge
dellNetSwModuleNextRebootImage{dellNetProcessorDeviceIndex="1",dellNetProcessorDeviceType="2"} 3
# HELP dellNetSwModuleRuntimeImgDate The release date of this software module. - 1.3.6.1.4.1.6027.3.26.1.4.5.1.2
# TYPE dellNetSwModuleRuntimeImgDate gauge
dellNetSwModuleRuntimeImgDate{dellNetProcessorDeviceIndex="1",dellNetProcessorDeviceType="2",dellNetSwModuleRuntimeImgDate="0x547565204A756E2031342031353A30303A32332032303136"} 1
# HELP dellNetSwModuleRuntimeImgVersion Current Dell Networking OS image version running in the system - 1.3.6.1.4.1.6027.3.26.1.4.5.1.1
# TYPE dellNetSwModuleRuntimeImgVersion gauge
dellNetSwModuleRuntimeImgVersion{dellNetProcessorDeviceIndex="1",dellNetProcessorDeviceType="2",dellNetSwModuleRuntimeImgVersion="9.10(0.1P3)"} 1
# HELP snmp_scrape_duration_seconds Total SNMP time scrape took (walk and processing).
# TYPE snmp_scrape_duration_seconds gauge
snmp_scrape_duration_seconds{module="dell_network"} 0.032976042
snmp_scrape_duration_seconds{module="system"} 0.015420667
# HELP snmp_scrape_packets_retried Packets retried for get, bulkget, and walk.
# TYPE snmp_scrape_packets_retried gauge
snmp_scrape_packets_retried{module="dell_network"} 0
snmp_scrape_packets_retried{module="system"} 0
# HELP snmp_scrape_packets_sent Packets sent for get, bulkget, and walk; including retries.
# TYPE snmp_scrape_packets_sent gauge
snmp_scrape_packets_sent{module="dell_network"} 5
snmp_scrape_packets_sent{module="system"} 1
# HELP snmp_scrape_pdus_returned PDUs returned from get, bulkget, and walk.
# TYPE snmp_scrape_pdus_returned gauge
snmp_scrape_pdus_returned{module="dell_network"} 29
snmp_scrape_pdus_returned{module="system"} 7
# HELP snmp_scrape_walk_duration_seconds Time SNMP walk/bulkwalk took.
# TYPE snmp_scrape_walk_duration_seconds gauge
snmp_scrape_walk_duration_seconds{module="dell_network"} 0.032798667
snmp_scrape_walk_duration_seconds{module="system"} 0.015379375
# HELP sysContact The textual identification of the contact person for this managed node, together with information on how to contact this person - 1.3.6.1.2.1.1.4
# TYPE sysContact gauge
sysContact{sysContact="MRs-servers"} 1
# HELP sysDescr A textual description of the entity - 1.3.6.1.2.1.1.1
# TYPE sysDescr gauge
sysDescr{sysDescr="Dell Networking OS Operating System Version: 2.0 Application Software Version: 9.10(0.1P3) Series: MXL-10/40GbE Copyright (c) 1999-2016 by Dell Inc. All Rights Reserved. Build Time: Tue Jun 14  15:00:23 2016"} 1
# HELP sysLocation The physical location of this node (e.g., 'telephone closet, 3rd floor') - 1.3.6.1.2.1.1.6
# TYPE sysLocation gauge
sysLocation{sysLocation=""} 1
# HELP sysName An administratively-assigned name for this managed node - 1.3.6.1.2.1.1.5
# TYPE sysName gauge
sysName{sysName="w1-1.cc4"} 1
# HELP sysObjectID The vendor's authoritative identification of the network management subsystem contained in the entity - 1.3.6.1.2.1.1.2
# TYPE sysObjectID gauge
sysObjectID{sysObjectID="1.3.6.1.4.1.6027.1.4.1"} 1
# HELP sysServices A value which indicates the set of services that this entity may potentially offer - 1.3.6.1.2.1.1.7
# TYPE sysServices gauge
sysServices 6
# HELP sysUpTime The time (in hundredths of a second) since the network management portion of the system was last re-initialized. - 1.3.6.1.2.1.1.3
# TYPE sysUpTime gauge
sysUpTime 1.67051901e+09
```