### PR TITLE
Add ifTable aliases to cisco_fc_fe module

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -128,6 +128,13 @@ modules:
       - CISCO-FC-FE-MIB::fcIfTxWaitCount
       - CISCO-FC-FE-MIB::fcIfCurrRxBbCredit
       - CISCO-FC-FE-MIB::fcIfCurrTxBbCredit
+    lookups:
+      - source_indexes: [ifIndex]
+        lookup: "IF-MIB::ifAlias"
+      - source_indexes: [ifIndex]
+        lookup: "IF-MIB::ifDescr"
+      - source_indexes: [ifIndex]
+        lookup: "IF-MIB::ifName"
 
 # Dell OpenManage MIBs
   dell:

--- a/snmp.yml
+++ b/snmp.yml
@@ -345,7 +345,7 @@ modules:
     - name: upsAdvBatteryRunTimeRemaining
       oid: 1.3.6.1.4.1.318.1.1.1.2.2.3
       type: gauge
-      help: The UPS battery run time remaining before battery exhaustion. - 1.3.6.1.4.1.318.1.1.1.2.2.3
+      help: The UPS battery run time remaining before battery exhaustion - 1.3.6.1.4.1.318.1.1.1.2.2.3
     - name: upsAdvBatteryReplaceIndicator
       oid: 1.3.6.1.4.1.318.1.1.1.2.2.4
       type: gauge
@@ -474,7 +474,7 @@ modules:
       oid: 1.3.6.1.4.1.318.1.1.1.2.2.15
       type: gauge
       help: The estimated remaining time required to charge the UPS to a full state
-        of charge. - 1.3.6.1.4.1.318.1.1.1.2.2.15
+        of charge - 1.3.6.1.4.1.318.1.1.1.2.2.15
     - name: upsAdvBatteryPower
       oid: 1.3.6.1.4.1.318.1.1.1.2.2.16
       type: gauge
@@ -1045,7 +1045,7 @@ modules:
       oid: 1.3.6.1.4.1.318.1.1.1.2.6.1.5
       type: gauge
       help: Temperature of the battery string or the average of the aggregated temperature
-        of each battery block/module (in tenths of degrees Celcius). - 1.3.6.1.4.1.318.1.1.1.2.6.1.5
+        of each battery block/module (in tenths of degrees Celcius) - 1.3.6.1.4.1.318.1.1.1.2.6.1.5
       indexes:
       - labelname: upsBatteryCabStringIndex
         type: gauge

--- a/snmp.yml
+++ b/snmp.yml
@@ -345,7 +345,7 @@ modules:
     - name: upsAdvBatteryRunTimeRemaining
       oid: 1.3.6.1.4.1.318.1.1.1.2.2.3
       type: gauge
-      help: The UPS battery run time remaining before battery exhaustion - 1.3.6.1.4.1.318.1.1.1.2.2.3
+      help: The UPS battery run time remaining before battery exhaustion. - 1.3.6.1.4.1.318.1.1.1.2.2.3
     - name: upsAdvBatteryReplaceIndicator
       oid: 1.3.6.1.4.1.318.1.1.1.2.2.4
       type: gauge
@@ -474,7 +474,7 @@ modules:
       oid: 1.3.6.1.4.1.318.1.1.1.2.2.15
       type: gauge
       help: The estimated remaining time required to charge the UPS to a full state
-        of charge - 1.3.6.1.4.1.318.1.1.1.2.2.15
+        of charge. - 1.3.6.1.4.1.318.1.1.1.2.2.15
     - name: upsAdvBatteryPower
       oid: 1.3.6.1.4.1.318.1.1.1.2.2.16
       type: gauge
@@ -1045,7 +1045,7 @@ modules:
       oid: 1.3.6.1.4.1.318.1.1.1.2.6.1.5
       type: gauge
       help: Temperature of the battery string or the average of the aggregated temperature
-        of each battery block/module (in tenths of degrees Celcius) - 1.3.6.1.4.1.318.1.1.1.2.6.1.5
+        of each battery block/module (in tenths of degrees Celcius). - 1.3.6.1.4.1.318.1.1.1.2.6.1.5
       indexes:
       - labelname: upsBatteryCabStringIndex
         type: gauge
@@ -3320,6 +3320,9 @@ modules:
         3: nonoperational
   cisco_fc_fe:
     walk:
+    - 1.3.6.1.2.1.2.2.1.2
+    - 1.3.6.1.2.1.31.1.1.1.1
+    - 1.3.6.1.2.1.31.1.1.1.18
     - 1.3.6.1.4.1.9.9.289.1.2.1.1.15
     - 1.3.6.1.4.1.9.9.289.1.2.1.1.26
     - 1.3.6.1.4.1.9.9.289.1.2.1.1.38
@@ -3338,6 +3341,22 @@ modules:
       indexes:
       - labelname: ifIndex
         type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
     - name: fcIfFramesDiscard
       oid: 1.3.6.1.4.1.9.9.289.1.2.1.1.26
       type: counter
@@ -3345,6 +3364,22 @@ modules:
       indexes:
       - labelname: ifIndex
         type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
     - name: fcIfTxWtAvgBBCreditTransitionToZero
       oid: 1.3.6.1.4.1.9.9.289.1.2.1.1.38
       type: counter
@@ -3353,6 +3388,22 @@ modules:
       indexes:
       - labelname: ifIndex
         type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
     - name: fcHCIfBBCreditTransistionFromZero
       oid: 1.3.6.1.4.1.9.9.289.1.2.1.1.40
       type: counter
@@ -3361,6 +3412,22 @@ modules:
       indexes:
       - labelname: ifIndex
         type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
     - name: fcHCIfBBCreditTransistionToZero
       oid: 1.3.6.1.4.1.9.9.289.1.2.1.1.41
       type: counter
@@ -3369,6 +3436,22 @@ modules:
       indexes:
       - labelname: ifIndex
         type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
     - name: fcIfInvalidTxWords
       oid: 1.3.6.1.4.1.9.9.289.1.2.1.1.5
       type: counter
@@ -3376,6 +3459,22 @@ modules:
       indexes:
       - labelname: ifIndex
         type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
     - name: fcIfInvalidCrcs
       oid: 1.3.6.1.4.1.9.9.289.1.2.1.1.6
       type: counter
@@ -3383,6 +3482,22 @@ modules:
       indexes:
       - labelname: ifIndex
         type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
     - name: fcIfCurrRxBbCredit
       oid: 1.3.6.1.4.1.9.9.289.1.2.5.1.1
       type: gauge
@@ -3391,6 +3506,22 @@ modules:
       indexes:
       - labelname: ifIndex
         type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
     - name: fcIfCurrTxBbCredit
       oid: 1.3.6.1.4.1.9.9.289.1.2.5.1.2
       type: gauge
@@ -3399,6 +3530,22 @@ modules:
       indexes:
       - labelname: ifIndex
         type: gauge
+      lookups:
+      - labels:
+        - ifIndex
+        labelname: ifAlias
+        oid: 1.3.6.1.2.1.31.1.1.1.18
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifDescr
+        oid: 1.3.6.1.2.1.2.2.1.2
+        type: DisplayString
+      - labels:
+        - ifIndex
+        labelname: ifName
+        oid: 1.3.6.1.2.1.31.1.1.1.1
+        type: DisplayString
   cisco_imc:
     walk:
     - 1.3.6.1.4.1.9.9.719.1.1.1.1.11


### PR DESCRIPTION
Add ifTable aliases (ifName etc)  to`cisco_fc_fe` module to correlate fibre channel metrics with standard interface metrics by name not only index.