### PR TITLE
chore: Fixup go directive

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/prometheus/snmp_exporter
 
-go 1.23
-
-toolchain go1.24.1
+go 1.23.0
 
 require (
 	github.com/alecthomas/kingpin/v2 v2.4.0


### PR DESCRIPTION
Use explicit semver version for Go minimum version directive.