### PR TITLE
chore(generator): fail early for bad walk OID

### DIFF
--- a/generator/tree.go
+++ b/generator/tree.go
@@ -302,6 +302,9 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 	// Remove redundant OIDs to be walked.
 	toWalk := []string{}
 	for _, oid := range cfg.Walk {
+		if strings.HasPrefix(oid, ".") {
+			return nil, fmt.Errorf("invalid OID %s, prefix of '.' should be removed", oid)
+		}
 		// Resolve name to OID if possible.
 		n, ok := nameToNode[oid]
 		if ok {


### PR DESCRIPTION
In `generator.yml` and in a `walk:` section.  If an OID starts with a
period, for example `.1.3.6.1.4.1.20916`, this will fail to be found,
as it should be: `1.3.6.1.4.1.20916`. But the error message lacks
detail when this happens.

Fail early if an OID starts with a "." and explain why.
