### PR TITLE
generator: Add Cisco Core metrics

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -69,6 +69,8 @@ modules:
     walk:
       - CISCO-PROCESS-MIB::cpmCPUTotal1minRev
       - CISCO-PROCESS-MIB::cpmCPUTotal5minRev
+      - CISCO-PROCESS-MIB::cpmCore1min
+      - CISCO-PROCESS-MIB::cpmCore5min
       - CISCO-MEMORY-POOL-MIB::ciscoMemoryPoolUsed
       - CISCO-MEMORY-POOL-MIB::ciscoMemoryPoolFree
       - CISCO-MEMORY-POOL-MIB::ciscoMemoryPoolType

--- a/snmp.yml
+++ b/snmp.yml
@@ -2930,6 +2930,8 @@ modules:
     - 1.3.6.1.2.1.47.1.1.1.1.7
     - 1.3.6.1.4.1.9.9.109.1.1.1.1.7
     - 1.3.6.1.4.1.9.9.109.1.1.1.1.8
+    - 1.3.6.1.4.1.9.9.109.1.1.2.1.4
+    - 1.3.6.1.4.1.9.9.109.1.1.2.1.5
     - 1.3.6.1.4.1.9.9.117.1.1.2.1.2
     - 1.3.6.1.4.1.9.9.221.1.1.1.1.2
     - 1.3.6.1.4.1.9.9.221.1.1.1.1.3
@@ -2956,6 +2958,24 @@ modules:
       help: The overall CPU busy percentage in the last 5 minute period - 1.3.6.1.4.1.9.9.109.1.1.1.1.8
       indexes:
       - labelname: cpmCPUTotalIndex
+        type: gauge
+    - name: cpmCore1min
+      oid: 1.3.6.1.4.1.9.9.109.1.1.2.1.4
+      type: gauge
+      help: The overall Core busy percentage in the last 1 minute period. - 1.3.6.1.4.1.9.9.109.1.1.2.1.4
+      indexes:
+      - labelname: cpmCPUTotalIndex
+        type: gauge
+      - labelname: cpmCoreIndex
+        type: gauge
+    - name: cpmCore5min
+      oid: 1.3.6.1.4.1.9.9.109.1.1.2.1.5
+      type: gauge
+      help: The overall Core busy percentage in the last 5 minute period. - 1.3.6.1.4.1.9.9.109.1.1.2.1.5
+      indexes:
+      - labelname: cpmCPUTotalIndex
+        type: gauge
+      - labelname: cpmCoreIndex
         type: gauge
     - name: cefcFRUPowerOperStatus
       oid: 1.3.6.1.4.1.9.9.117.1.1.2.1.2


### PR DESCRIPTION
Add per-core CPU metrics from `CISCO-PROCESS-MIBS`. This will help with monitoring CPU utilization on Cisco devices with multi-core CPUs.