### PR TITLE
fix(config): also error when env var in config is prefixed or suffixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ scrape_configs:
 ```
 
 You could pass `username`, `password` & `priv_password` via environment variables of your choice in below format. 
-If the variables exist in the environment, they are resolved on the fly otherwise the string in the config file is passed as-is.
+If the variables exist in the environment, they are resolved on the fly, otherwise `snmp_exporter` will error while loading the config.
 
 This requires the `--config.expand-environment-variables` flag be set.
 

--- a/config/config.go
+++ b/config/config.go
@@ -361,11 +361,16 @@ func (re *Regexp) UnmarshalYAML(unmarshal func(interface{}) error) error {
 }
 
 func substituteEnvVariables(value string) (string, error) {
+	var missingEnv = ""
 	result := os.Expand(value, func(s string) string {
-		return os.Getenv(s)
+		v, found := os.LookupEnv(s)
+		if !found && missingEnv != "" {
+			missingEnv = s
+		}
+		return v
 	})
-	if result == "" {
-		return "", errors.New(value + " environment variable not found")
+	if result == "" || missingEnv != "" {
+		return "", errors.New(missingEnv + " environment variable not found")
 	}
 	return result, nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -73,7 +73,7 @@ func TestLoadMultipleConfigs(t *testing.T) {
 
 // When all environment variables are present
 func TestEnvSecrets(t *testing.T) {
-	t.Setenv("ENV_USERNAME", "snmp_username")
+	t.Setenv("ENV_USERNAME", "username") // snmp_ prefix is set in config file
 	t.Setenv("ENV_PASSWORD", "snmp_password")
 	t.Setenv("ENV_PRIV_PASSWORD", "snmp_priv_password")
 
@@ -110,6 +110,9 @@ func TestEnvSecretsMissing(t *testing.T) {
 
 	sc := &SafeConfig{}
 	err := sc.ReloadConfig(nopLogger, []string{"testdata/snmp-auth-envvars.yml"}, true)
+	if err == nil {
+		t.Fatal("no error despite missing env var")
+	}
 	if err != nil {
 		// we check the error message pattern to determine the error
 		if strings.Contains(err.Error(), "environment variable not found") {

--- a/testdata/snmp-auth-envvars.yml
+++ b/testdata/snmp-auth-envvars.yml
@@ -2,7 +2,7 @@ auths:
   with_secret:
     community: mysecret
     security_level: SomethingReadOnly
-    username: ${ENV_USERNAME}
+    username: snmp_${ENV_USERNAME}
     password: ${ENV_PASSWORD}
     auth_protocol: SHA256
     priv_protocol: AES


### PR DESCRIPTION
The documentation claimed that the config would be used as-is if an env var is not found in the environment. But that's not how `snmp_exporter` behaves: if an env var is missing, it errors while loading the config. I've updated the README to reflect that.


If an env var was part of a larger string, `snmp_exporter` would neither error *nor* leave the string as-is. Instead, os.Expand would silently replace the env vars with "". I've updated the implementation to also error when the (missing) env var is found within a larger string. A common failure scenario is having a password like `abcd$geh==1(` in the config: with `config.expand-environment-variables`, this password would silently be changed to `abcd==1` (stripping the env var), so authentication against targets would fail despite having corrects auths in the config. Now, `snmp_exporter` errors and complains about the missing variable `geh`.