### PR TITLE
fix(Makefile): change extracted filename from .txt to .mib

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -336,7 +336,7 @@ $(MIBDIR)/.sophos_xg:
 	$(eval TMP := $(shell mktemp))
 	@echo ">> Downloading Sophos XG to $(TMP)"
 	@curl $(CURL_OPTS) -o $(TMP) $(SOPHOS_XG_URL)
-	@unzip -j -d $(MIBDIR) $(TMP) sophos-xg-mib/SOPHOS-XG-MIB20.txt
+	@unzip -j -d $(MIBDIR) $(TMP) sophos-xg-mib/SOPHOS-XG-MIB20.mib
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.sophos_xg
 


### PR DESCRIPTION
## Problem

While building the generator, the build failed with the following error:

```
>> Downloading Sophos XG to /tmp/tmp.MxIy5pSd8r
Archive:  /tmp/tmp.MxIy5pSd8r
caution: filename not matched:  sophos-xg-mib/SOPHOS-XG-MIB20.txt
make: *** [Makefile:339: mibs/.sophos_xg] Error 11
```

## Cause

The `unzip` command in the Makefile expected a file named `SOPHOS-XG-MIB20.txt`, but the actual file inside the ZIP archive has a `.mib` extension instead.

## Fix

Updated the Makefile to use the correct filename with the `.mib` extension.
