### PR TITLE
generator: Update Raritan PDU2 MIB to 4.3.10 and add Asset Management support

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -61,7 +61,8 @@ UBNT_AIRFIBER_URL := https://dl.ubnt.com/firmwares/airfiber5X/v4.1.0/UBNT-MIB.tx
 UBNT_DL_URL       := http://dl.ubnt-ut.com/snmp
 UPS_MIB_URL       := https://raw.githubusercontent.com/pgmillon/observium/refs/heads/master/mibs/UPS-MIB
 RARITAN_URL       := https://cdn.raritan.com/download/PX/v1.5.20/PDU-MIB.txt
-RARITAN2_URL      := https://cdn1.raritan.com/download/src-g2/4.0.20/PDU2_MIB_4.0.20_49038.txt
+RARITAN2_URL      := https://cdn1.raritan.com/download/pdu-g2/4.3.10/PDU2_MIB_4.3.10_51837.txt
+RARITAN_AM_URL    := https://cdn1.raritan.com/download/pdu-g2/4.3.10/AssetManagement_MIB_4.3.10_51837.txt
 INFRAPOWER_URL    := https://www.austin-hughes.com/wp-content/uploads/2021/05/IPD-03-S-MIB.zip
 LIEBERT_URL       := https://www.vertiv.com/globalassets/documents/software/monitoring/lgpmib-win_rev16_299461_0.zip
 READYNAS_URL      := https://www.downloads.netgear.com/files/ReadyNAS/READYNAS-MIB.txt
@@ -171,6 +172,7 @@ mibs: \
   $(MIBDIR)/UBNT-AirMAX-MIB.txt \
   $(MIBDIR)/PDU-MIB.txt \
   $(MIBDIR)/PDU2-MIB.txt \
+  $(MIBDIR)/PDU_AssetManagement_MIB.txt \
   $(MIBDIR)/Infrapower-MIB.mib \
   $(MIBDIR)/LIEBERT_GP_PDU.MIB \
   $(MIBDIR)/CyberPower.MIB \
@@ -409,6 +411,10 @@ $(MIBDIR)/PDU-MIB.txt:
 $(MIBDIR)/PDU2-MIB.txt:
 	@echo ">> Downloading Raritan PDU2-MIB"
 	@curl $(CURL_OPTS) -o $(MIBDIR)/PDU2-MIB.txt "$(RARITAN2_URL)"
+
+$(MIBDIR)/PDU_AssetManagement_MIB.txt:
+	@echo ">> Downloading Raritan AssetManagement_MIB"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/PDU_AssetManagement_MIB.txt "$(RARITAN_AM_URL)"
 
 $(MIBDIR)/Infrapower-MIB.mib:
 	$(eval TMP := $(shell mktemp))

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -914,10 +914,9 @@ modules:
       naptCacheIfIndex:
         ignore: true
 
-# Raritan
+# Raritan PDU (Legacy PX series - PDU-MIB)
 #
 # https://cdn.raritan.com/download/PX/v1.5.20/PDU-MIB.txt
-# https://cdn1.raritan.com/download/src-g2/4.0.20/PDU2_MIB_4.0.20_49038.txt
   raritan:
     walk:
       - 1.3.6.1.4.1.13742.4.1.20.2.1.7 # inletCurrent
@@ -930,13 +929,125 @@ modules:
       - 1.3.6.1.4.1.13742.4.1.2.2.1.6  # outletVoltage
       - 1.3.6.1.4.1.13742.4.1.2.2.1.7  # outletActivePower
       - 1.3.6.1.4.1.13742.4.1.3.1.5    # unitCpuTemp
-      - 1.3.6.1.4.1.13742.6.5.5.3.1    # externalSensors
     lookups:
       - source_indexes: [outletIndex]
         lookup: outletLabel
     overrides:
       outletOperationalState:
         type: EnumAsStateSet
+
+# Raritan PDU2 (PX2, PX3, PX4, PXC, SRC, PRO3X, PRO4X series - PDU2-MIB)
+#
+# https://cdn1.raritan.com/download/pdu-g2/4.3.10/PDU2_MIB_4.3.10_51837.txt
+# https://cdn1.raritan.com/download/pdu-g2/4.3.10/AssetManagement_MIB_4.3.10_51837.txt
+  raritan_pdu2:
+    walk:
+      # Nameplate (device identification)
+      - "PDU2-MIB::nameplateTable"
+      # Unit configuration
+      - "PDU2-MIB::unitConfigurationTable"
+      # Inlet configuration
+      - "PDU2-MIB::inletConfigurationTable"
+      # Outlet configuration
+      - "PDU2-MIB::outletConfigurationTable"
+      # Unit sensor measurements (temperature, humidity, etc.)
+      - "PDU2-MIB::unitSensorMeasurementsTable"
+      # Inlet sensor measurements (voltage, current, power, energy)
+      - "PDU2-MIB::inletSensorMeasurementsTable"
+      # Inlet pole sensor measurements (per-pole data for 3-phase)
+      - "PDU2-MIB::inletPoleSensorMeasurementsTable"
+      # Outlet sensor measurements (voltage, current, power, energy per outlet)
+      - "PDU2-MIB::outletSensorMeasurementsTable"
+      # Outlet pole sensor measurements
+      - "PDU2-MIB::outletPoleSensorMeasurementsTable"
+      # Over current protector measurements (breaker status)
+      - "PDU2-MIB::overCurrentProtectorSensorMeasurementsTable"
+      # External sensor measurements (environmental sensors)
+      - "PDU2-MIB::externalSensorMeasurementsTable"
+      # Circuit measurements (for branch circuit monitoring)
+      - "PDU2-MIB::circuitSensorMeasurementsTable"
+      # Transfer switch measurements
+      - "PDU2-MIB::transferSwitchSensorMeasurementsTable"
+    lookups:
+      - source_indexes: [pduId]
+        lookup: "PDU2-MIB::pduName"
+      - source_indexes: [pduId, inletId]
+        lookup: "PDU2-MIB::inletLabel"
+      - source_indexes: [pduId, outletId]
+        lookup: "PDU2-MIB::outletLabel"
+      - source_indexes: [pduId, outletId]
+        lookup: "PDU2-MIB::outletName"
+      - source_indexes: [pduId, externalSensorId]
+        lookup: "PDU2-MIB::externalSensorSerialNumber"
+    overrides:
+      pduName:
+        ignore: true
+      inletLabel:
+        ignore: true
+      outletLabel:
+        ignore: true
+      outletName:
+        ignore: true
+      externalSensorSerialNumber:
+        ignore: true
+      measurementsUnitSensorState:
+        type: EnumAsStateSet
+      measurementsInletSensorState:
+        type: EnumAsStateSet
+      measurementsOutletSensorState:
+        type: EnumAsStateSet
+      measurementsExternalSensorState:
+        type: EnumAsStateSet
+      measurementsOverCurrentProtectorSensorState:
+        type: EnumAsStateSet
+      measurementsCircuitSensorState:
+        type: EnumAsStateSet
+      measurementsTransferSwitchSensorState:
+        type: EnumAsStateSet
+
+# Raritan Asset Management (Asset Strips for rack unit tracking)
+#
+# https://cdn1.raritan.com/download/pdu-g2/4.3.10/AssetManagement_MIB_4.3.10_51837.txt
+  raritan_assetmanagement:
+    walk:
+      # Asset strip count and default LED colors
+      - "ASSETMANAGEMENT-MIB::assetStripCount"
+      - "ASSETMANAGEMENT-MIB::defaultLEDColorConnected"
+      - "ASSETMANAGEMENT-MIB::defaultLEDColorDisconnected"
+      # Asset strip configuration (strip state, rack unit count, etc.)
+      - "ASSETMANAGEMENT-MIB::assetStripConfigurationTable"
+      # Asset management table (tag IDs, rack unit positions, LED status)
+      - "ASSETMANAGEMENT-MIB::assetManagementTable"
+      # Blade extension table (for blade servers)
+      - "ASSETMANAGEMENT-MIB::bladeExtensionTable"
+    lookups:
+      - source_indexes: [assetStripID]
+        lookup: "ASSETMANAGEMENT-MIB::assetStripName"
+      - source_indexes: [assetStripID, rackUnitID]
+        lookup: "ASSETMANAGEMENT-MIB::rackUnitName"
+    overrides:
+      assetStripName:
+        ignore: true
+      rackUnitName:
+        ignore: true
+      assetStripState:
+        type: EnumAsStateSet
+      ledOperationMode:
+        type: EnumAsStateSet
+      ledMode:
+        type: EnumAsStateSet
+      rackUnitType:
+        type: EnumAsInfo
+      assetStripType:
+        type: EnumAsInfo
+      rackUnitNumberingMode:
+        type: EnumAsInfo
+      assetStripOrientation:
+        type: EnumAsInfo
+      tagID:
+        type: DisplayString
+      tagFamily:
+        type: DisplayString
 
 # InfraPower PDU's
 #

--- a/snmp.yml
+++ b/snmp.yml
@@ -37389,7 +37389,6 @@ modules:
     - 1.3.6.1.4.1.13742.4.1.20.2.1.7
     - 1.3.6.1.4.1.13742.4.1.20.2.1.8
     - 1.3.6.1.4.1.13742.4.1.20.2.1.9
-    - 1.3.6.1.4.1.13742.6.5.5.3.1
     get:
     - 1.3.6.1.4.1.13742.4.1.3.1.5.0
     metrics:
@@ -37505,27 +37504,2827 @@ modules:
       type: gauge
       help: The value for the unit's CPU temperature sensor in tenth degrees celsius.
         - 1.3.6.1.4.1.13742.4.1.3.1.5
-    - name: measurementsExternalSensorIsAvailable
-      oid: 1.3.6.1.4.1.13742.6.5.5.3.1.2
+  raritan_assetmanagement:
+    walk:
+    - 1.3.6.1.4.1.13742.7.1.6.1
+    - 1.3.6.1.4.1.13742.7.1.7.1
+    - 1.3.6.1.4.1.13742.7.1.7.2
+    get:
+    - 1.3.6.1.4.1.13742.7.1.1.0
+    - 1.3.6.1.4.1.13742.7.1.2.0
+    - 1.3.6.1.4.1.13742.7.1.4.0
+    metrics:
+    - name: assetStripCount
+      oid: 1.3.6.1.4.1.13742.7.1.1
       type: gauge
-      help: The sensor is present. - 1.3.6.1.4.1.13742.6.5.5.3.1.2
+      help: The number of asset management strip units supported. - 1.3.6.1.4.1.13742.7.1.1
+    - name: defaultLEDColorConnected
+      oid: 1.3.6.1.4.1.13742.7.1.2
+      type: OctetString
+      help: Default color of all LEDs (RGB) when a tag is connected during automatic
+        operation; in binary format - 1.3.6.1.4.1.13742.7.1.2
+    - name: defaultLEDColorDisconnected
+      oid: 1.3.6.1.4.1.13742.7.1.4
+      type: OctetString
+      help: Default color of all LEDs (RGB) when no tag is connected during automatic
+        operation; in binary format - 1.3.6.1.4.1.13742.7.1.4
+    - name: assetStripID
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.1
+      type: gauge
+      help: A unique value for each asset strip - 1.3.6.1.4.1.13742.7.1.6.1.1.1
       indexes:
-      - labelname: pduId
+      - labelname: assetStripID
         type: gauge
-      - labelname: sensorID
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+    - name: rackUnitCount
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.2
+      type: gauge
+      help: The number of rack-units for the asset management. - 1.3.6.1.4.1.13742.7.1.6.1.1.2
+      indexes:
+      - labelname: assetStripID
         type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+    - name: assetStripState
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.3
+      type: EnumAsStateSet
+      help: Asset management strip state. - 1.3.6.1.4.1.13742.7.1.6.1.1.3
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      enum_values:
+        1: disconnected
+        2: firmwareUpdate
+        3: unsupported
+        4: available
+    - name: rackUnitNumberingMode
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.5
+      type: EnumAsInfo
+      help: The rack unit nmbering mode for this asset strip. - 1.3.6.1.4.1.13742.7.1.6.1.1.5
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      enum_values:
+        0: topDown
+        1: bottomUp
+    - name: rackUnitNumberingOffset
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.6
+      type: gauge
+      help: The offset (starting value) for rack Unit Numbering; This takes care of
+        the case in which the asset strip is monitoring not all the assets but a subset
+        of it, starting from racknumberingOffset - 1.3.6.1.4.1.13742.7.1.6.1.1.6
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+    - name: assetStripOrientation
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.7
+      type: EnumAsInfo
+      help: Is the asset strip oriented such that the connector is at the top or the
+        bottom? If the asset strip has a tilt sensor, then this varaible is read-only
+        and an to set (write) it will result in an error - 1.3.6.1.4.1.13742.7.1.6.1.1.7
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      enum_values:
+        0: topConnector
+        1: bottomConnector
+    - name: currentMainTagCount
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.8
+      type: gauge
+      help: Number of tags currently connected to the main strip. - 1.3.6.1.4.1.13742.7.1.6.1.1.8
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+    - name: currentBladeTagCount
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.9
+      type: gauge
+      help: Number of tags currently connected to blade extensions - 1.3.6.1.4.1.13742.7.1.6.1.1.9
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+    - name: maxMainTagCount
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.10
+      type: gauge
+      help: Maximum number of tags on the main asset strip. - 1.3.6.1.4.1.13742.7.1.6.1.1.10
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+    - name: maxBladeTagCount
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.11
+      type: gauge
+      help: Maximum number of blade tags supported. - 1.3.6.1.4.1.13742.7.1.6.1.1.11
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+    - name: bladeExtensionOverflow
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.12
+      type: gauge
+      help: Set if the maximum number of supported tags on blade extensions is reached
+        - 1.3.6.1.4.1.13742.7.1.6.1.1.12
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
       enum_values:
         1: "true"
         2: "false"
-    - name: measurementsExternalSensorState
-      oid: 1.3.6.1.4.1.13742.6.5.5.3.1.3
+    - name: assetStripType
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.13
+      type: EnumAsInfo
+      help: The asset strip type. - 1.3.6.1.4.1.13742.7.1.6.1.1.13
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      enum_values:
+        0: simple
+        1: composite
+    - name: numberOfComponentAssetStrips
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.14
       type: gauge
-      help: The sensor state. - 1.3.6.1.4.1.13742.6.5.5.3.1.3
+      help: The number of components building a composite asset strip. - 1.3.6.1.4.1.13742.7.1.6.1.1.14
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+    - name: assetStripDefaultLEDColorConnected
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.15
+      type: OctetString
+      help: Default color of all LEDs (RGB) when a tag is connected during automatic
+        operation; in binary format. - 1.3.6.1.4.1.13742.7.1.6.1.1.15
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+    - name: assetStripDefaultLEDColorConnectedStr
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.16
+      type: DisplayString
+      help: Default color of all LEDs (RGB) when a tag is connected during automatic
+        operation; string with 3 hex octets - 1.3.6.1.4.1.13742.7.1.6.1.1.16
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+    - name: assetStripDefaultLEDColorDisconnected
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.17
+      type: OctetString
+      help: Default color of all LEDs (RGB) when no tag is connected during automatic
+        operation; in binary format. - 1.3.6.1.4.1.13742.7.1.6.1.1.17
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+    - name: assetStripDefaultLEDColorDisconnectedStr
+      oid: 1.3.6.1.4.1.13742.7.1.6.1.1.18
+      type: DisplayString
+      help: Default color of all LEDs (RGB) when no tag is connected during automatic
+        operation; string with 3 hex octets - 1.3.6.1.4.1.13742.7.1.6.1.1.18
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+    - name: rackUnitID
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.1
+      type: gauge
+      help: A unique value for each rack unit - 1.3.6.1.4.1.13742.7.1.7.1.1.1
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+    - name: ledOperationMode
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.2
+      type: EnumAsStateSet
+      help: Operation mode of the LED (manual or automatic, based on tag connection).
+        - 1.3.6.1.4.1.13742.7.1.7.1.1.2
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+      enum_values:
+        1: manual
+        2: automatic
+    - name: ledMode
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.3
+      type: EnumAsStateSet
+      help: Mode of the LED (on, off, fastBlink,slowBlink) - 1.3.6.1.4.1.13742.7.1.7.1.1.3
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+      enum_values:
+        1: "on"
+        2: "off"
+        3: fastBlink
+        4: slowBlink
+    - name: ledColor
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.4
+      type: OctetString
+      help: Color of the LED (RGB) in binary format - 1.3.6.1.4.1.13742.7.1.7.1.1.4
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+    - name: ledColorStr
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.5
+      type: DisplayString
+      help: Color of the LED (RGB) in string format - 1.3.6.1.4.1.13742.7.1.7.1.1.5
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+    - name: tagID
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.6
+      type: DisplayString
+      help: Asset management tag attached to the rack unit - 1.3.6.1.4.1.13742.7.1.7.1.1.6
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+    - name: tagFamily
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.7
+      type: DisplayString
+      help: Family of the asset management tag attached to the rack unit - 1.3.6.1.4.1.13742.7.1.7.1.1.7
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+    - name: rackUnitPosition
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.8
+      type: gauge
+      help: A number associated with each rack unit - 1.3.6.1.4.1.13742.7.1.7.1.1.8
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+    - name: rackUnitType
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.9
+      type: EnumAsInfo
+      help: Type of the connected tag (single server or blade extension) - 1.3.6.1.4.1.13742.7.1.7.1.1.9
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+      enum_values:
+        1: single
+        2: blade
+        30: none
+        31: unknown
+    - name: bladeExtensionSize
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.10
+      type: gauge
+      help: In case a blade extension is connected this returns the number of slots
+        on the extension - 1.3.6.1.4.1.13742.7.1.7.1.1.10
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+    - name: assetStripCascadePosition
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.13
+      type: gauge
+      help: This is the position of the asset Strip in a cascaded chain - 1.3.6.1.4.1.13742.7.1.7.1.1.13
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+    - name: rackUnitRelativePosition
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.14
+      type: gauge
+      help: This is the relative position of the rackUnit within the assetStrip -
+        1.3.6.1.4.1.13742.7.1.7.1.1.14
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+    - name: assetStripNumberOfRackUnits
+      oid: 1.3.6.1.4.1.13742.7.1.7.1.1.15
+      type: gauge
+      help: For non-cascaded asset strips, value = rackUnitCount For cascaded asset
+        strips, it is the number of rack units in the asset Strip - 1.3.6.1.4.1.13742.7.1.7.1.1.15
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+    - name: bladeSlotID
+      oid: 1.3.6.1.4.1.13742.7.1.7.2.1.1
+      type: gauge
+      help: A unique value for each slot on a blade extension. - 1.3.6.1.4.1.13742.7.1.7.2.1.1
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      - labelname: bladeSlotID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+    - name: bladeTagID
+      oid: 1.3.6.1.4.1.13742.7.1.7.2.1.2
+      type: DisplayString
+      help: Asset management tag attached to a blade extension at the rack unit -
+        1.3.6.1.4.1.13742.7.1.7.2.1.2
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      - labelname: bladeSlotID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+    - name: bladeSlotPosition
+      oid: 1.3.6.1.4.1.13742.7.1.7.2.1.3
+      type: gauge
+      help: A number associated with each blade slot - 1.3.6.1.4.1.13742.7.1.7.2.1.3
+      indexes:
+      - labelname: assetStripID
+        type: gauge
+      - labelname: rackUnitID
+        type: gauge
+      - labelname: bladeSlotID
+        type: gauge
+      lookups:
+      - labels:
+        - assetStripID
+        labelname: assetStripName
+        oid: 1.3.6.1.4.1.13742.7.1.6.1.1.4
+        type: DisplayString
+      - labels:
+        - assetStripID
+        - rackUnitID
+        labelname: rackUnitName
+        oid: 1.3.6.1.4.1.13742.7.1.7.1.1.12
+        type: DisplayString
+  raritan_pdu2:
+    walk:
+    - 1.3.6.1.4.1.13742.6.3.2.1
+    - 1.3.6.1.4.1.13742.6.3.2.2
+    - 1.3.6.1.4.1.13742.6.3.3.3
+    - 1.3.6.1.4.1.13742.6.3.5.3
+    - 1.3.6.1.4.1.13742.6.5.1.3
+    - 1.3.6.1.4.1.13742.6.5.2.3
+    - 1.3.6.1.4.1.13742.6.5.2.4
+    - 1.3.6.1.4.1.13742.6.5.3.3
+    - 1.3.6.1.4.1.13742.6.5.4.3
+    - 1.3.6.1.4.1.13742.6.5.4.4
+    - 1.3.6.1.4.1.13742.6.5.5.3
+    - 1.3.6.1.4.1.13742.6.5.7.3
+    - 1.3.6.1.4.1.13742.6.5.8.3
+    metrics:
+    - name: pduId
+      oid: 1.3.6.1.4.1.13742.6.3.2.1.1.1
+      type: gauge
+      help: A unique value for each PDU or power meter - 1.3.6.1.4.1.13742.6.3.2.1.1.1
       indexes:
       - labelname: pduId
         type: gauge
-      - labelname: sensorID
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pduManufacturer
+      oid: 1.3.6.1.4.1.13742.6.3.2.1.1.2
+      type: DisplayString
+      help: The PDU manufacturer. - 1.3.6.1.4.1.13742.6.3.2.1.1.2
+      indexes:
+      - labelname: pduId
         type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pduModel
+      oid: 1.3.6.1.4.1.13742.6.3.2.1.1.3
+      type: DisplayString
+      help: The PDU model name. - 1.3.6.1.4.1.13742.6.3.2.1.1.3
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pduSerialNumber
+      oid: 1.3.6.1.4.1.13742.6.3.2.1.1.4
+      type: DisplayString
+      help: The PDU serial number. - 1.3.6.1.4.1.13742.6.3.2.1.1.4
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pduRatedVoltage
+      oid: 1.3.6.1.4.1.13742.6.3.2.1.1.5
+      type: DisplayString
+      help: The PDU voltage rating. - 1.3.6.1.4.1.13742.6.3.2.1.1.5
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pduRatedCurrent
+      oid: 1.3.6.1.4.1.13742.6.3.2.1.1.6
+      type: DisplayString
+      help: The PDU current rating. - 1.3.6.1.4.1.13742.6.3.2.1.1.6
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pduRatedFrequency
+      oid: 1.3.6.1.4.1.13742.6.3.2.1.1.7
+      type: DisplayString
+      help: The PDU frequency rating. - 1.3.6.1.4.1.13742.6.3.2.1.1.7
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pduRatedVA
+      oid: 1.3.6.1.4.1.13742.6.3.2.1.1.8
+      type: DisplayString
+      help: The PDU VA (VoltAmps) rating. - 1.3.6.1.4.1.13742.6.3.2.1.1.8
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pduImage
+      oid: 1.3.6.1.4.1.13742.6.3.2.1.1.9
+      type: DisplayString
+      help: The URL of the wiring diagram for this PDU. - 1.3.6.1.4.1.13742.6.3.2.1.1.9
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: inletCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.2
+      type: gauge
+      help: The number of inlets. - 1.3.6.1.4.1.13742.6.3.2.2.1.2
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: overCurrentProtectorCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.3
+      type: gauge
+      help: The number of overcurrent protectors. - 1.3.6.1.4.1.13742.6.3.2.2.1.3
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: outletCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.4
+      type: gauge
+      help: The number of outlets. - 1.3.6.1.4.1.13742.6.3.2.2.1.4
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: inletControllerCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.5
+      type: gauge
+      help: The number of inlet controllers. - 1.3.6.1.4.1.13742.6.3.2.2.1.5
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: outletControllerCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.6
+      type: gauge
+      help: The number of outlet controllers. - 1.3.6.1.4.1.13742.6.3.2.2.1.6
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: externalSensorCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.7
+      type: gauge
+      help: The maximum supported number of external sensors - 1.3.6.1.4.1.13742.6.3.2.2.1.7
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pxIPAddress
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.8
+      type: InetAddressIPv4
+      help: The current IP address - 1.3.6.1.4.1.13742.6.3.2.2.1.8
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: netmask
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.9
+      type: InetAddressIPv4
+      help: The current netmask - 1.3.6.1.4.1.13742.6.3.2.2.1.9
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: gateway
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.10
+      type: InetAddressIPv4
+      help: The current gateway - 1.3.6.1.4.1.13742.6.3.2.2.1.10
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pxMACAddress
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.11
+      type: PhysAddress48
+      help: The current MAC address - 1.3.6.1.4.1.13742.6.3.2.2.1.11
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: utcOffset
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.12
+      type: DisplayString
+      help: The current UTC offset. - 1.3.6.1.4.1.13742.6.3.2.2.1.12
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: networkInterfaceType
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.14
+      type: gauge
+      help: 'The network interface type: wired or wireless - 1.3.6.1.4.1.13742.6.3.2.2.1.14'
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        0: wired
+        1: wireless
+    - name: externalSensorsZCoordinateUnits
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.34
+      type: gauge
+      help: 'External sensor Z coordinate units: freeform text or rack units (U) Default
+        is U. - 1.3.6.1.4.1.13742.6.3.2.2.1.34'
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        0: rackUnits
+        1: text
+    - name: unitDeviceCapabilities
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.35
+      type: Bits
+      help: A bit string indicating which unit sensors are available. - 1.3.6.1.4.1.13742.6.3.2.2.1.35
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        4: activePower
+        5: apparentPower
+        7: activeEnergy
+        8: apparentEnergy
+        45: i1smpsStatus
+        46: i2smpsStatus
+    - name: outletSequencingDelay
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.36
+      type: gauge
+      help: This OID is deprecated, it is an alias for inrushGuardDelay - 1.3.6.1.4.1.13742.6.3.2.2.1.36
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: globalOutletPowerCyclingPowerOffPeriod
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.37
+      type: gauge
+      help: The power-off period when an outlet is cycled; applies to all outlets
+        unless overridden at the outlet level; specified in seconds; 1 <= value <=
+        3600 seconds. - 1.3.6.1.4.1.13742.6.3.2.2.1.37
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: globalOutletStateOnStartup
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.38
+      type: gauge
+      help: The outlet state used when powering the respective inlet; applies to all
+        outlets unless overridden at the outlet level - 1.3.6.1.4.1.13742.6.3.2.2.1.38
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        0: "off"
+        1: "on"
+        2: lastKnownState
+    - name: outletPowerupSequence
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.39
+      type: DisplayString
+      help: The sequence in which will the outlets will be switched on under the following
+        conditions - 1.3.6.1.4.1.13742.6.3.2.2.1.39
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pduPowerCyclingPowerOffPeriod
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.40
+      type: gauge
+      help: When power to the PX is cycled (either manually or because of a temporary
+        power loss), this number determines how many seconds the PX will wait before
+        it provides power to the outlets - 1.3.6.1.4.1.13742.6.3.2.2.1.40
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pduDaisychainMemberType
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.41
+      type: gauge
+      help: The role of the unit in a port forwarding USB or Ethernet cascade - 1.3.6.1.4.1.13742.6.3.2.2.1.41
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        0: standalone
+        1: primaryUnit
+        2: expansionUnit
+    - name: managedExternalSensorCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.42
+      type: gauge
+      help: The number of managed external sensors - 1.3.6.1.4.1.13742.6.3.2.2.1.42
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pxInetAddressType
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.50
+      type: gauge
+      help: The type of address format This object is deprecated in favor of ipAddressTable
+        from the IP-MIB (rfc4293). - 1.3.6.1.4.1.13742.6.3.2.2.1.50
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        0: unknown
+        1: ipv4
+        2: ipv6
+        3: ipv4z
+        4: ipv6z
+        16: dns
+    - name: pxInetIPAddress
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.51
+      type: InetAddress
+      help: The current IP address - 1.3.6.1.4.1.13742.6.3.2.2.1.51
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pxInetNetmask
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.52
+      type: OctetString
+      help: The current netmask - 1.3.6.1.4.1.13742.6.3.2.2.1.52
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: pxInetGateway
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.53
+      type: OctetString
+      help: The current gateway - 1.3.6.1.4.1.13742.6.3.2.2.1.53
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: loadShedding
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.55
+      type: gauge
+      help: Enter/Exit Load Shedding Mode - 1.3.6.1.4.1.13742.6.3.2.2.1.55
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: serverCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.56
+      type: gauge
+      help: The number of servers monitored with the server reachability feature -
+        1.3.6.1.4.1.13742.6.3.2.2.1.56
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: inrushGuardDelay
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.57
+      type: gauge
+      help: The time interval between switching on two outlets; specified in milliseconds;
+        100 <= value <= 10000 milliseconds. - 1.3.6.1.4.1.13742.6.3.2.2.1.57
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: cascadedDeviceConnected
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.58
+      type: gauge
+      help: Indicates whether another PX2 is connected using an USB cable to the USB-A
+        port of this PX2 in a cascaded configuration. - 1.3.6.1.4.1.13742.6.3.2.2.1.58
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: synchronizeWithNTPServer
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.59
+      type: gauge
+      help: Indicates whether time is synchronized with an NTP server. - 1.3.6.1.4.1.13742.6.3.2.2.1.59
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: useDHCPProvidedNTPServer
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.60
+      type: gauge
+      help: '**NOTE: This object is obsolete - 1.3.6.1.4.1.13742.6.3.2.2.1.60'
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: firstNTPServerAddressType
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.61
+      type: gauge
+      help: Represents the type of the corresponding instance of firstNTPServerAddress
+        object - 1.3.6.1.4.1.13742.6.3.2.2.1.61
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        0: unknown
+        1: ipv4
+        2: ipv6
+        3: ipv4z
+        4: ipv6z
+        16: dns
+    - name: firstNTPServerAddress
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.62
+      type: InetAddress
+      help: The address of the primary NTP server - 1.3.6.1.4.1.13742.6.3.2.2.1.62
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: secondNTPServerAddressType
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.63
+      type: gauge
+      help: Represents the type of the corresponding instance of secondNTPServerAddress
+        object - 1.3.6.1.4.1.13742.6.3.2.2.1.63
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        0: unknown
+        1: ipv4
+        2: ipv6
+        3: ipv4z
+        4: ipv6z
+        16: dns
+    - name: secondNTPServerAddress
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.64
+      type: InetAddress
+      help: The address of the second NTP server - 1.3.6.1.4.1.13742.6.3.2.2.1.64
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: wireCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.65
+      type: gauge
+      help: The number of wire objects in the PDU topology - 1.3.6.1.4.1.13742.6.3.2.2.1.65
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: transferSwitchCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.66
+      type: gauge
+      help: The number of transfer switches. - 1.3.6.1.4.1.13742.6.3.2.2.1.66
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: productType
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.67
+      type: gauge
+      help: The product type (PDU, BCM, transfer switch or power meter). - 1.3.6.1.4.1.13742.6.3.2.2.1.67
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        0: rackPdu
+        1: bcm
+        2: transferSwitch
+        3: powerMeter
+    - name: meteringControllerCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.68
+      type: gauge
+      help: The number of metering controllers. - 1.3.6.1.4.1.13742.6.3.2.2.1.68
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: relayBehaviorOnPowerLoss
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.69
+      type: gauge
+      help: The relay behavior on power loss (latching or non-latching). - 1.3.6.1.4.1.13742.6.3.2.2.1.69
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        0: nonLatching
+        1: latching
+    - name: deviceCascadeType
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.70
+      type: gauge
+      help: The type of network cascade this device is part of (none, bridging or
+        port forwarding). - 1.3.6.1.4.1.13742.6.3.2.2.1.70
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        0: bridging
+        1: portForwarding
+        2: none
+    - name: deviceCascadePosition
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.71
+      type: gauge
+      help: The position of the device in the cascade chain - 1.3.6.1.4.1.13742.6.3.2.2.1.71
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: peripheralDevicesAutoManagement
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.72
+      type: gauge
+      help: Defines whether newly-connected peripheral devices are automatically assigned
+        to an unused slot. - 1.3.6.1.4.1.13742.6.3.2.2.1.72
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: frontPanelOutletSwitching
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.73
+      type: gauge
+      help: Enables/disables switching of outlets using the PDU front panel. - 1.3.6.1.4.1.13742.6.3.2.2.1.73
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: frontPanelRCMSelfTest
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.74
+      type: gauge
+      help: Enables/disables front panel RCM self-test. - 1.3.6.1.4.1.13742.6.3.2.2.1.74
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: frontPanelActuatorControl
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.75
+      type: gauge
+      help: Enables/disables front panel peripheral actuator control. - 1.3.6.1.4.1.13742.6.3.2.2.1.75
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: circuitCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.76
+      type: gauge
+      help: The number of branch circuits in a panel. - 1.3.6.1.4.1.13742.6.3.2.2.1.76
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: activeDNSServerCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.77
+      type: gauge
+      help: The number of active DNS servers - 1.3.6.1.4.1.13742.6.3.2.2.1.77
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: activeNTPServerCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.78
+      type: gauge
+      help: The number of active NTP servers - 1.3.6.1.4.1.13742.6.3.2.2.1.78
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: peripheralDevicePackageCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.79
+      type: gauge
+      help: The number of peripheral device packages. - 1.3.6.1.4.1.13742.6.3.2.2.1.79
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: outletGroupCount
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.80
+      type: gauge
+      help: The number of configured outlet groups - 1.3.6.1.4.1.13742.6.3.2.2.1.80
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: demandUpdateInterval
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.81
+      type: gauge
+      help: The update interval (in seconds) for demand sensors (BCM2 only) - 1.3.6.1.4.1.13742.6.3.2.2.1.81
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: demandAveragingIntervals
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.82
+      type: gauge
+      help: The number of intervals for demand sensor averaging (BCM2 only) - 1.3.6.1.4.1.13742.6.3.2.2.1.82
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: hasDCInlets
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.83
+      type: gauge
+      help: True if the PDU has at least one DC inlet - 1.3.6.1.4.1.13742.6.3.2.2.1.83
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: pduOrientation
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.84
+      type: gauge
+      help: The detected PDU orientation at startup (none if orientation is not supported).
+        - 1.3.6.1.4.1.13742.6.3.2.2.1.84
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        0: none
+        1: bottomFeed
+        2: topFeed
+    - name: pduUptime
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.85
+      type: gauge
+      help: The number of seconds elapsed since the PDU booted - 1.3.6.1.4.1.13742.6.3.2.2.1.85
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: tripCauseOutletHandling
+      oid: 1.3.6.1.4.1.13742.6.3.2.2.1.86
+      type: gauge
+      help: How to handle outlets that are suspected to have caused an OCP trip event.
+        - 1.3.6.1.4.1.13742.6.3.2.2.1.86
+      indexes:
+      - labelname: pduId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        0: keepUnchanged
+        1: suspend
+    - name: inletId
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.1
+      type: gauge
+      help: A unique value for each inlet - 1.3.6.1.4.1.13742.6.3.3.3.1.1
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: inletName
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.3
+      type: DisplayString
+      help: The user-defined name. - 1.3.6.1.4.1.13742.6.3.3.3.1.3
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: inletPlug
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.4
+      type: gauge
+      help: The type of plug/receptacle wired to the inlet - 1.3.6.1.4.1.13742.6.3.3.3.1.4
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+      enum_values:
+        -1: plugOTHER
+        0: plugNONE
+        1: plug56P320
+        2: plug56P520
+        3: plug56P532
+        4: plugCS8365C
+        5: plugIEC320C14
+        6: plugIEC320C20
+        7: plugIEC603093WIRE250V16A
+        8: plugIEC603093WIRE250V20A
+        9: plugIEC603093WIRE250V30A
+        10: plugIEC603093WIRE250V32A
+        11: plugIEC603093WIRE250V60A
+        12: plugIEC603093WIRE250V63A
+        13: plugIEC603093WIRE250V100A
+        14: plugIEC603093WIRE250V125A
+        15: plugIEC603094WIRE250V20A
+        16: plugIEC603094WIRE250V30A
+        17: plugIEC603094WIRE250V60A
+        18: plugIEC603094WIRE250V100A
+        23: plugIEC603095WIRE208V20A
+        24: plugIEC603095WIRE208V30A
+        25: plugIEC603095WIRE208V60A
+        26: plugIEC603095WIRE208V100A
+        27: plugIEC603095WIRE415V16A
+        28: plugIEC603095WIRE415V32A
+        29: plugIEC603095WIRE415V63A
+        30: plugIEC603095WIRE415V125A
+        31: plugIEC603095WIRE480V20A
+        32: plugIEC603095WIRE480V30A
+        33: plugIEC603095WIRE480V60A
+        34: plugIEC603095WIRE480V100A
+        35: plugNEMA515P
+        36: plugNEMAL515P
+        37: plugNEMA520P
+        38: plugNEMAL520P
+        39: plugNEMAL530P
+        40: plugNEMAL615P
+        41: plugNEMAL620P
+        42: plugNEMAL630P
+        43: plugNEMAL1520P
+        44: plugNEMAL1530P
+        45: plugNEMAL2120P
+        46: plugNEMAL2130P
+        47: plugNEMAL2230P
+        48: plug56P320F
+        49: plug56PA320
+    - name: inletPoleCount
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.5
+      type: gauge
+      help: The number of poles - 1.3.6.1.4.1.13742.6.3.3.3.1.5
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: inletRatedVoltage
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.6
+      type: DisplayString
+      help: The inlet voltage rating. - 1.3.6.1.4.1.13742.6.3.3.3.1.6
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: inletRatedCurrent
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.7
+      type: DisplayString
+      help: The inlet current rating. - 1.3.6.1.4.1.13742.6.3.3.3.1.7
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: inletRatedFrequency
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.8
+      type: DisplayString
+      help: The inlet frequency rating - 1.3.6.1.4.1.13742.6.3.3.3.1.8
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: inletRatedVA
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.9
+      type: DisplayString
+      help: The inlet VA (VoltAmps) rating - 1.3.6.1.4.1.13742.6.3.3.3.1.9
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: inletDeviceCapabilities
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.10
+      type: Bits
+      help: A bit string indicating which inlet sensors are available. - 1.3.6.1.4.1.13742.6.3.3.3.1.10
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+      enum_values:
+        0: rmsCurrent
+        1: peakCurrent
+        2: unbalancedCurrent
+        3: rmsVoltage
+        4: activePower
+        5: apparentPower
+        6: powerFactor
+        7: activeEnergy
+        8: apparentEnergy
+        21: surgeProtectorStatus
+        22: frequency
+        23: phaseAngle
+        25: residualCurrent
+        26: rcmState
+        28: reactivePower
+        31: powerQuality
+        34: displacementPowerFactor
+        35: residualDcCurrent
+        50: crestFactor
+        53: activePowerDemand
+        54: residualAcCurrent
+        56: voltageThd
+        57: currentThd
+        59: unbalancedVoltage
+        60: unbalancedLineLineCurrent
+        61: unbalancedLineLineVoltage
+    - name: inletPoleCapabilities
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.11
+      type: Bits
+      help: A bit string indicating which inlet pole sensors are available. - 1.3.6.1.4.1.13742.6.3.3.3.1.11
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+      enum_values:
+        0: rmsCurrent
+        1: peakCurrent
+        3: rmsVoltage
+        4: activePower
+        5: apparentPower
+        6: powerFactor
+        7: activeEnergy
+        8: apparentEnergy
+        23: phaseAngle
+        24: rmsVoltageLN
+        25: residualCurrent
+        26: rcmState
+        28: reactivePower
+        34: displacementPowerFactor
+        35: residualDcCurrent
+        50: crestFactor
+        54: residualAcCurrent
+        56: voltageThd
+        57: currentThd
+    - name: inletPlugDescriptor
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.12
+      type: DisplayString
+      help: The inlet plug type as a string. - 1.3.6.1.4.1.13742.6.3.3.3.1.12
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: inletEnableState
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.13
+      type: gauge
+      help: Enable/disable PDU operation for this inlet - 1.3.6.1.4.1.13742.6.3.3.3.1.13
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: inletRCMResidualOperatingCurrent
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.14
+      type: gauge
+      help: '**NOTE:This object is obsolete - 1.3.6.1.4.1.13742.6.3.3.3.1.14'
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: inletIsDC
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.15
+      type: gauge
+      help: 'Inlet current type: true for DC, false for AC - 1.3.6.1.4.1.13742.6.3.3.3.1.15'
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: inletLinePairCount
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.16
+      type: gauge
+      help: The number of inlet line pairs. - 1.3.6.1.4.1.13742.6.3.3.3.1.16
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: inletLinePairCapabilities
+      oid: 1.3.6.1.4.1.13742.6.3.3.3.1.17
+      type: Bits
+      help: A bit string indicating which inlet line pair sensors are available. -
+        1.3.6.1.4.1.13742.6.3.3.3.1.17
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+      enum_values:
+        0: rmsCurrent
+        1: peakCurrent
+        3: rmsVoltage
+        4: activePower
+        5: apparentPower
+        6: powerFactor
+        7: activeEnergy
+        8: apparentEnergy
+        23: phaseAngle
+        28: reactivePower
+        34: displacementPowerFactor
+        50: crestFactor
+        56: voltageThd
+        57: currentThd
+    - name: outletId
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.1
+      type: gauge
+      help: A unique value for each outlet - 1.3.6.1.4.1.13742.6.3.5.3.1.1
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: outletReceptacle
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.4
+      type: gauge
+      help: The receptacle type - 1.3.6.1.4.1.13742.6.3.5.3.1.4
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        -1: receptacleOTHER
+        0: receptacleNONE
+        1: receptacleBS1363
+        3: receptacle56P532
+        4: receptacleCS8364C
+        5: receptacleIEC320C13
+        6: receptacleIEC320C19
+        7: receptacleIEC603093WIRE250V16A
+        8: receptacleIEC603093WIRE250V20A
+        9: receptacleIEC603093WIRE250V30A
+        10: receptacleIEC603093WIRE250V32A
+        11: receptacleIEC603093WIRE250V60A
+        12: receptacleIEC603093WIRE250V63A
+        13: receptacleIEC603093WIRE250V100A
+        14: receptacleIEC603093WIRE250V125A
+        15: receptacleIEC603094WIRE250V20A
+        16: receptacleIEC603094WIRE250V30A
+        17: receptacleIEC603094WIRE250V60A
+        18: receptacleIEC603094WIRE250V100A
+        23: receptacleIEC603095WIRE208V20A
+        24: receptacleIEC603095WIRE208V30A
+        25: receptacleIEC603095WIRE208V60A
+        26: receptacleIEC603095WIRE208V100A
+        27: receptacleIEC603095WIRE415V16A
+        28: receptacleIEC603095WIRE415V32A
+        29: receptacleIEC603095WIRE415V63A
+        30: receptacleIEC603095WIRE415V125A
+        31: receptacleIEC603095WIRE480V20A
+        32: receptacleIEC603095WIRE480V30A
+        33: receptacleIEC603095WIRE480V60A
+        34: receptacleIEC603095WIRE480V100A
+        35: receptacleNEMA515R
+        36: receptacleNEMAL515R
+        37: receptacleNEMA520R
+        38: receptacleNEMAL520R
+        39: receptacleNEMAL530R
+        40: receptacleNEMAL615R
+        41: receptacleNEMAL620R
+        42: receptacleNEMAL630R
+        43: receptacleNEMAL1520R
+        44: receptacleNEMAL1530R
+        45: receptacleNEMAL2120RP
+        46: receptacleNEMAL2130R
+        47: receptacleSCHUKOTYPEE
+        48: receptacleSCHUKOTYPEF
+    - name: outletPoleCount
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.5
+      type: gauge
+      help: The number of poles. - 1.3.6.1.4.1.13742.6.3.5.3.1.5
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: outletRatedVoltage
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.6
+      type: DisplayString
+      help: The outlet voltage rating. - 1.3.6.1.4.1.13742.6.3.5.3.1.6
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: outletRatedCurrent
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.7
+      type: DisplayString
+      help: The outlet current rating. - 1.3.6.1.4.1.13742.6.3.5.3.1.7
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: outletRatedVA
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.8
+      type: DisplayString
+      help: The outlet VA (VoltAmps) rating. - 1.3.6.1.4.1.13742.6.3.5.3.1.8
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: outletDeviceCapabilities
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.10
+      type: Bits
+      help: A bit string indicating which outlet sensors are available. - 1.3.6.1.4.1.13742.6.3.5.3.1.10
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        0: rmsCurrent
+        1: peakCurrent
+        2: unbalancedCurrent
+        3: rmsVoltage
+        4: activePower
+        5: apparentPower
+        6: powerFactor
+        7: activeEnergy
+        8: apparentEnergy
+        13: onOff
+        22: frequency
+        23: phaseAngle
+        28: reactivePower
+        34: displacementPowerFactor
+        50: crestFactor
+        56: voltageThd
+        57: currentThd
+        58: inrushCurrent
+    - name: outletPoleCapabilities
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.11
+      type: Bits
+      help: A bit string indicating which outlet pole sensors are available. - 1.3.6.1.4.1.13742.6.3.5.3.1.11
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        0: rmsCurrent
+        1: peakCurrent
+        3: rmsVoltage
+        4: activePower
+        5: apparentPower
+        6: powerFactor
+        7: activeEnergy
+        8: apparentEnergy
+        23: phaseAngle
+        24: rmsVoltageLN
+        28: reactivePower
+        34: displacementPowerFactor
+        50: crestFactor
+        56: voltageThd
+        57: currentThd
+    - name: outletPowerCyclingPowerOffPeriod
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.12
+      type: gauge
+      help: The power-off period when an outlet is cycled - 1.3.6.1.4.1.13742.6.3.5.3.1.12
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: outletStateOnStartup
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.13
+      type: gauge
+      help: The outlet state when powering the respective inlet - 1.3.6.1.4.1.13742.6.3.5.3.1.13
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        0: "off"
+        1: "on"
+        2: lastKnownState
+        3: globalOutletStateOnStartup
+    - name: outletUseGlobalPowerCyclingPowerOffPeriod
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.14
+      type: gauge
+      help: 'Indicates which power-off period to use when the outlet is cycled: -
+        true: use globalOutletPowerCyclingPowerOffPeriod - false: use outletPowerCyclingPowerOffPeriod
+        - 1.3.6.1.4.1.13742.6.3.5.3.1.14'
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: outletSwitchable
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.28
+      type: gauge
+      help: Is this outlet switchable? - 1.3.6.1.4.1.13742.6.3.5.3.1.28
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: outletReceptacleDescriptor
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.29
+      type: DisplayString
+      help: The outlet receptacle type as a string. - 1.3.6.1.4.1.13742.6.3.5.3.1.29
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: outletNonCritical
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.30
+      type: gauge
+      help: Is this outlet non-critical? Non-critical outlets will be switched off
+        when load shedding is enabled. - 1.3.6.1.4.1.13742.6.3.5.3.1.30
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: outletSequenceDelay
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.32
+      type: gauge
+      help: The time interval between switching on this outlet and the next outlet
+        in the outlet sequence - 1.3.6.1.4.1.13742.6.3.5.3.1.32
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: outletPowerSource
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.33
+      type: OctetString
+      help: This object allows discovery of how the PDU is wired - 1.3.6.1.4.1.13742.6.3.5.3.1.33
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: outletServiceMode
+      oid: 1.3.6.1.4.1.13742.6.3.5.3.1.34
+      type: gauge
+      help: Whether the outlet is currently in service mode - 1.3.6.1.4.1.13742.6.3.5.3.1.34
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsUnitSensorIsAvailable
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.2
+      type: gauge
+      help: The sensor is present. - 1.3.6.1.4.1.13742.6.5.1.3.1.2
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsUnitSensorState
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.3
+      type: EnumAsStateSet
+      help: The sensor state. - 1.3.6.1.4.1.13742.6.5.1.3.1.3
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
       enum_values:
         -1: unavailable
         0: open
@@ -37558,6 +40357,8746 @@ modules:
         28: critical
         29: selfTest
         30: nonRedundant
+        31: inactive
+        32: i1Selected
+        33: i2Selected
+        34: i1SelectedAndActive
+        35: i2SelectedAndActive
+        36: bypassActive
+        37: i1Active
+        38: i2Active
+        39: bypassSelectedButInactive
+    - name: measurementsUnitSensorValue
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.4
+      type: gauge
+      help: The sensor reading as an unsigned integer - 1.3.6.1.4.1.13742.6.5.1.3.1.4
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsUnitSensorTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.5
+      type: gauge
+      help: The timestamp for reading. - 1.3.6.1.4.1.13742.6.5.1.3.1.5
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsUnitSensorSignedValue
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.6
+      type: gauge
+      help: The sensor reading as a signed integer - 1.3.6.1.4.1.13742.6.5.1.3.1.6
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsUnitSensorMinMaxValid
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.7
+      type: gauge
+      help: The minimum and maximum values of sensor reading and their timestamps
+        provided as measurementsUnitSensor[Signed]{Min|Max}{Value|TimeStamp} are valid
+        - 1.3.6.1.4.1.13742.6.5.1.3.1.7
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsUnitSensorMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.8
+      type: gauge
+      help: The minimum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by unitSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.1.3.1.8
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsUnitSensorSignedMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.9
+      type: gauge
+      help: The minimum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by unitSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.1.3.1.9
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsUnitSensorMinTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.10
+      type: gauge
+      help: The timestamp of last change of the minimum value of sensor reading provided
+        as measurementUnitSensor[Signed]MinValue - 1.3.6.1.4.1.13742.6.5.1.3.1.10
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsUnitSensorMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.11
+      type: gauge
+      help: The maximum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by unitSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.1.3.1.11
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsUnitSensorSignedMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.12
+      type: gauge
+      help: The maximum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by unitSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.1.3.1.12
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsUnitSensorMaxTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.13
+      type: gauge
+      help: The timestamp of last change of the maximum value of sensor reading provided
+        as measurementUnitSensor[Signed]MaxValue - 1.3.6.1.4.1.13742.6.5.1.3.1.13
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsUnitSensorMinMaxResetTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.14
+      type: gauge
+      help: The timestamp of last reset of all minimum and maximum values of sensor
+        reading including their timestamps, provided as measurementsUnitSensor[Signed]{Min|Max}{Value|TimeStamp}
+        and measurementsUnitSensorMinMaxValid - 1.3.6.1.4.1.13742.6.5.1.3.1.14
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsUnitSensorResetTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.1.3.1.15
+      type: gauge
+      help: The timestamp indicating when the sensor value was last reset - 1.3.6.1.4.1.13742.6.5.1.3.1.15
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsInletSensorIsAvailable
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.2
+      type: gauge
+      help: The sensor is present. - 1.3.6.1.4.1.13742.6.5.2.3.1.2
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsInletSensorState
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.3
+      type: EnumAsStateSet
+      help: The sensor state. - 1.3.6.1.4.1.13742.6.5.2.3.1.3
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+      enum_values:
+        -1: unavailable
+        0: open
+        1: closed
+        2: belowLowerCritical
+        3: belowLowerWarning
+        4: normal
+        5: aboveUpperWarning
+        6: aboveUpperCritical
+        7: "on"
+        8: "off"
+        9: detected
+        10: notDetected
+        11: alarmed
+        12: ok
+        14: fail
+        15: "yes"
+        16: "no"
+        17: standby
+        18: one
+        19: two
+        20: inSync
+        21: outOfSync
+        22: i1OpenFault
+        23: i1ShortFault
+        24: i2OpenFault
+        25: i2ShortFault
+        26: fault
+        27: warning
+        28: critical
+        29: selfTest
+        30: nonRedundant
+        31: inactive
+        32: i1Selected
+        33: i2Selected
+        34: i1SelectedAndActive
+        35: i2SelectedAndActive
+        36: bypassActive
+        37: i1Active
+        38: i2Active
+        39: bypassSelectedButInactive
+    - name: measurementsInletSensorValue
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.4
+      type: gauge
+      help: The sensor reading as an unsigned integer - 1.3.6.1.4.1.13742.6.5.2.3.1.4
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletSensorTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.5
+      type: gauge
+      help: The timestamp for reading. - 1.3.6.1.4.1.13742.6.5.2.3.1.5
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletSensorSignedValue
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.6
+      type: gauge
+      help: The sensor reading as a signed integer - 1.3.6.1.4.1.13742.6.5.2.3.1.6
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletSensorMinMaxValid
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.7
+      type: gauge
+      help: The minimum and maximum values of sensor reading and their timestamps
+        provided as measurementsInletSensor[Signed]{Min|Max}{Value|TimeStamp} are
+        valid - 1.3.6.1.4.1.13742.6.5.2.3.1.7
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsInletSensorMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.8
+      type: gauge
+      help: The minimum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by inletSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.2.3.1.8
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletSensorSignedMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.9
+      type: gauge
+      help: The minimum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by inletSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.2.3.1.9
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletSensorMinTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.10
+      type: gauge
+      help: The timestamp of last change of the minimum value of sensor reading provided
+        as measurementInletSensor[Signed]MinValue - 1.3.6.1.4.1.13742.6.5.2.3.1.10
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletSensorMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.11
+      type: gauge
+      help: The maximum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by inletSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.2.3.1.11
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletSensorSignedMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.12
+      type: gauge
+      help: The maximum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by inletSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.2.3.1.12
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletSensorMaxTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.13
+      type: gauge
+      help: The timestamp of last change of the maximum value of sensor reading provided
+        as measurementInletSensor[Signed]MaxValue - 1.3.6.1.4.1.13742.6.5.2.3.1.13
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletSensorMinMaxResetTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.14
+      type: gauge
+      help: The timestamp of last reset of all minimum and maximum values of sensor
+        reading including their timestamps, provided as measurementsInletSensor[Signed]{Min|Max}{Value|TimeStamp}
+        and measurementsInletSensorMinMaxValid - 1.3.6.1.4.1.13742.6.5.2.3.1.14
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletSensorResetTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.2.3.1.15
+      type: gauge
+      help: The timestamp indicating when the sensor value was last reset - 1.3.6.1.4.1.13742.6.5.2.3.1.15
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletPoleSensorIsAvailable
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.2
+      type: gauge
+      help: The sensor is present. - 1.3.6.1.4.1.13742.6.5.2.4.1.2
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsInletPoleSensorState
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.3
+      type: gauge
+      help: The sensor state. - 1.3.6.1.4.1.13742.6.5.2.4.1.3
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+      enum_values:
+        -1: unavailable
+        0: open
+        1: closed
+        2: belowLowerCritical
+        3: belowLowerWarning
+        4: normal
+        5: aboveUpperWarning
+        6: aboveUpperCritical
+        7: "on"
+        8: "off"
+        9: detected
+        10: notDetected
+        11: alarmed
+        12: ok
+        14: fail
+        15: "yes"
+        16: "no"
+        17: standby
+        18: one
+        19: two
+        20: inSync
+        21: outOfSync
+        22: i1OpenFault
+        23: i1ShortFault
+        24: i2OpenFault
+        25: i2ShortFault
+        26: fault
+        27: warning
+        28: critical
+        29: selfTest
+        30: nonRedundant
+        31: inactive
+        32: i1Selected
+        33: i2Selected
+        34: i1SelectedAndActive
+        35: i2SelectedAndActive
+        36: bypassActive
+        37: i1Active
+        38: i2Active
+        39: bypassSelectedButInactive
+    - name: measurementsInletPoleSensorValue
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.4
+      type: gauge
+      help: The sensor reading as an unsigned integer - 1.3.6.1.4.1.13742.6.5.2.4.1.4
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletPoleSensorTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.5
+      type: gauge
+      help: The timestamp for reading. - 1.3.6.1.4.1.13742.6.5.2.4.1.5
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletPoleSensorSignedValue
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.6
+      type: gauge
+      help: The sensor reading as a signed integer - 1.3.6.1.4.1.13742.6.5.2.4.1.6
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletPoleSensorMinMaxValid
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.7
+      type: gauge
+      help: The minimum and maximum values of sensor reading and their timestamps
+        provided as measurementsInletPoleSensor[Signed]{Min|Max}{Value|TimeStamp}
+        are valid - 1.3.6.1.4.1.13742.6.5.2.4.1.7
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsInletPoleSensorMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.8
+      type: gauge
+      help: The minimum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by inletPoleSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.2.4.1.8
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletPoleSensorSignedMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.9
+      type: gauge
+      help: The minimum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by inletPoleSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.2.4.1.9
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletPoleSensorMinTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.10
+      type: gauge
+      help: The timestamp of last change of the minimum value of sensor reading provided
+        as measurementInletPoleSensor[Signed]MinValue - 1.3.6.1.4.1.13742.6.5.2.4.1.10
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletPoleSensorMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.11
+      type: gauge
+      help: The maximum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by inletPoleSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.2.4.1.11
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletPoleSensorSignedMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.12
+      type: gauge
+      help: The maximum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by inletPoleSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.2.4.1.12
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletPoleSensorMaxTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.13
+      type: gauge
+      help: The timestamp of last change of the maximum value of sensor reading provided
+        as measurementInletPoleSensor[Signed]MaxValue - 1.3.6.1.4.1.13742.6.5.2.4.1.13
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsInletPoleSensorMinMaxResetTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.2.4.1.14
+      type: gauge
+      help: The timestamp of last reset of all minimum and maximum values of sensor
+        reading including their timestamps, provided as measurementsInletPoleSensor[Signed]{Min|Max}{Value|TimeStamp}
+        and measurementsInletPoleSensorMinMaxValid - 1.3.6.1.4.1.13742.6.5.2.4.1.14
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: inletId
+        type: gauge
+      - labelname: inletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - inletId
+        labelname: inletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.3.3.1.2
+        type: DisplayString
+    - name: measurementsOverCurrentProtectorSensorIsAvailable
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.2
+      type: gauge
+      help: The sensor is present. - 1.3.6.1.4.1.13742.6.5.3.3.1.2
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsOverCurrentProtectorSensorState
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.3
+      type: EnumAsStateSet
+      help: The sensor state. - 1.3.6.1.4.1.13742.6.5.3.3.1.3
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        -1: unavailable
+        0: open
+        1: closed
+        2: belowLowerCritical
+        3: belowLowerWarning
+        4: normal
+        5: aboveUpperWarning
+        6: aboveUpperCritical
+        7: "on"
+        8: "off"
+        9: detected
+        10: notDetected
+        11: alarmed
+        12: ok
+        14: fail
+        15: "yes"
+        16: "no"
+        17: standby
+        18: one
+        19: two
+        20: inSync
+        21: outOfSync
+        22: i1OpenFault
+        23: i1ShortFault
+        24: i2OpenFault
+        25: i2ShortFault
+        26: fault
+        27: warning
+        28: critical
+        29: selfTest
+        30: nonRedundant
+        31: inactive
+        32: i1Selected
+        33: i2Selected
+        34: i1SelectedAndActive
+        35: i2SelectedAndActive
+        36: bypassActive
+        37: i1Active
+        38: i2Active
+        39: bypassSelectedButInactive
+    - name: measurementsOverCurrentProtectorSensorValue
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.4
+      type: gauge
+      help: The sensor reading as an unsigned integer - 1.3.6.1.4.1.13742.6.5.3.3.1.4
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsOverCurrentProtectorSensorTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.5
+      type: gauge
+      help: The timestamp for reading. - 1.3.6.1.4.1.13742.6.5.3.3.1.5
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsOverCurrentProtectorSensorSignedValue
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.6
+      type: gauge
+      help: The sensor reading as a signed integer - 1.3.6.1.4.1.13742.6.5.3.3.1.6
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsOverCurrentProtectorSensorMinMaxValid
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.7
+      type: gauge
+      help: The minimum and maximum values of sensor reading and their timestamps
+        provided as measurementsOverCurrentProtectorSensor[Signed]{Min|Max}{Value|TimeStamp}
+        are valid - 1.3.6.1.4.1.13742.6.5.3.3.1.7
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsOverCurrentProtectorSensorMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.8
+      type: gauge
+      help: The minimum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by overCurrentProtectorSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.3.3.1.8
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsOverCurrentProtectorSensorSignedMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.9
+      type: gauge
+      help: The minimum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by overCurrentProtectorSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.3.3.1.9
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsOverCurrentProtectorSensorMinTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.10
+      type: gauge
+      help: The timestamp of last change of the minimum value of sensor reading provided
+        as measurementOverCurrentProtectorSensor[Signed]MinValue - 1.3.6.1.4.1.13742.6.5.3.3.1.10
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsOverCurrentProtectorSensorMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.11
+      type: gauge
+      help: The maximum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by overCurrentProtectorSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.3.3.1.11
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsOverCurrentProtectorSensorSignedMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.12
+      type: gauge
+      help: The maximum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by overCurrentProtectorSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.3.3.1.12
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsOverCurrentProtectorSensorMaxTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.13
+      type: gauge
+      help: The timestamp of last change of the maximum value of sensor reading provided
+        as measurementOverCurrentProtectorSensor[Signed]MaxValue - 1.3.6.1.4.1.13742.6.5.3.3.1.13
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsOverCurrentProtectorSensorMinMaxResetTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.3.3.1.14
+      type: gauge
+      help: The timestamp of last reset of all minimum and maximum values of sensor
+        reading including their timestamps, provided as measurementsOverCurrentProtectorSensor[Signed]{Min|Max}{Value|TimeStamp}
+        and measurementsOverCurrentProtectorSensorMinMaxValid - 1.3.6.1.4.1.13742.6.5.3.3.1.14
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: overCurrentProtectorIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsOutletSensorIsAvailable
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.2
+      type: gauge
+      help: The sensor is present. - 1.3.6.1.4.1.13742.6.5.4.3.1.2
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsOutletSensorState
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.3
+      type: EnumAsStateSet
+      help: The sensor state. - 1.3.6.1.4.1.13742.6.5.4.3.1.3
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        -1: unavailable
+        0: open
+        1: closed
+        2: belowLowerCritical
+        3: belowLowerWarning
+        4: normal
+        5: aboveUpperWarning
+        6: aboveUpperCritical
+        7: "on"
+        8: "off"
+        9: detected
+        10: notDetected
+        11: alarmed
+        12: ok
+        14: fail
+        15: "yes"
+        16: "no"
+        17: standby
+        18: one
+        19: two
+        20: inSync
+        21: outOfSync
+        22: i1OpenFault
+        23: i1ShortFault
+        24: i2OpenFault
+        25: i2ShortFault
+        26: fault
+        27: warning
+        28: critical
+        29: selfTest
+        30: nonRedundant
+        31: inactive
+        32: i1Selected
+        33: i2Selected
+        34: i1SelectedAndActive
+        35: i2SelectedAndActive
+        36: bypassActive
+        37: i1Active
+        38: i2Active
+        39: bypassSelectedButInactive
+    - name: measurementsOutletSensorValue
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.4
+      type: gauge
+      help: The sensor reading as an unsigned integer - 1.3.6.1.4.1.13742.6.5.4.3.1.4
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletSensorTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.5
+      type: gauge
+      help: The timestamp for reading. - 1.3.6.1.4.1.13742.6.5.4.3.1.5
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletSensorSignedValue
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.6
+      type: gauge
+      help: The sensor reading as a signed integer - 1.3.6.1.4.1.13742.6.5.4.3.1.6
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletSensorMinMaxValid
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.7
+      type: gauge
+      help: The minimum and maximum values of sensor reading and their timestamps
+        provided as measurementsOutletSensor[Signed]{Min|Max}{Value|TimeStamp} are
+        valid - 1.3.6.1.4.1.13742.6.5.4.3.1.7
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsOutletSensorMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.8
+      type: gauge
+      help: The minimum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by outletSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.4.3.1.8
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletSensorSignedMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.9
+      type: gauge
+      help: The minimum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by outletSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.4.3.1.9
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletSensorMinTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.10
+      type: gauge
+      help: The timestamp of last change of the minimum value of sensor reading provided
+        as measurementOutletSensor[Signed]MinValue - 1.3.6.1.4.1.13742.6.5.4.3.1.10
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletSensorMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.11
+      type: gauge
+      help: The maximum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by outletSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.4.3.1.11
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletSensorSignedMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.12
+      type: gauge
+      help: The maximum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by outletSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.4.3.1.12
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletSensorMaxTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.13
+      type: gauge
+      help: The timestamp of last change of the maximum value of sensor reading provided
+        as measurementOutletSensor[Signed]MaxValue - 1.3.6.1.4.1.13742.6.5.4.3.1.13
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletSensorMinMaxResetTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.14
+      type: gauge
+      help: The timestamp of last reset of all minimum and maximum values of sensor
+        reading including their timestamps, provided as measurementsOutletSensor[Signed]{Min|Max}{Value|TimeStamp}
+        and measurementsOutletSensorMinMaxValid - 1.3.6.1.4.1.13742.6.5.4.3.1.14
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletSensorResetTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.4.3.1.15
+      type: gauge
+      help: The timestamp indicating when the sensor value was last reset - 1.3.6.1.4.1.13742.6.5.4.3.1.15
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletPoleSensorIsAvailable
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.2
+      type: gauge
+      help: The sensor is present. - 1.3.6.1.4.1.13742.6.5.4.4.1.2
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsOutletPoleSensorState
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.3
+      type: gauge
+      help: The sensor state. - 1.3.6.1.4.1.13742.6.5.4.4.1.3
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        -1: unavailable
+        0: open
+        1: closed
+        2: belowLowerCritical
+        3: belowLowerWarning
+        4: normal
+        5: aboveUpperWarning
+        6: aboveUpperCritical
+        7: "on"
+        8: "off"
+        9: detected
+        10: notDetected
+        11: alarmed
+        12: ok
+        14: fail
+        15: "yes"
+        16: "no"
+        17: standby
+        18: one
+        19: two
+        20: inSync
+        21: outOfSync
+        22: i1OpenFault
+        23: i1ShortFault
+        24: i2OpenFault
+        25: i2ShortFault
+        26: fault
+        27: warning
+        28: critical
+        29: selfTest
+        30: nonRedundant
+        31: inactive
+        32: i1Selected
+        33: i2Selected
+        34: i1SelectedAndActive
+        35: i2SelectedAndActive
+        36: bypassActive
+        37: i1Active
+        38: i2Active
+        39: bypassSelectedButInactive
+    - name: measurementsOutletPoleSensorValue
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.4
+      type: gauge
+      help: The sensor reading as an unsigned integer - 1.3.6.1.4.1.13742.6.5.4.4.1.4
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletPoleSensorTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.5
+      type: gauge
+      help: The timestamp for reading. - 1.3.6.1.4.1.13742.6.5.4.4.1.5
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletPoleSensorSignedValue
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.6
+      type: gauge
+      help: The sensor reading as a signed integer - 1.3.6.1.4.1.13742.6.5.4.4.1.6
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletPoleSensorMinMaxValid
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.7
+      type: gauge
+      help: The minimum and maximum values of sensor reading and their timestamps
+        provided as measurementsOutletPoleSensor[Signed]{Min|Max}{Value|TimeStamp}
+        are valid - 1.3.6.1.4.1.13742.6.5.4.4.1.7
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsOutletPoleSensorMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.8
+      type: gauge
+      help: The minimum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by outletPoleSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.4.4.1.8
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletPoleSensorSignedMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.9
+      type: gauge
+      help: The minimum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by outletPoleSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.4.4.1.9
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletPoleSensorMinTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.10
+      type: gauge
+      help: The timestamp of last change of the minimum value of sensor reading provided
+        as measurementOutletPoleSensor[Signed]MinValue - 1.3.6.1.4.1.13742.6.5.4.4.1.10
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletPoleSensorMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.11
+      type: gauge
+      help: The maximum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by outletPoleSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.4.4.1.11
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletPoleSensorSignedMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.12
+      type: gauge
+      help: The maximum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by outletPoleSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.4.4.1.12
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletPoleSensorMaxTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.13
+      type: gauge
+      help: The timestamp of last change of the maximum value of sensor reading provided
+        as measurementOutletPoleSensor[Signed]MaxValue - 1.3.6.1.4.1.13742.6.5.4.4.1.13
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsOutletPoleSensorMinMaxResetTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.4.4.1.14
+      type: gauge
+      help: The timestamp of last reset of all minimum and maximum values of sensor
+        reading including their timestamps, provided as measurementsOutletPoleSensor[Signed]{Min|Max}{Value|TimeStamp}
+        and measurementsOutletPoleSensorMinMaxValid - 1.3.6.1.4.1.13742.6.5.4.4.1.14
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: outletId
+        type: gauge
+      - labelname: outletPoleIndex
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletLabel
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.2
+        type: DisplayString
+      - labels:
+        - pduId
+        - outletId
+        labelname: outletName
+        oid: 1.3.6.1.4.1.13742.6.3.5.3.1.3
+        type: DisplayString
+    - name: measurementsExternalSensorIsAvailable
+      oid: 1.3.6.1.4.1.13742.6.5.5.3.1.2
+      type: gauge
+      help: The sensor is present. - 1.3.6.1.4.1.13742.6.5.5.3.1.2
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorID
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsExternalSensorState
+      oid: 1.3.6.1.4.1.13742.6.5.5.3.1.3
+      type: EnumAsStateSet
+      help: The sensor state. - 1.3.6.1.4.1.13742.6.5.5.3.1.3
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: sensorID
+        type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        -1: unavailable
+        0: open
+        1: closed
+        2: belowLowerCritical
+        3: belowLowerWarning
+        4: normal
+        5: aboveUpperWarning
+        6: aboveUpperCritical
+        7: "on"
+        8: "off"
+        9: detected
+        10: notDetected
+        11: alarmed
+        12: ok
+        14: fail
+        15: "yes"
+        16: "no"
+        17: standby
+        18: one
+        19: two
+        20: inSync
+        21: outOfSync
+        22: i1OpenFault
+        23: i1ShortFault
+        24: i2OpenFault
+        25: i2ShortFault
+        26: fault
+        27: warning
+        28: critical
+        29: selfTest
+        30: nonRedundant
+        31: inactive
+        32: i1Selected
+        33: i2Selected
+        34: i1SelectedAndActive
+        35: i2SelectedAndActive
+        36: bypassActive
+        37: i1Active
+        38: i2Active
+        39: bypassSelectedButInactive
     - name: measurementsExternalSensorValue
       oid: 1.3.6.1.4.1.13742.6.5.5.3.1.4
       type: gauge
@@ -37567,6 +49106,12 @@ modules:
         type: gauge
       - labelname: sensorID
         type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
     - name: measurementsExternalSensorTimeStamp
       oid: 1.3.6.1.4.1.13742.6.5.5.3.1.5
       type: gauge
@@ -37576,6 +49121,12 @@ modules:
         type: gauge
       - labelname: sensorID
         type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
     - name: measurementsExternalSensorMinMaxValid
       oid: 1.3.6.1.4.1.13742.6.5.5.3.1.7
       type: gauge
@@ -37587,6 +49138,12 @@ modules:
         type: gauge
       - labelname: sensorID
         type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
       enum_values:
         1: "true"
         2: "false"
@@ -37601,6 +49158,12 @@ modules:
         type: gauge
       - labelname: sensorID
         type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
     - name: measurementsExternalSensorMinTimeStamp
       oid: 1.3.6.1.4.1.13742.6.5.5.3.1.10
       type: gauge
@@ -37611,6 +49174,12 @@ modules:
         type: gauge
       - labelname: sensorID
         type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
     - name: measurementsExternalSensorMaxValue
       oid: 1.3.6.1.4.1.13742.6.5.5.3.1.11
       type: gauge
@@ -37622,6 +49191,12 @@ modules:
         type: gauge
       - labelname: sensorID
         type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
     - name: measurementsExternalSensorMaxTimeStamp
       oid: 1.3.6.1.4.1.13742.6.5.5.3.1.13
       type: gauge
@@ -37632,6 +49207,12 @@ modules:
         type: gauge
       - labelname: sensorID
         type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
     - name: measurementsExternalSensorMinMaxResetTimeStamp
       oid: 1.3.6.1.4.1.13742.6.5.5.3.1.14
       type: gauge
@@ -37643,6 +49224,2807 @@ modules:
         type: gauge
       - labelname: sensorID
         type: gauge
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsTransferSwitchSensorIsAvailable
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.2
+      type: gauge
+      help: The sensor is present. - 1.3.6.1.4.1.13742.6.5.7.3.1.2
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsTransferSwitchSensorState
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.3
+      type: EnumAsStateSet
+      help: The sensor state. - 1.3.6.1.4.1.13742.6.5.7.3.1.3
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        -1: unavailable
+        0: open
+        1: closed
+        2: belowLowerCritical
+        3: belowLowerWarning
+        4: normal
+        5: aboveUpperWarning
+        6: aboveUpperCritical
+        7: "on"
+        8: "off"
+        9: detected
+        10: notDetected
+        11: alarmed
+        12: ok
+        14: fail
+        15: "yes"
+        16: "no"
+        17: standby
+        18: one
+        19: two
+        20: inSync
+        21: outOfSync
+        22: i1OpenFault
+        23: i1ShortFault
+        24: i2OpenFault
+        25: i2ShortFault
+        26: fault
+        27: warning
+        28: critical
+        29: selfTest
+        30: nonRedundant
+        31: inactive
+        32: i1Selected
+        33: i2Selected
+        34: i1SelectedAndActive
+        35: i2SelectedAndActive
+        36: bypassActive
+        37: i1Active
+        38: i2Active
+        39: bypassSelectedButInactive
+    - name: measurementsTransferSwitchSensorValue
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.4
+      type: gauge
+      help: The sensor reading as an unsigned integer - 1.3.6.1.4.1.13742.6.5.7.3.1.4
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsTransferSwitchSensorTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.5
+      type: gauge
+      help: The timestamp for reading. - 1.3.6.1.4.1.13742.6.5.7.3.1.5
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsTransferSwitchSensorSignedValue
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.6
+      type: gauge
+      help: The sensor reading as a signed integer - 1.3.6.1.4.1.13742.6.5.7.3.1.6
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsTransferSwitchSensorMinMaxValid
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.7
+      type: gauge
+      help: The minimum and maximum values of sensor reading and their timestamps
+        provided as measurementsTransferSwitchSensor[Signed]{Min|Max}{Value|TimeStamp}
+        are valid - 1.3.6.1.4.1.13742.6.5.7.3.1.7
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsTransferSwitchSensorMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.8
+      type: gauge
+      help: The minimum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by transferSwitchSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.7.3.1.8
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsTransferSwitchSensorSignedMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.9
+      type: gauge
+      help: The minimum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by transferSwitchSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.7.3.1.9
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsTransferSwitchSensorMinTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.10
+      type: gauge
+      help: The timestamp of last change of the minimum value of sensor reading provided
+        as measurementTransferSwitchSensor[Signed]MinValue - 1.3.6.1.4.1.13742.6.5.7.3.1.10
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsTransferSwitchSensorMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.11
+      type: gauge
+      help: The maximum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by transferSwitchSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.7.3.1.11
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsTransferSwitchSensorSignedMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.12
+      type: gauge
+      help: The maximum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by transferSwitchSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.7.3.1.12
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsTransferSwitchSensorMaxTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.13
+      type: gauge
+      help: The timestamp of last change of the maximum value of sensor reading provided
+        as measurementTransferSwitchSensor[Signed]MaxValue - 1.3.6.1.4.1.13742.6.5.7.3.1.13
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsTransferSwitchSensorMinMaxResetTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.7.3.1.14
+      type: gauge
+      help: The timestamp of last reset of all minimum and maximum values of sensor
+        reading including their timestamps, provided as measurementsTransferSwitchSensor[Signed]{Min|Max}{Value|TimeStamp}
+        and measurementsTransferSwitchSensorMinMaxValid - 1.3.6.1.4.1.13742.6.5.7.3.1.14
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: transferSwitchId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsCircuitSensorIsAvailable
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.2
+      type: gauge
+      help: The sensor is present. - 1.3.6.1.4.1.13742.6.5.8.3.1.2
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsCircuitSensorState
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.3
+      type: EnumAsStateSet
+      help: The sensor state. - 1.3.6.1.4.1.13742.6.5.8.3.1.3
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        -1: unavailable
+        0: open
+        1: closed
+        2: belowLowerCritical
+        3: belowLowerWarning
+        4: normal
+        5: aboveUpperWarning
+        6: aboveUpperCritical
+        7: "on"
+        8: "off"
+        9: detected
+        10: notDetected
+        11: alarmed
+        12: ok
+        14: fail
+        15: "yes"
+        16: "no"
+        17: standby
+        18: one
+        19: two
+        20: inSync
+        21: outOfSync
+        22: i1OpenFault
+        23: i1ShortFault
+        24: i2OpenFault
+        25: i2ShortFault
+        26: fault
+        27: warning
+        28: critical
+        29: selfTest
+        30: nonRedundant
+        31: inactive
+        32: i1Selected
+        33: i2Selected
+        34: i1SelectedAndActive
+        35: i2SelectedAndActive
+        36: bypassActive
+        37: i1Active
+        38: i2Active
+        39: bypassSelectedButInactive
+    - name: measurementsCircuitSensorValue
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.4
+      type: gauge
+      help: The sensor reading as an unsigned integer - 1.3.6.1.4.1.13742.6.5.8.3.1.4
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsCircuitSensorTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.5
+      type: gauge
+      help: The timestamp for reading. - 1.3.6.1.4.1.13742.6.5.8.3.1.5
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsCircuitSensorSignedValue
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.6
+      type: gauge
+      help: The sensor reading as a signed integer - 1.3.6.1.4.1.13742.6.5.8.3.1.6
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsCircuitSensorMinMaxValid
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.7
+      type: gauge
+      help: The minimum and maximum values of sensor reading and their timestamps
+        provided as measurementsCircuitSensor[Signed]{Min|Max}{Value|TimeStamp} are
+        valid - 1.3.6.1.4.1.13742.6.5.8.3.1.7
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+      enum_values:
+        1: "true"
+        2: "false"
+    - name: measurementsCircuitSensorMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.8
+      type: gauge
+      help: The minimum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by circuitSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.8.3.1.8
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsCircuitSensorSignedMinValue
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.9
+      type: gauge
+      help: The minimum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by circuitSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.8.3.1.9
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsCircuitSensorMinTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.10
+      type: gauge
+      help: The timestamp of last change of the minimum value of sensor reading provided
+        as measurementCircuitSensor[Signed]MinValue - 1.3.6.1.4.1.13742.6.5.8.3.1.10
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsCircuitSensorMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.11
+      type: gauge
+      help: The maximum value of sensor reading since last reset as an unsigned integer
+        The value of this OID variable should be scaled by circuitSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.8.3.1.11
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsCircuitSensorSignedMaxValue
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.12
+      type: gauge
+      help: The maximum value of sensor reading since last reset as a signed integer
+        The value of this OID variable should be scaled by circuitSensorDecimalDigits
+        - 1.3.6.1.4.1.13742.6.5.8.3.1.12
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsCircuitSensorMaxTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.13
+      type: gauge
+      help: The timestamp of last change of the maximum value of sensor reading provided
+        as measurementCircuitSensor[Signed]MaxValue - 1.3.6.1.4.1.13742.6.5.8.3.1.13
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsCircuitSensorMinMaxResetTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.14
+      type: gauge
+      help: The timestamp of last reset of all minimum and maximum values of sensor
+        reading including their timestamps, provided as measurementsCircuitSensor[Signed]{Min|Max}{Value|TimeStamp}
+        and measurementsCircuitSensorMinMaxValid - 1.3.6.1.4.1.13742.6.5.8.3.1.14
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
+    - name: measurementsCircuitSensorResetTimeStamp
+      oid: 1.3.6.1.4.1.13742.6.5.8.3.1.15
+      type: gauge
+      help: The timestamp indicating when the sensor value was last reset - 1.3.6.1.4.1.13742.6.5.8.3.1.15
+      indexes:
+      - labelname: pduId
+        type: gauge
+      - labelname: circuitId
+        type: gauge
+      - labelname: sensorType
+        type: gauge
+        enum_values:
+          1: rmsCurrent
+          2: peakCurrent
+          3: unbalancedCurrent
+          4: rmsVoltage
+          5: activePower
+          6: apparentPower
+          7: powerFactor
+          8: activeEnergy
+          9: apparentEnergy
+          10: temperature
+          11: humidity
+          12: airFlow
+          13: airPressure
+          14: onOff
+          15: trip
+          16: vibration
+          17: waterDetection
+          18: smokeDetection
+          19: binary
+          20: contact
+          21: fanSpeed
+          22: surgeProtectorStatus
+          23: frequency
+          24: phaseAngle
+          25: rmsVoltageLN
+          26: residualCurrent
+          27: rcmState
+          28: absoluteHumidity
+          29: reactivePower
+          30: other
+          31: none
+          32: powerQuality
+          33: overloadStatus
+          34: overheatStatus
+          35: displacementPowerFactor
+          36: residualDcCurrent
+          37: fanStatus
+          38: inletPhaseSyncAngle
+          39: inletPhaseSync
+          40: operatingState
+          41: activeInlet
+          42: illuminance
+          43: doorContact
+          44: tamperDetection
+          45: motionDetection
+          46: i1smpsStatus
+          47: i2smpsStatus
+          48: switchStatus
+          49: doorLockState
+          50: doorHandleLock
+          51: crestFactor
+          52: length
+          53: distance
+          54: activePowerDemand
+          55: residualAcCurrent
+          56: particleDensity
+          57: voltageThd
+          58: currentThd
+          59: inrushCurrent
+          60: unbalancedVoltage
+          61: unbalancedLineLineCurrent
+          62: unbalancedLineLineVoltage
+          63: dewPoint
+          64: mass
+          65: flux
+          66: luminousIntensity
+          67: luminousEnergy
+          68: luminousFlux
+          69: luminousEmittance
+          70: electricalResistance
+          71: electricalImpedance
+          72: totalHarmonicDistortion
+          73: magneticFieldStrength
+          74: magneticFluxDensity
+          75: electricFieldStrength
+          76: selection
+          77: rotationalSpeed
+          78: transferSwitchBypassState
+          79: batteryLevel
+          80: installFaultStatus
+          81: transferSwitchOutputStatus
+      lookups:
+      - labels:
+        - pduId
+        labelname: pduName
+        oid: 1.3.6.1.4.1.13742.6.3.2.2.1.13
+        type: DisplayString
   readynas:
     walk:
     - 1.3.6.1.4.1.4526


### PR DESCRIPTION

This pull request adds support for the latest Raritan PDU2 and Asset Management MIBs, updating both the Makefile and generator configuration to download and process these new MIB files. It introduces two new modules in `generator.yml` for enhanced device monitoring and asset tracking, and updates URLs to point to the latest vendor releases.

**Raritan MIB support and configuration updates:**

* Updated `RARITAN2_URL` in `generator/Makefile` to use the latest PDU2 MIB version, and added a new `RARITAN_AM_URL` for Asset Management MIB downloads.
* Added rules to download the new `PDU_AssetManagement_MIB.txt` file and included it in the list of MIBs to process. [[1]](diffhunk://#diff-36c2ba83b3e1592b9ad1f62e9d72265a0713bab8f9dd6529e5f9be97ff55fa48R175) [[2]](diffhunk://#diff-36c2ba83b3e1592b9ad1f62e9d72265a0713bab8f9dd6529e5f9be97ff55fa48R415-R418)

**New modules for device and asset management:**

* Introduced the `raritan_pdu2` module in `generator/generator.yml` for advanced monitoring of Raritan PX2, PX3, PX4, PXC, SRC, PRO3X, and PRO4X series PDUs, with extensive SNMP table walks, lookups, and state overrides.
* Added the `raritan_assetmanagement` module for tracking rack asset strips, including configuration and management tables, lookups, and type overrides for asset-related fields.

**Documentation and comments:**

* Updated comments in `generator/generator.yml` to clarify the scope of the legacy and new Raritan modules, and removed outdated references to old MIB versions.