### PR TITLE
Allow community string as ENV Variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ scrape_configs:
       - targets: ['localhost:9116']
 ```
 
-You could pass `username`, `password` & `priv_password` via environment variables of your choice in below format. 
+You could pass `username`, `password`, `priv_password` & `community` via environment variables of your choice in below format. 
 If the variables exist in the environment, they are resolved on the fly otherwise the string in the config file is passed as-is.
 
 This requires the `--config.expand-environment-variables` flag be set.
@@ -185,7 +185,7 @@ This requires the `--config.expand-environment-variables` flag be set.
 ```YAML
 auths:
   example_with_envs:
-    community: mysecret
+    community: ${SNMP_COMMUNITY_STRING}
     security_level: SomethingReadOnly
     username: ${ARISTA_USERNAME}
     password: ${ARISTA_PASSWORD}

--- a/config/config.go
+++ b/config/config.go
@@ -83,6 +83,13 @@ func LoadFile(logger *slog.Logger, paths []string, expandEnvVars bool) (*Config,
 				}
 				cfg.Auths[i].PrivPassword.Set(privPassword)
 			}
+			if auth.Community != "" {
+				community, err := substituteEnvVariables(string(auth.Community))
+				if err != nil {
+					return nil, err
+				}
+				cfg.Auths[i].Community.Set(community)
+			}
 		}
 	}
 

--- a/config_test.go
+++ b/config_test.go
@@ -76,6 +76,7 @@ func TestEnvSecrets(t *testing.T) {
 	t.Setenv("ENV_USERNAME", "snmp_username")
 	t.Setenv("ENV_PASSWORD", "snmp_password")
 	t.Setenv("ENV_PRIV_PASSWORD", "snmp_priv_password")
+	t.Setenv("ENV_COMMUNITY", "snmp_community")
 
 	sc := &SafeConfig{}
 	err := sc.ReloadConfig(nopLogger, []string{"testdata/snmp-auth-envvars.yml"}, true)
@@ -97,7 +98,7 @@ func TestEnvSecrets(t *testing.T) {
 
 	// we check whether vars we set are resolved correctly in config
 	for i := range sc.C.Auths {
-		if sc.C.Auths[i].Username != "snmp_username" || sc.C.Auths[i].Password != "snmp_password" || sc.C.Auths[i].PrivPassword != "snmp_priv_password" {
+		if sc.C.Auths[i].Username != "snmp_username" || sc.C.Auths[i].Password != "snmp_password" || sc.C.Auths[i].PrivPassword != "snmp_priv_password" || sc.C.Auths[i].Community != "snmp_community" {
 			t.Fatal("failed to resolve secrets from env vars")
 		}
 	}

--- a/testdata/snmp-auth-envvars.yml
+++ b/testdata/snmp-auth-envvars.yml
@@ -1,6 +1,6 @@
 auths:
   with_secret:
-    community: mysecret
+    community: ${ENV_COMMUNITY}
     security_level: SomethingReadOnly
     username: ${ENV_USERNAME}
     password: ${ENV_PASSWORD}


### PR DESCRIPTION
Although community strings are not really considered secret, we do have a use-case to provide them as environment variables. Updated is adding Community to be able to come from an environment variable, testing and the README adjustment.

@SuperQ @bastischubert @RichiH