### PR TITLE
RFC 2579 DISPLAY-HINT Support for Unknown Textual Conventions

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,64 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"go.yaml.in/yaml/v2"
+)
+
+func TestFormatOpValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		yaml    string
+		wantErr string // empty = expect success
+	}{
+		{
+			name:    "valid FormatOp",
+			yaml:    `{take: 1, fmt: "d", sep: "."}`,
+			wantErr: "",
+		},
+		{
+			name:    "take zero causes infinite loop",
+			yaml:    `{take: 0, fmt: "x"}`,
+			wantErr: "take must be positive",
+		},
+		{
+			name:    "invalid fmt rejected",
+			yaml:    `{take: 1, fmt: "z"}`,
+			wantErr: "fmt must be one of",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var op FormatOp
+			err := yaml.Unmarshal([]byte(tt.yaml), &op)
+
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Errorf("unexpected error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Errorf("expected error containing %q, got nil", tt.wantErr)
+				} else if !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("expected error containing %q, got %v", tt.wantErr, err)
+				}
+			}
+		})
+	}
+}

--- a/generator/README.md
+++ b/generator/README.md
@@ -175,7 +175,10 @@ modules:
         type: DisplayString # Override the metric type, possible types are:
                              #   gauge:   An integer with type gauge.
                              #   counter: An integer with type counter.
-                             #   OctetString: A bit string, rendered as 0xff34.
+                             #   OctetString: A bit string, rendered as 0xff34. Use to disable
+                             #       automatic DISPLAY-HINT formatting when raw hex is preferred.
+                             #   DisplayHint: Format per RFC 2579 DISPLAY-HINT. See display_hint option.
+                             #       Textual conventions with valid MIB hints are auto-formatted.
                              #   DateAndTime: An RFC 2579 DateAndTime byte sequence. If the device has no time zone data, UTC is used.
                              #   ParseDateAndTime: Parse a DisplayString and return the timestamp. See datetime_pattern config option
                              #   NTPTimeStamp: Parse the NTP timestamp (RFC-1305, March 1992, Section 3.1) and return Unix timestamp as float.
@@ -191,6 +194,10 @@ modules:
                              #   EnumAsInfo: An enum for which a single timeseries is created. Good for constant values.
                              #   EnumAsStateSet: An enum with a time series per state. Good for variable low-cardinality enums.
                              #   Bits: An RFC 2578 BITS construct, which produces a StateSet with a time series per bit.
+        display_hint: "1d.1d.1d.1d" # RFC 2579 DISPLAY-HINT string. Implies type: DisplayHint.
+                                    # Use for MIBs with broken/missing hints, or to override the MIB's hint.
+                                    # Examples: "1d.1d.1d.1d" (IPv4), "1x:" (MAC), "255a" (ASCII string),
+                                    #           "1d.1d.1d.1d%4d" (InetAddressIPv4z: 192.168.1.1%42).
 
     filters: # Define filters to collect only a subset of OID table indices
       static: # static filters are handled in the generator. They will convert walks to multiple gets with the specified indices

--- a/generator/hint_parser.go
+++ b/generator/hint_parser.go
@@ -1,0 +1,108 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"errors"
+	"strconv"
+
+	"github.com/prometheus/snmp_exporter/config"
+)
+
+// parseDisplayHint parses an RFC 2579 DISPLAY-HINT string for OCTET STRING
+// into a slice of FormatOp. Returns an error for invalid or unsupported hints.
+//
+// RFC 2579 Section 3.1 defines the octet-format specification with five parts:
+//  1. Optional '*' repeat indicator - first byte of value is repeat count
+//  2. Octet length - decimal digits specifying bytes to consume
+//  3. Format - 'd' decimal, 'x' hex, 'o' octal, 'a' ASCII, 't' UTF-8
+//  4. Optional separator - single character after each application
+//  5. Optional terminator - single character after repeat group (requires '*' and separator)
+//
+// The collector implements RFC 2579's implicit repetition rule: the last spec
+// repeats until data is exhausted. Trailing separator is suppressed.
+//
+// Examples:
+//   - "1d.1d.1d.1d" (InetAddressIPv4) -> 4 specs: {1,d,.}, {1,d,.}, {1,d,.}, {1,d}
+//   - "1x:" (PhysAddress) -> 1 spec: {1,x,:} - collector repeats for all bytes
+//   - "2x:2x:2x:2x:2x:2x:2x:2x" (InetAddressIPv6) -> 8 specs: {2,x,:} ... {2,x}
+//   - "*1x:/1x:" (hypothetical) -> {*,1,x,:,/} - first byte is count
+func parseDisplayHint(hint string) ([]config.FormatOp, error) {
+	if hint == "" {
+		return nil, errors.New("empty hint")
+	}
+
+	var ops []config.FormatOp
+	pos := 0
+
+	for pos < len(hint) {
+		op := config.FormatOp{}
+
+		// (1) Optional '*' repeat indicator
+		if pos < len(hint) && hint[pos] == '*' {
+			op.StarPrefix = true
+			pos++
+		}
+
+		// (2) Octet length - one or more decimal digits (required)
+		if pos >= len(hint) || !isDigit(hint[pos]) {
+			return nil, errors.New("expected octet length")
+		}
+		start := pos
+		for pos < len(hint) && isDigit(hint[pos]) {
+			pos++
+		}
+		take, err := strconv.Atoi(hint[start:pos])
+		if err != nil {
+			return nil, err
+		}
+		op.Take = take
+
+		// (3) Format character - d/x/o/a/t (required)
+		if pos >= len(hint) {
+			return nil, errors.New("expected format character")
+		}
+		switch hint[pos] {
+		case 'd', 'x', 'o', 'a', 't':
+			op.Fmt = string(hint[pos])
+			pos++
+		default:
+			return nil, errors.New("invalid format character: " + string(hint[pos]))
+		}
+
+		// (4) Optional separator - any character except digit and '*'
+		if pos < len(hint) && !isDigit(hint[pos]) && hint[pos] != '*' {
+			op.Sep = string(hint[pos])
+			pos++
+
+			// (5) Optional terminator - only valid if StarPrefix is set
+			if op.StarPrefix && pos < len(hint) && !isDigit(hint[pos]) && hint[pos] != '*' {
+				op.Term = string(hint[pos])
+				pos++
+			}
+		}
+
+		ops = append(ops, op)
+	}
+
+	if len(ops) == 0 {
+		return nil, errors.New("no format specifications parsed")
+	}
+
+	return ops, nil
+}
+
+func isDigit(c byte) bool {
+	return c >= '0' && c <= '9'
+}

--- a/generator/hint_parser_test.go
+++ b/generator/hint_parser_test.go
@@ -1,0 +1,351 @@
+// Copyright 2025 The Prometheus Authors
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/prometheus/snmp_exporter/config"
+)
+
+func TestParseDisplayHint(t *testing.T) {
+	tests := []struct {
+		name    string
+		hint    string
+		want    []config.FormatOp
+		wantErr bool
+	}{
+		{
+			name: "InetAddressIPv4 - 1d.1d.1d.1d",
+			hint: "1d.1d.1d.1d",
+			want: []config.FormatOp{
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d"},
+			},
+		},
+		{
+			name: "InetAddressIPv4z - 1d.1d.1d.1d%4d",
+			hint: "1d.1d.1d.1d%4d",
+			want: []config.FormatOp{
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "%"},
+				{Take: 4, Fmt: "d"},
+			},
+		},
+		{
+			name: "InetAddressIPv6 - 2x:2x:2x:2x:2x:2x:2x:2x",
+			hint: "2x:2x:2x:2x:2x:2x:2x:2x",
+			want: []config.FormatOp{
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x"},
+			},
+		},
+		{
+			name: "InetAddressIPv6z - 2x:2x:2x:2x:2x:2x:2x:2x%4d",
+			hint: "2x:2x:2x:2x:2x:2x:2x:2x%4d",
+			want: []config.FormatOp{
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: "%"},
+				{Take: 4, Fmt: "d"},
+			},
+		},
+		{
+			name: "PhysAddress - 1x:",
+			hint: "1x:",
+			want: []config.FormatOp{
+				{Take: 1, Fmt: "x", Sep: ":"},
+			},
+		},
+		{
+			name: "DisplayString - 255a",
+			hint: "255a",
+			want: []config.FormatOp{
+				{Take: 255, Fmt: "a"},
+			},
+		},
+		{
+			name: "UTF8 string - 255t (SNMP-TARGET-MIB, VMWARE-VRNI-MIB)",
+			hint: "255t",
+			want: []config.FormatOp{
+				{Take: 255, Fmt: "t"},
+			},
+		},
+		{
+			name: "Simple decimal - 1d",
+			hint: "1d",
+			want: []config.FormatOp{
+				{Take: 1, Fmt: "d"},
+			},
+		},
+		{
+			name: "Simple hex - 2x (TN-TC)",
+			hint: "2x",
+			want: []config.FormatOp{
+				{Take: 2, Fmt: "x"},
+			},
+		},
+		{
+			name: "Octal format - 1o",
+			hint: "1o",
+			want: []config.FormatOp{
+				{Take: 1, Fmt: "o"},
+			},
+		},
+		{
+			name: "Hex with dash separator - 1x- (ALCATEL-IND1-ISIS-SPB-MIB)",
+			hint: "1x-",
+			want: []config.FormatOp{
+				{Take: 1, Fmt: "x", Sep: "-"},
+			},
+		},
+		{
+			name: "Star prefix with separator and terminator (SNMPv2-TM SnmpOSIAddress variant)",
+			hint: "*1x:/",
+			want: []config.FormatOp{
+				{Take: 1, StarPrefix: true, Fmt: "x", Sep: ":", Term: "/"},
+			},
+		},
+		{
+			name: "Star prefix without terminator",
+			hint: "*1x:",
+			want: []config.FormatOp{
+				{Take: 1, StarPrefix: true, Fmt: "x", Sep: ":"},
+			},
+		},
+		{
+			name: "Multi-digit octet length - 128a (CIENA-WS-TYPEDEFS-MIB)",
+			hint: "128a",
+			want: []config.FormatOp{
+				{Take: 128, Fmt: "a"},
+			},
+		},
+		{
+			name: "DateAndTime-like complex hint",
+			hint: "2d-1d-1d,1d:1d:1d.1d",
+			want: []config.FormatOp{
+				{Take: 2, Fmt: "d", Sep: "-"},
+				{Take: 1, Fmt: "d", Sep: "-"},
+				{Take: 1, Fmt: "d", Sep: ","},
+				{Take: 1, Fmt: "d", Sep: ":"},
+				{Take: 1, Fmt: "d", Sep: ":"},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d"},
+			},
+		},
+		{
+			name: "UUID format - 4x-2x-2x-1x1x-6x (UUID-TC-MIB)",
+			hint: "4x-2x-2x-1x1x-6x",
+			want: []config.FormatOp{
+				{Take: 4, Fmt: "x", Sep: "-"},
+				{Take: 2, Fmt: "x", Sep: "-"},
+				{Take: 2, Fmt: "x", Sep: "-"},
+				{Take: 1, Fmt: "x"},
+				{Take: 1, Fmt: "x", Sep: "-"},
+				{Take: 6, Fmt: "x"},
+			},
+		},
+		{
+			name: "UUID variant - 4x-2x-2x-2x-6x (TIMETRA-TC-MIB, RUCKUS-TC-MIB)",
+			hint: "4x-2x-2x-2x-6x",
+			want: []config.FormatOp{
+				{Take: 4, Fmt: "x", Sep: "-"},
+				{Take: 2, Fmt: "x", Sep: "-"},
+				{Take: 2, Fmt: "x", Sep: "-"},
+				{Take: 2, Fmt: "x", Sep: "-"},
+				{Take: 6, Fmt: "x"},
+			},
+		},
+		{
+			name: "IPv4 with prefix - 1d.1d.1d.1d/1d (VIPTELA-OPER-BGP, SNMPv2-TM)",
+			hint: "1d.1d.1d.1d/1d",
+			want: []config.FormatOp{
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "/"},
+				{Take: 1, Fmt: "d"},
+			},
+		},
+		{
+			name: "IPv4 with port - 1d.1d.1d.1d:2d (MPLS-TC-STD-MIB, TRANSPORT-ADDRESS-MIB)",
+			hint: "1d.1d.1d.1d:2d",
+			want: []config.FormatOp{
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: ":"},
+				{Take: 2, Fmt: "d"},
+			},
+		},
+		{
+			name: "Version number - 4d.4d.4d.4d (RAISECOM-SYSTEM-MIB)",
+			hint: "4d.4d.4d.4d",
+			want: []config.FormatOp{
+				{Take: 4, Fmt: "d", Sep: "."},
+				{Take: 4, Fmt: "d", Sep: "."},
+				{Take: 4, Fmt: "d", Sep: "."},
+				{Take: 4, Fmt: "d"},
+			},
+		},
+		{
+			name: "VPN RD - 2x-1d.1d.1d.1d:2d (JUNIPER-VPN-MIB)",
+			hint: "2x-1d.1d.1d.1d:2d",
+			want: []config.FormatOp{
+				{Take: 2, Fmt: "x", Sep: "-"},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: ":"},
+				{Take: 2, Fmt: "d"},
+			},
+		},
+		{
+			name: "Simple date - 2d-1d-1d (ADVA-MIB)",
+			hint: "2d-1d-1d",
+			want: []config.FormatOp{
+				{Take: 2, Fmt: "d", Sep: "-"},
+				{Take: 1, Fmt: "d", Sep: "-"},
+				{Take: 1, Fmt: "d"},
+			},
+		},
+		{
+			name: "MAC with dash - 1x-1x-1x-1x-1x-1x (TPLINK-TC-MIB)",
+			hint: "1x-1x-1x-1x-1x-1x",
+			want: []config.FormatOp{
+				{Take: 1, Fmt: "x", Sep: "-"},
+				{Take: 1, Fmt: "x", Sep: "-"},
+				{Take: 1, Fmt: "x", Sep: "-"},
+				{Take: 1, Fmt: "x", Sep: "-"},
+				{Take: 1, Fmt: "x", Sep: "-"},
+				{Take: 1, Fmt: "x"},
+			},
+		},
+		{
+			name: "Bridge ID - 2d.1x:1x:1x:1x:1x:1x (PRVT-SPANNING-TREE-MIB)",
+			hint: "2d.1x:1x:1x:1x:1x:1x",
+			want: []config.FormatOp{
+				{Take: 2, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "x", Sep: ":"},
+				{Take: 1, Fmt: "x", Sep: ":"},
+				{Take: 1, Fmt: "x", Sep: ":"},
+				{Take: 1, Fmt: "x", Sep: ":"},
+				{Take: 1, Fmt: "x", Sep: ":"},
+				{Take: 1, Fmt: "x"},
+			},
+		},
+		{
+			name: "DHCP format - 1d,1d,1x:1x:1x:1x:1x:1x (CISCO-IETF-DHCP-SERVER-MIB)",
+			hint: "1d,1d,1x:1x:1x:1x:1x:1x",
+			want: []config.FormatOp{
+				{Take: 1, Fmt: "d", Sep: ","},
+				{Take: 1, Fmt: "d", Sep: ","},
+				{Take: 1, Fmt: "x", Sep: ":"},
+				{Take: 1, Fmt: "x", Sep: ":"},
+				{Take: 1, Fmt: "x", Sep: ":"},
+				{Take: 1, Fmt: "x", Sep: ":"},
+				{Take: 1, Fmt: "x", Sep: ":"},
+				{Take: 1, Fmt: "x"},
+			},
+		},
+		{
+			name: "IPv6-mapped IPv4 - 2x:2x:2x:2x:2x:2x:1d.1d.1d.1d (WATCHGUARD-IPSEC-SA-MON-MIB-EXT)",
+			hint: "2x:2x:2x:2x:2x:2x:1d.1d.1d.1d",
+			want: []config.FormatOp{
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 2, Fmt: "x", Sep: ":"},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d", Sep: "."},
+				{Take: 1, Fmt: "d"},
+			},
+		},
+		{
+			name: "Timezone offset - 1a1d:1d (SNMPv2-TC DateAndTime suffix)",
+			hint: "1a1d:1d",
+			want: []config.FormatOp{
+				{Take: 1, Fmt: "a"},
+				{Take: 1, Fmt: "d", Sep: ":"},
+				{Take: 1, Fmt: "d"},
+			},
+		},
+		{
+			name: "Leading zero in octet length - 02x (IMM-MIB)",
+			hint: "02x",
+			want: []config.FormatOp{
+				{Take: 2, Fmt: "x"},
+			},
+		},
+		{
+			name: "Zero octet length - 0a (TRANSPORT-ADDRESS-MIB bracket literal)",
+			hint: "0a",
+			want: []config.FormatOp{
+				{Take: 0, Fmt: "a"},
+			},
+		},
+		{
+			name:    "Empty hint",
+			hint:    "",
+			wantErr: true,
+		},
+		{
+			name:    "Missing octet length",
+			hint:    "d",
+			wantErr: true,
+		},
+		{
+			name:    "Invalid format character",
+			hint:    "1z",
+			wantErr: true,
+		},
+		{
+			name:    "Missing format character",
+			hint:    "1",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseDisplayHint(tt.hint)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("parseDisplayHint(%q) error = %v, wantErr %v", tt.hint, err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseDisplayHint(%q) = %+v, want %+v", tt.hint, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Note: This PR should be considered a draft / request for comments. I didn't get a chance to run through more than some very basic real-world testing - away for a week or so, and thought that it might be good to float the current state for feedback, or if anyone else wanted to do some testing with their environment.

There is a "soft" breaking change in that various TCs that currently hit the Octet String format - which may be handled via post-processing, or query-time formatting will suddenly be formatted "correctly". This might be a point of contention, and needs some thought. There are escape hatches available using overrides to maintain the old behavior, but it does require the user to set those.

**TL;DR:** Unknown textual conventions with valid DISPLAY-HINTs now render as formatted strings instead of raw hex. For example, a vendor TC with hint `255a` displays `"PowerEdge R750"` instead of `0x506F776572456467652052373530`. Override with `type: OctetString` to preserve hex output.

## Problem

When the generator encounters an unknown textual convention with an OCTET STRING base type, it falls back to raw hex output even when the MIB contains a valid DISPLAY-HINT that describes how to format the value.

Examples of affected scenarios:
- Vendor-specific TCs (Dell String64, Huawei LUN names, Brocade WWNs)
- Less common standard TCs not explicitly coded
- Any OCTET STRING-based TC with a DISPLAY-HINT that lacks a hardcoded handler

The current approach of having to handle less common TCs is a pretty common pain point for users and maintainers based on some looking through Github issues / discussions / prometheus-users mailing list. Hard coding TCs is fine for common types, but it ends up meaning that the barrier for entry is much higher for users with less common TCs. Currently the solution often requires a PR to add those TCs, which is too hard for many users to solve. There's also a bunch of maintenance and review overhead for the project as the TC support grows.

This provides a generic option for solving a class of issues, and gives users the ability to define custom formatting without having to resort to a bunch of regex-based overrides.

In principle some of the card coded TCs could be removed from the codebase with this approach, but that is currently outside the scope of the PR.

The current intent is to use this as a fallback in the case that there's not hard-coded parsers for a type.

## Scope Limitations

This PR addresses OCTET STRING formatting via DISPLAY-HINT. It does NOT address:

- **INTEGER DISPLAY-HINT scaling** - `d-N` format for implied decimal point (rare, no demand found).
- **Semantic types** - Types needing more than formatting (DateAndTime timezone handling already has dedicated support).

## Solution

A new `DisplayHint` type implements RFC 2579 DISPLAY-HINT parsing. 

### Design: Generator IR / Collector Evaluation

The generator compiles DISPLAY-HINT strings into an intermediate representation (`FormatSpec`) stored in snmp.yml. The collector evaluates this IR at scrape time without having to parse display-hints directly.

**Why IR instead of runtime parsing?**

An alternative would be storing the raw DISPLAY-HINT string in snmp.yml and parsing it at scrape time. The IR approach was chosen for:

1. **Performance** - Parsing happens once at generation, not per-PDU at scrape time. FormatSpec evaluation is a simple slice iteration with no string parsing, regex, or allocations beyond the output buffer.

2. **Validation** - Malformed hints fail at `make generate` with clear errors, not silently at scrape time. Users discover problems before deployment.

3. **Consistency** - Follows the existing snmp_exporter pattern where the generator compiles MIB knowledge into snmp.yml, keeping the collector MIB-agnostic. 

### Generator Phase
- Parses DISPLAY-HINT strings into `FormatOp` intermediate representation
- Stores pre-compiled format spec in snmp.yml
- Unknown TCs with valid hints get `type: DisplayHint` instead of `OctetString`

### Collector Phase
- Applies format spec via slice iteration (no runtime parsing)
- Handles all RFC 2579 format types: decimal (`d`), hex (`x`), octal (`o`), ASCII (`a`), UTF-8 (`t`)
- Implements implicit repetition rule (last spec repeats until data exhausted)
- Proper separator/terminator suppression per RFC

### generator.yml Example:

```yaml
  modules:
    mymodule:
      walk:
        - 1.3.6.1.4.1.12345
      overrides:
        # Force raw hex output (previous behavior)
        someBinaryOid:
          type: OctetString

        # Explicitly use MIB's DISPLAY-HINT
        someVendorTC:
          type: DisplayHint

        # Custom hint for broken/missing MIB hint
        badVendorString:
          display_hint: "64a"
```

### snmp.yml Example

```yaml
# DISPLAY-HINT "1x:" (MAC/PhysAddress) becomes:
format_spec:
  - {take: 1, fmt: x, sep: ":"}
# Single spec; collector applies RFC 2579 implicit repetition
# 6-byte input → "aa:bb:cc:dd:ee:ff"

# DISPLAY-HINT "255a" (ASCII string) becomes:
format_spec:
  - {take: 255, fmt: a}
# Renders bytes as ASCII text

# DISPLAY-HINT "4x-2x-2x-2x-6x" (UUID-style) becomes:
format_spec:
  - {take: 4, fmt: x, sep: "-"}
  - {take: 2, fmt: x, sep: "-"}
  - {take: 2, fmt: x, sep: "-"}
  - {take: 2, fmt: x, sep: "-"}
  - {take: 6, fmt: x}
```

## Sample / Example Issues This Would Address

| Issue | Problem | Vendor |
|-------|---------|--------|
| #1387 | String64 TC as hex (`0x44656C6C20496E632E` instead of "Dell Inc.") | Dell iDRAC |
| #607 | 8-byte WWN as hex (PhysAddress48 truncates to 6 bytes) | Brocade FC |
| #264 | modelName as hex (`0x44533231326A` instead of "DS212j") | Synology |
| #558 | Temperature as hex (`0x323243` instead of "22C") | Aruba |
| #930 | Model name as hex (`0x506F776572456467652052373530` instead of "PowerEdge R750") | Dell |
| #1383 | ServObjDesc TC not recognized as DisplayString derivative | Nokia |

Plus vendor TCs from Huawei (LUN names), HP iLO (timestamps), and others where DISPLAY-HINT exists but no hardcoded handler.

## Breaking Changes

### Behavior Change on Regeneration

When users regenerate `snmp.yml`, unknown TCs with parseable DISPLAY-HINTs will change output format:

| Before | After | Hint |
|--------|-------|------|
| `0xaabbccddeeff` | `aa:bb:cc:dd:ee:ff` | `1x:` |
| `0x506F776572456467652052373530` | `PowerEdge R750` | `255a` |
| `0x44533231326A` | `DS212j` | `64a` |

**Affected downstream configurations:**
- `regex_extracts` patterns expecting hex format
- `metric_relabel_configs` matching hex strings
- Dashboards/alerts with hex string matches
- Automation parsing exporter output

### Escape Hatches

Users can preserve previous behavior:

```yaml
# In generator.yml
overrides:
  someOid:
    type: OctetString  # Forces raw hex output
```

Or specify a custom format:

```yaml
overrides:
  someOid:
    display_hint: "1x."  # Custom hint (dot-separated hex)
```

### Type Override Summary

| Override | Result |
|----------|--------|
| `type: OctetString` | Raw hex (previous behavior) |
| `type: DisplayHint` | Use MIB's DISPLAY-HINT |
| `display_hint: "..."` | Custom hint string (implies DisplayHint type) |

## Performance

Performance is pretty comparable to hard-coded variants:

| Scenario | FormatSpec | Hardcoded Handler | Delta |
|----------|------------|-------------------|-------|
| MAC (6 bytes) | 323 ns | 294 ns | +10% |
| IPv4 (4 bytes) | 77 ns | 89 ns | -13% |
| IPv6 (16 bytes) | 469 ns | 572 ns | -18% |

## Questions for Reviewers

1. Is the breaking change acceptable given the escape hatch exists?
2. is it disruptive enough that it should be opt-in (initially perhaps?) via cli flag or similar?
3. Are there vendor MIBs with unusual DISPLAY-HINTs that should be tested?
4. Any concerns about the snmp.yml schema addition (FormatOp struct design)?
5. Feedback on the FormatSpec IR approach vs alternatives? 
