### PR TITLE
updated APC Powernet MIB to v457 

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -31,7 +31,7 @@ ifeq ($(SELINUX_ENABLED),1)
   DOCKER_VOL_OPTS ?= :z
 endif
 
-APC_URL           := https://download.schneider-electric.com/files?p_File_Name=powernet452.mib&p_Doc_Ref=APC_POWERNETMIB_452_EN&p_enDocType=Firmware
+APC_URL           := https://download.schneider-electric.com/files?p_Doc_Ref=APC_POWERNETMIB_EN&p_enDocType=Firmware
 ARISTA_URL        := https://www.arista.com/assets/data/docs/MIBS
 CISCO_URL         := https://raw.githubusercontent.com/cisco/cisco-mibs/f55dc443daff58dfc86a764047ded2248bb94e12/v2
 DELL_URL          := https://dl.dell.com/FOLDER11196144M/1/Dell-OM-MIBS-11010_A00.zip

--- a/snmp.yml
+++ b/snmp.yml
@@ -345,7 +345,7 @@ modules:
     - name: upsAdvBatteryRunTimeRemaining
       oid: 1.3.6.1.4.1.318.1.1.1.2.2.3
       type: gauge
-      help: The UPS battery run time remaining before battery exhaustion. - 1.3.6.1.4.1.318.1.1.1.2.2.3
+      help: The UPS battery run time remaining before battery exhaustion - 1.3.6.1.4.1.318.1.1.1.2.2.3
     - name: upsAdvBatteryReplaceIndicator
       oid: 1.3.6.1.4.1.318.1.1.1.2.2.4
       type: gauge
@@ -474,7 +474,7 @@ modules:
       oid: 1.3.6.1.4.1.318.1.1.1.2.2.15
       type: gauge
       help: The estimated remaining time required to charge the UPS to a full state
-        of charge. - 1.3.6.1.4.1.318.1.1.1.2.2.15
+        of charge - 1.3.6.1.4.1.318.1.1.1.2.2.15
     - name: upsAdvBatteryPower
       oid: 1.3.6.1.4.1.318.1.1.1.2.2.16
       type: gauge
@@ -1045,7 +1045,7 @@ modules:
       oid: 1.3.6.1.4.1.318.1.1.1.2.6.1.5
       type: gauge
       help: Temperature of the battery string or the average of the aggregated temperature
-        of each battery block/module (in tenths of degrees Celcius). - 1.3.6.1.4.1.318.1.1.1.2.6.1.5
+        of each battery block/module (in tenths of degrees Celcius) - 1.3.6.1.4.1.318.1.1.1.2.6.1.5
       indexes:
       - labelname: upsBatteryCabStringIndex
         type: gauge


### PR DESCRIPTION
as the old version is no longer available for download
