### PR TITLE
config: allow setting default auth via YAML using `default: true`

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -38,6 +38,16 @@ func LoadFile(paths []string, expandEnvVars bool) (*Config, error) {
 				return nil, err
 			}
 			err = yaml.UnmarshalStrict(content, cfg)
+			foundDefault := false
+			for name, auth := range cfg.Auths {
+				if auth.Default {
+					if foundDefault {
+						return nil, fmt.Errorf("multiple auths marked as default: already set, found again in %s", name)
+					}
+					DefaultAuth = *auth
+					foundDefault = true
+				}
+			}
 			if err != nil {
 				return nil, err
 			}
@@ -69,7 +79,6 @@ func LoadFile(paths []string, expandEnvVars bool) (*Config, error) {
 			}
 		}
 	}
-
 	return cfg, nil
 }
 
@@ -277,6 +286,7 @@ type Auth struct {
 	PrivPassword  Secret `yaml:"priv_password,omitempty"`
 	ContextName   string `yaml:"context_name,omitempty"`
 	Version       int    `yaml:"version,omitempty"`
+	Default       bool   `yaml:"default,omitempty"`
 }
 
 func (c *Auth) UnmarshalYAML(unmarshal func(interface{}) error) error {


### PR DESCRIPTION
Adds support for marking an SNMP auth block as the default by specifying `default: true` in the YAML configuration. When present, the marked auth is assigned to `DefaultAuth` and used wherever a default is needed. If multiple auths are marked as default, an error is returned.

This makes the default behavior configurable without code changes.