### PR TITLE
handle net-snmp 5.9.5.x changes to struct tclist

### DIFF
--- a/generator/net_snmp.go
+++ b/generator/net_snmp.go
@@ -19,6 +19,7 @@ package main
 #include <net-snmp/net-snmp-config.h>
 #include <net-snmp/mib_api.h>
 #include <net-snmp/agent/agent_callbacks.h>
+#include <net-snmp/library/snmp_api.h>
 #include <net-snmp/library/default_store.h>
 #include <net-snmp/library/parse.h>
 #include <unistd.h>
@@ -41,6 +42,9 @@ struct tc {
   struct enum_list *enums;
   struct range_list *ranges;
   char           *description;
+#if defined(SNMP_FLAGS_SESSION_USER)
+  int             lineno;
+#endif
 #if !defined(NETSNMP_DS_LIB_ADD_FORWARDER_INFO)
 } tclist[MAXTC];
 int tc_alloc = MAXTC;


### PR DESCRIPTION
tclist gained an additional member (int lineno, at the end). add this to snmp_exporter's copy of the struct, taking the lead from existing checks by conditioning it on SNMP_FLAGS_SESSION_USER that was added to net-snmp/library/snmp_api.h between 5.7.4 and 5.7.5.

fixes segfaults when running generator.