### PR TITLE
Optimize OID conversion functions with pre-allocation

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -797,7 +797,11 @@ func bits(metric *config.Metric, value any, labelnames, labelvalues []string) []
 // Some routers exclude trailing 0s in responses.
 func splitOid(oid []int, count int) ([]int, []int) {
 	head := make([]int, count)
-	tail := []int{}
+	tailCapacity := len(oid) - count
+	if tailCapacity < 0 {
+		tailCapacity = 0
+	}
+	tail := make([]int, 0, tailCapacity)
 	for i, v := range oid {
 		if i < count {
 			head[i] = v


### PR DESCRIPTION
This PR optimizes the OID conversion functions by using pre-allocation and strings.Builder to reduce memory allocations and improve performance.

  Changes:
  - Optimize oidToList with pre-allocation
  - Optimize listToOid using strings.Builder
  - Optimize splitOid with pre-allocation