### PR TITLE
Add Yamaha RT Series module

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -69,6 +69,8 @@ POWERCOM_URL      := https://www.upspowercom.com/pcm-img/Card-DA807/Upsmate_PCM.
 TPLINK_DDM        := https://static.tp-link.com/upload/software/2024/202402/20240229/L2-tplinkMibs.zip
 CISCO_CUCS_URL    := https://raw.githubusercontent.com/cisco/cisco-mibs/refs/heads/main/ucs-mibs
 CISCO_CUCS_URL_v2 := https://raw.githubusercontent.com/cisco/cisco-mibs/refs/heads/main/v2
+YAMAHA_URL        := https://www.rtpro.yamaha.co.jp/RT/docs/mib/
+
 CYBERPOWER_VERSION := 2.11
 CYBERPOWER_URL     := https://dl4jz3rbrsfum.cloudfront.net/software/CyberPower_MIB_v$(CYBERPOWER_VERSION).MIB.zip
 
@@ -103,7 +105,8 @@ clean:
 		$(MIBDIR)/readynas \
 		$(MIBDIR)/readydataos \
 		$(MIBDIR)/.eltex-mes \
-		$(MIBDIR)/.juniper
+		$(MIBDIR)/.juniper \
+		$(MIBDIR)/.yamaha-rt
 
 generator: *.go
 	go build
@@ -120,7 +123,7 @@ docker:
 
 .PHONY: docker-generate
 docker-generate: docker mibs
-	docker run --rm -v "${PWD}:/opt$(DOCKER_VOL_OPTS)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)" generate 
+	docker run --rm -v "${PWD}:/opt$(DOCKER_VOL_OPTS)" "$(DOCKER_REPO)/$(DOCKER_IMAGE_NAME):$(SANITIZED_DOCKER_IMAGE_TAG)" --no-fail-on-parse-errors generate
 
 .PHONY: docker-publish
 docker-publish:
@@ -177,7 +180,8 @@ mibs: \
   $(MIBDIR)/.dlink-mibs \
   $(MIBDIR)/.eltex-mes \
   $(MIBDIR)/.juniper \
-  $(MIBDIR)/.dell-network
+  $(MIBDIR)/.dell-network \
+	$(MIBDIR)/.yamaha-rt
 
 $(MIBDIR)/apc-powernet-mib:
 	@echo ">> Downloading apc-powernet-mib" 
@@ -508,3 +512,18 @@ $(MIBDIR)/.cisco-device:
 	@curl $(CURL_OPTS) -o $(MIBDIR)/CISCO-NS-MIB $(CISCO_URL)/CISCO-NS-MIB.my
 	@curl $(CURL_OPTS) -o $(MIBDIR)/CISCO-QOS-PIB-MIB $(CISCO_URL)/CISCO-QOS-PIB-MIB.my
 	@touch $(MIBDIR)/.cisco-device
+
+$(MIBDIR)/.yamaha-rt:
+	@echo ">> Downloading Yamaha RT Series MIBs"
+	@curl $(CURL_OPTS) $(CURL_USER_AGENT) -o $(MIBDIR)/yamaha-product.mib.txt $(YAMAHA_URL)/yamaha-product.mib.txt
+	@curl $(CURL_OPTS) $(CURL_USER_AGENT) -o $(MIBDIR)/yamaha-rt.mib.txt $(YAMAHA_URL)/yamaha-rt.mib.txt
+	@curl $(CURL_OPTS) $(CURL_USER_AGENT) -o $(MIBDIR)/yamaha-rt-firmware.mib.txt $(YAMAHA_URL)/yamaha-rt-firmware.mib.txt
+	@curl $(CURL_OPTS) $(CURL_USER_AGENT) -o $(MIBDIR)/yamaha-rt-hardware.mib.txt $(YAMAHA_URL)/yamaha-rt-hardware.mib.txt
+	@curl $(CURL_OPTS) $(CURL_USER_AGENT) -o $(MIBDIR)/yamaha-rt-interfaces.mib.txt $(YAMAHA_URL)/yamaha-rt-interfaces.mib.txt
+	@curl $(CURL_OPTS) $(CURL_USER_AGENT) -o $(MIBDIR)/yamaha-rt-ip.mib.txt $(YAMAHA_URL)/yamaha-rt-ip.mib.txt
+	@curl $(CURL_OPTS) $(CURL_USER_AGENT) -o $(MIBDIR)/yamaha-rt-switch.mib.txt $(YAMAHA_URL)/yamaha-rt-switch.mib.txt
+	@curl $(CURL_OPTS) $(CURL_USER_AGENT) -o $(MIBDIR)/yamaha-smi.mib.txt $(YAMAHA_URL)/yamaha-smi.mib.txt
+	# Workaround to make DisplayString available (#867)
+	@find $(MIBDIR) -name 'yamaha-*.mib.txt' | xargs sed -i.bak -z -E 's/(DisplayString(, PhysAddress)?[[:space:]\n]*FROM )RFC1213-MIB/\1SNMPv2-TC/'
+	@rm $(MIBDIR)/yamaha-*.mib.txt.bak
+	@touch $(MIBDIR)/.yamaha-rt

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -1090,3 +1090,37 @@ modules:
         scale: .01
       jnxDomCurrentTxLaserBiasCurrent:
         scale: .001
+
+# Yamaha RT Series
+#
+# http://www.rtpro.yamaha.co.jp/RT/docs/mib/yamaha-private-mib.zip
+  yamaha_rt:
+    walk:
+      - yrhMemorySize
+      - yrhMemoryUtil
+      - yrhCpuUtil5sec
+      - yrhCpuUtil1min
+      - yrhCpuUtil5min
+      - yrhMultiCpuUtil5sec
+      - yrhMultiCpuUtil1min
+      - yrhMultiCpuUtil5min
+      - yrfRevision
+      - yrfUpTime
+    overrides:
+      yrhMemoryUtil:
+        scale: 0.01
+      yrhCpuUtil5sec:
+        scale: 0.01
+      yrhCpuUtil1min:
+        scale: 0.01
+      yrhCpuUtil5min:
+        scale: 0.01
+      yrhMultiCpuUtil5sec:
+        scale: 0.01
+      yrhMultiCpuUtil1min:
+        scale: 0.01
+      yrhMultiCpuUtil5min:
+        scale: 0.01
+      yrfUpTime:
+        help: The time (in seconds) since the network management portion of the system was last re-initialized - 1.3.6.1.4.1.1182.2.2.4
+        scale: 0.01

--- a/snmp.yml
+++ b/snmp.yml
@@ -44740,3 +44740,75 @@ modules:
       oid: 1.3.6.1.4.1.2021.11.67
       type: gauge
       help: The number of processors, as counted by the agent - 1.3.6.1.4.1.2021.11.67
+  yamaha_rt:
+    walk:
+    - 1.3.6.1.4.1.1182.2.1.18.1.3
+    - 1.3.6.1.4.1.1182.2.1.18.1.4
+    - 1.3.6.1.4.1.1182.2.1.18.1.5
+    get:
+    - 1.3.6.1.4.1.1182.2.1.2.0
+    - 1.3.6.1.4.1.1182.2.1.4.0
+    - 1.3.6.1.4.1.1182.2.1.5.0
+    - 1.3.6.1.4.1.1182.2.1.6.0
+    - 1.3.6.1.4.1.1182.2.1.7.0
+    - 1.3.6.1.4.1.1182.2.2.3.0
+    - 1.3.6.1.4.1.1182.2.2.4.0
+    metrics:
+    - name: yrhMultiCpuUtil5sec
+      oid: 1.3.6.1.4.1.1182.2.1.18.1.3
+      type: gauge
+      help: The average utilization of CPU in 5 seconds. - 1.3.6.1.4.1.1182.2.1.18.1.3
+      indexes:
+      - labelname: yrhMultiCpuIndex
+        type: gauge
+      scale: 0.01
+    - name: yrhMultiCpuUtil1min
+      oid: 1.3.6.1.4.1.1182.2.1.18.1.4
+      type: gauge
+      help: The average utilization of CPU in 1 minutes. - 1.3.6.1.4.1.1182.2.1.18.1.4
+      indexes:
+      - labelname: yrhMultiCpuIndex
+        type: gauge
+      scale: 0.01
+    - name: yrhMultiCpuUtil5min
+      oid: 1.3.6.1.4.1.1182.2.1.18.1.5
+      type: gauge
+      help: The average utilization of CPU in 5 minutes. - 1.3.6.1.4.1.1182.2.1.18.1.5
+      indexes:
+      - labelname: yrhMultiCpuIndex
+        type: gauge
+      scale: 0.01
+    - name: yrhMemorySize
+      oid: 1.3.6.1.4.1.1182.2.1.2
+      type: gauge
+      help: The size of main memory in bytes. - 1.3.6.1.4.1.1182.2.1.2
+    - name: yrhMemoryUtil
+      oid: 1.3.6.1.4.1.1182.2.1.4
+      type: gauge
+      help: The utilization in percentage of main memory. - 1.3.6.1.4.1.1182.2.1.4
+      scale: 0.01
+    - name: yrhCpuUtil5sec
+      oid: 1.3.6.1.4.1.1182.2.1.5
+      type: gauge
+      help: The average utilization of CPU in 5 seconds. - 1.3.6.1.4.1.1182.2.1.5
+      scale: 0.01
+    - name: yrhCpuUtil1min
+      oid: 1.3.6.1.4.1.1182.2.1.6
+      type: gauge
+      help: The average utilization of CPU in 1 minutes. - 1.3.6.1.4.1.1182.2.1.6
+      scale: 0.01
+    - name: yrhCpuUtil5min
+      oid: 1.3.6.1.4.1.1182.2.1.7
+      type: gauge
+      help: The average utilization of CPU in 5 minutes. - 1.3.6.1.4.1.1182.2.1.7
+      scale: 0.01
+    - name: yrfRevision
+      oid: 1.3.6.1.4.1.1182.2.2.3
+      type: DisplayString
+      help: A textual string containing a revision information of an firmware - 1.3.6.1.4.1.1182.2.2.3
+    - name: yrfUpTime
+      oid: 1.3.6.1.4.1.1182.2.2.4
+      type: gauge
+      help: The time (in seconds) since the network management portion of the system
+        was last re-initialized - 1.3.6.1.4.1.1182.2.2.4
+      scale: 0.01


### PR DESCRIPTION
Download MIBs from https://www.rtpro.yamaha.co.jp/RT/docs/mib/ .

<details>
<summary>Example output from yamaha_rt:</summary>

```plain
# HELP snmp_scrape_duration_seconds Total SNMP time scrape took (walk and processing).
# TYPE snmp_scrape_duration_seconds gauge
snmp_scrape_duration_seconds{module="yamaha_rt"} 0.022254834
# HELP snmp_scrape_packets_retried Packets retried for get, bulkget, and walk.
# TYPE snmp_scrape_packets_retried gauge
snmp_scrape_packets_retried{module="yamaha_rt"} 0
# HELP snmp_scrape_packets_sent Packets sent for get, bulkget, and walk; including retries.
# TYPE snmp_scrape_packets_sent gauge
snmp_scrape_packets_sent{module="yamaha_rt"} 4
# HELP snmp_scrape_pdus_returned PDUs returned from get, bulkget, and walk.
# TYPE snmp_scrape_pdus_returned gauge
snmp_scrape_pdus_returned{module="yamaha_rt"} 19
# HELP snmp_scrape_walk_duration_seconds Time SNMP walk/bulkwalk took.
# TYPE snmp_scrape_walk_duration_seconds gauge
snmp_scrape_walk_duration_seconds{module="yamaha_rt"} 0.022005167
# HELP yrfRevision A textual string containing a revision information of an firmware - 1.3.6.1.4.1.1182.2.2.3
# TYPE yrfRevision gauge
yrfRevision{yrfRevision="RTX1300 Rev.23.00.13 (Wed Jun 19 09:13:13 2024)"} 1
# HELP yrfUpTime The time (in seconds) since the network management portion of the system was last re-initialized - 1.3.6.1.4.1.1182.2.2.4
# TYPE yrfUpTime gauge
yrfUpTime 1.995670363e+07
# HELP yrhCpuUtil1min The average utilization of CPU in 1 minutes. - 1.3.6.1.4.1.1182.2.1.6
# TYPE yrhCpuUtil1min gauge
yrhCpuUtil1min 0
# HELP yrhCpuUtil5min The average utilization of CPU in 5 minutes. - 1.3.6.1.4.1.1182.2.1.7
# TYPE yrhCpuUtil5min gauge
yrhCpuUtil5min 0
# HELP yrhCpuUtil5sec The average utilization of CPU in 5 seconds. - 1.3.6.1.4.1.1182.2.1.5
# TYPE yrhCpuUtil5sec gauge
yrhCpuUtil5sec 0
# HELP yrhMemorySize The size of main memory in bytes. - 1.3.6.1.4.1.1182.2.1.2
# TYPE yrhMemorySize gauge
yrhMemorySize 1.073741824e+09
# HELP yrhMemoryUtil The utilization in percentage of main memory. - 1.3.6.1.4.1.1182.2.1.4
# TYPE yrhMemoryUtil gauge
yrhMemoryUtil 0.32
# HELP yrhMultiCpuUtil1min The average utilization of CPU in 1 minutes. - 1.3.6.1.4.1.1182.2.1.18.1.4
# TYPE yrhMultiCpuUtil1min gauge
yrhMultiCpuUtil1min{yrhMultiCpuIndex="1"} 0
yrhMultiCpuUtil1min{yrhMultiCpuIndex="2"} 0
yrhMultiCpuUtil1min{yrhMultiCpuIndex="3"} 0
yrhMultiCpuUtil1min{yrhMultiCpuIndex="4"} 0
# HELP yrhMultiCpuUtil5min The average utilization of CPU in 5 minutes. - 1.3.6.1.4.1.1182.2.1.18.1.5
# TYPE yrhMultiCpuUtil5min gauge
yrhMultiCpuUtil5min{yrhMultiCpuIndex="1"} 0
yrhMultiCpuUtil5min{yrhMultiCpuIndex="2"} 0
yrhMultiCpuUtil5min{yrhMultiCpuIndex="3"} 0
yrhMultiCpuUtil5min{yrhMultiCpuIndex="4"} 0
# HELP yrhMultiCpuUtil5sec The average utilization of CPU in 5 seconds. - 1.3.6.1.4.1.1182.2.1.18.1.3
# TYPE yrhMultiCpuUtil5sec gauge
yrhMultiCpuUtil5sec{yrhMultiCpuIndex="1"} 0.01
yrhMultiCpuUtil5sec{yrhMultiCpuIndex="2"} 0
yrhMultiCpuUtil5sec{yrhMultiCpuIndex="3"} 0
yrhMultiCpuUtil5sec{yrhMultiCpuIndex="4"} 0
```
</details>