### PR TITLE
Handle uint32 type in pduValueAsString, minor gosnmp usage fixes

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -143,7 +143,7 @@ func ScrapeTarget(snmp scraper.SNMPScraper, target string, auth *config.Auth, mo
 			return results, fmt.Errorf("error reported by target %s: Error Status %d", target, packet.Error)
 		}
 		for _, v := range packet.Variables {
-			if v.Type == gosnmp.NoSuchObject || v.Type == gosnmp.NoSuchInstance {
+			if v.Type == gosnmp.NoSuchObject || v.Type == gosnmp.NoSuchInstance || v.Type == gosnmp.EndOfMibView {
 				logger.Debug("OID not supported by target", "oids", v.Name)
 				continue
 			}
@@ -818,6 +818,8 @@ func pduValueAsString(pdu *gosnmp.SnmpPDU, typ string, metrics Metrics) string {
 	case int:
 		return strconv.Itoa(v)
 	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint32:
 		return strconv.FormatUint(uint64(v), 10)
 	case uint64:
 		return strconv.FormatUint(v, 10)

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -737,6 +737,10 @@ func TestPduValueAsString(t *testing.T) {
 			result: "1",
 		},
 		{
+			pdu:    &gosnmp.SnmpPDU{Value: uint32(1)},
+			result: "1",
+		},
+		{
 			pdu:    &gosnmp.SnmpPDU{Value: uint64(1)},
 			result: "1",
 		},
@@ -1533,6 +1537,68 @@ func TestScrapeTarget(t *testing.T) {
 			},
 			getCall:  []string{"1.3.6.1.2.1.31.1.1.1.18.2", "1.3.6.1.2.1.31.1.1.1.18.3"},
 			walkCall: []string{"1.3.6.1.2.1.2.2.1.2"},
+		},
+		{
+			name: "filter NoSuchObject",
+			module: &config.Module{
+				Get: []string{"1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.2.0"},
+			},
+			getResponse: map[string]gosnmp.SnmpPDU{
+				"1.3.6.1.2.1.1.1.0": {Type: gosnmp.OctetString, Name: "1.3.6.1.2.1.1.1.0", Value: "Test Device"},
+				"1.3.6.1.2.1.1.2.0": {Type: gosnmp.NoSuchObject, Name: "1.3.6.1.2.1.1.2.0", Value: nil},
+			},
+			expectPdus: []gosnmp.SnmpPDU{
+				{Type: gosnmp.OctetString, Name: "1.3.6.1.2.1.1.1.0", Value: "Test Device"},
+			},
+			getCall:  []string{"1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.2.0"},
+			walkCall: []string{},
+		},
+		{
+			name: "filter NoSuchInstance",
+			module: &config.Module{
+				Get: []string{"1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.3.0"},
+			},
+			getResponse: map[string]gosnmp.SnmpPDU{
+				"1.3.6.1.2.1.1.1.0": {Type: gosnmp.OctetString, Name: "1.3.6.1.2.1.1.1.0", Value: "Test Device"},
+				"1.3.6.1.2.1.1.3.0": {Type: gosnmp.NoSuchInstance, Name: "1.3.6.1.2.1.1.3.0", Value: nil},
+			},
+			expectPdus: []gosnmp.SnmpPDU{
+				{Type: gosnmp.OctetString, Name: "1.3.6.1.2.1.1.1.0", Value: "Test Device"},
+			},
+			getCall:  []string{"1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.3.0"},
+			walkCall: []string{},
+		},
+		{
+			name: "filter EndOfMibView",
+			module: &config.Module{
+				Get: []string{"1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.4.0"},
+			},
+			getResponse: map[string]gosnmp.SnmpPDU{
+				"1.3.6.1.2.1.1.1.0": {Type: gosnmp.OctetString, Name: "1.3.6.1.2.1.1.1.0", Value: "Test Device"},
+				"1.3.6.1.2.1.1.4.0": {Type: gosnmp.EndOfMibView, Name: "1.3.6.1.2.1.1.4.0", Value: nil},
+			},
+			expectPdus: []gosnmp.SnmpPDU{
+				{Type: gosnmp.OctetString, Name: "1.3.6.1.2.1.1.1.0", Value: "Test Device"},
+			},
+			getCall:  []string{"1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.4.0"},
+			walkCall: []string{},
+		},
+		{
+			name: "filter all exception types",
+			module: &config.Module{
+				Get: []string{"1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.2.0", "1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.4.0"},
+			},
+			getResponse: map[string]gosnmp.SnmpPDU{
+				"1.3.6.1.2.1.1.1.0": {Type: gosnmp.OctetString, Name: "1.3.6.1.2.1.1.1.0", Value: "Test Device"},
+				"1.3.6.1.2.1.1.2.0": {Type: gosnmp.NoSuchObject, Name: "1.3.6.1.2.1.1.2.0", Value: nil},
+				"1.3.6.1.2.1.1.3.0": {Type: gosnmp.NoSuchInstance, Name: "1.3.6.1.2.1.1.3.0", Value: nil},
+				"1.3.6.1.2.1.1.4.0": {Type: gosnmp.EndOfMibView, Name: "1.3.6.1.2.1.1.4.0", Value: nil},
+			},
+			expectPdus: []gosnmp.SnmpPDU{
+				{Type: gosnmp.OctetString, Name: "1.3.6.1.2.1.1.1.0", Value: "Test Device"},
+			},
+			getCall:  []string{"1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.2.0", "1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.4.0"},
+			walkCall: []string{},
 		},
 	}
 

--- a/scraper/gosnmp.go
+++ b/scraper/gosnmp.go
@@ -78,7 +78,7 @@ func (g *GoSNMPWrapper) Connect() error {
 }
 
 func (g *GoSNMPWrapper) Close() error {
-	return g.c.Conn.Close()
+	return g.c.Close()
 }
 
 func (g *GoSNMPWrapper) Get(oids []string) (*gosnmp.SnmpPacket, error) {


### PR DESCRIPTION
Fixes a bug where TimeTicks and Uinteger32 values corrupt label values when used in lookups.

`pduValueAsString` handles `uint` but not `uint32`. gosnmp returns TimeTicks and Uinteger32 as `uint32`, so they fall through to the default case which uses `fmt.Sprintf("%s", ...)`. This produces malformed labels like:

```
ifAdminStatus{ifDescr="lo",ifIndex="1",ifLastChange="%!s(uint32=0)"} 1
```

instead of:

```
ifAdminStatus{ifDescr="lo",ifIndex="1",ifLastChange="0"} 1
```

To reproduce, use a lookup on any TimeTicks field:

```yaml
modules:
  test:
    walk: [ifTable]
    lookups:
      - source_indexes: [ifIndex]
        lookup: ifLastChange
```

Also includes two minor correctness improvements:

- **Close() method** - Use `g.c.Close()` instead of `g.c.Conn.Close()` for proper mutex protection. Not a practical issue given the connection-per-scrape model, but better to use the API as intended.

- **EndOfMibView handling** - Added to Get response exception check alongside NoSuchObject and NoSuchInstance. Per RFC 3416 this shouldn't appear in Get responses, but non-compliant devices exist.
