### PR TITLE
printer_mib: annotate supply metrics with prtMarkerSuppliesDescription

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -868,6 +868,8 @@ modules:
     lookups:
       - source_indexes: [hrDeviceIndex, prtMarkerSuppliesIndex]
         lookup: prtMarkerSuppliesType
+      - source_indexes: [hrDeviceIndex, prtMarkerSuppliesIndex]
+        lookup: prtMarkerSuppliesDescription
     overrides:
       prtGeneralReset:
         type: EnumAsStateSet

--- a/snmp.yml
+++ b/snmp.yml
@@ -37110,6 +37110,12 @@ modules:
         labelname: prtMarkerSuppliesType
         oid: 1.3.6.1.2.1.43.11.1.1.5
         type: gauge
+      - labels:
+        - hrDeviceIndex
+        - prtMarkerSuppliesIndex
+        labelname: prtMarkerSuppliesDescription
+        oid: 1.3.6.1.2.1.43.11.1.1.6
+        type: DisplayString
       enum_values:
         1: other
         2: unknown
@@ -37164,6 +37170,12 @@ modules:
         labelname: prtMarkerSuppliesType
         oid: 1.3.6.1.2.1.43.11.1.1.5
         type: gauge
+      - labels:
+        - hrDeviceIndex
+        - prtMarkerSuppliesIndex
+        labelname: prtMarkerSuppliesDescription
+        oid: 1.3.6.1.2.1.43.11.1.1.6
+        type: DisplayString
     - name: prtMarkerSuppliesMaxCapacity
       oid: 1.3.6.1.2.1.43.11.1.1.8
       type: gauge
@@ -37181,6 +37193,12 @@ modules:
         labelname: prtMarkerSuppliesType
         oid: 1.3.6.1.2.1.43.11.1.1.5
         type: gauge
+      - labels:
+        - hrDeviceIndex
+        - prtMarkerSuppliesIndex
+        labelname: prtMarkerSuppliesDescription
+        oid: 1.3.6.1.2.1.43.11.1.1.6
+        type: DisplayString
     - name: prtMarkerSuppliesLevel
       oid: 1.3.6.1.2.1.43.11.1.1.9
       type: gauge
@@ -37198,6 +37216,12 @@ modules:
         labelname: prtMarkerSuppliesType
         oid: 1.3.6.1.2.1.43.11.1.1.5
         type: gauge
+      - labels:
+        - hrDeviceIndex
+        - prtMarkerSuppliesIndex
+        labelname: prtMarkerSuppliesDescription
+        oid: 1.3.6.1.2.1.43.11.1.1.6
+        type: DisplayString
     - name: prtConsoleDisable
       oid: 1.3.6.1.2.1.43.5.1.1.13
       type: EnumAsStateSet


### PR DESCRIPTION
Add the prtMarkerSuppliesDescription label - such as "Magenta Toner Cartridge" or "Waste Toner Box" - to the following metrics.

* prtMarkerSuppliesType
* prtMarkerSuppliesMaxCapacity
* prtMarkerSuppliesLevel

While it would be possible to drop the existing prtMarkerSuppliesDescription metric, it is retained for compatibility.