### PR TITLE
Improve Sentry4-MIB module

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -449,39 +449,49 @@ modules:
 # https://cdn10.servertech.com/assets/documents/documents/815/original/Sentry4.mib
   servertech_sentry4:
     walk:
-      - 1.3.6.1.4.1.1718.4.1.3.3   # st4InputCordMonitorTable
-      - 1.3.6.1.4.1.1718.4.1.4.3   # st4LineMonitorTable
-      - 1.3.6.1.4.1.1718.4.1.5.3   # st4PhaseMonitorTable
-      - 1.3.6.1.4.1.1718.4.1.7.3   # st4BranchMonitorTable
-      - 1.3.6.1.4.1.1718.4.1.8.3   # st4OutletMonitorTable
-      - 1.3.6.1.4.1.1718.4.1.9.3   # st4TempSensorMonitorTable
-      - 1.3.6.1.4.1.1718.4.1.14.3  # st4FanSensorMonitorTable
-
+      - "Sentry4-MIB::st4InputCordMonitorTable"   # 1.3.6.1.4.1.1718.4.1.3.3
+      - "Sentry4-MIB::st4LineMonitorTable"        # 1.3.6.1.4.1.1718.4.1.4.3
+      - "Sentry4-MIB::st4PhaseMonitorTable"       # 1.3.6.1.4.1.1718.4.1.5.3
+      - "Sentry4-MIB::st4BranchMonitorTable"      # 1.3.6.1.4.1.1718.4.1.7.3
+      - "Sentry4-MIB::st4OutletMonitorTable"      # 1.3.6.1.4.1.1718.4.1.8.3
+      - "Sentry4-MIB::st4TempSensorMonitorTable"  # 1.3.6.1.4.1.1718.4.1.9.3
+      - "Sentry4-MIB::st4FanSensorMonitorTable"   # 1.3.6.1.4.1.1718.4.1.14.3
     lookups:
-      - source_indexes: [st4UnitIndex]
-        lookup: st4UnitName
+      - source_indexes: [st4UnitIndex, st4InputCordIndex]
+        lookup: st4InputCordID
       - source_indexes: [st4UnitIndex, st4InputCordIndex]
         lookup: st4InputCordName
         drop_source_indexes: true
       - source_indexes: [st4UnitIndex, st4InputCordIndex, st4LineIndex]
+        lookup: st4LineID
+      - source_indexes: [st4UnitIndex, st4InputCordIndex, st4LineIndex]
         lookup: st4LineLabel
+      - source_indexes: [st4UnitIndex, st4InputCordIndex, st4PhaseIndex]
+        lookup: st4PhaseID
         drop_source_indexes: true
       - source_indexes: [st4UnitIndex, st4InputCordIndex, st4PhaseIndex]
         lookup: st4PhaseLabel
         drop_source_indexes: true
       - source_indexes: [st4UnitIndex, st4InputCordIndex, st4BranchIndex]
+        lookup: st4BranchID
+      - source_indexes: [st4UnitIndex, st4InputCordIndex, st4BranchIndex]
         lookup: st4BranchLabel
         drop_source_indexes: true
+      - source_indexes: [st4UnitIndex, st4InputCordIndex, st4OutletIndex]
+        lookup: st4OutletID
       - source_indexes: [st4UnitIndex, st4InputCordIndex, st4OutletIndex]
         lookup: st4OutletName
         drop_source_indexes: true
       - source_indexes: [st4UnitIndex, st4AdcSensorIndex]
+        lookup: st4AdcSensorID
+        drop_source_indexes: true
+      - source_indexes: [st4UnitIndex, st4AdcSensorIndex]
         lookup: st4AdcSensorName
         drop_source_indexes: true
-      - source_indexes: [st4UnitIndex, st4AdcSensorIndex, st4FanSensorIndex]
-        lookup: st4AdcSensorName
-        drop_source_indexes: true
-
+      - source_indexes: [st4UnitIndex, st4FanSensorIndex]
+        lookup: st4FanSensorID
+      - source_indexes: [st4UnitIndex, st4FanSensorIndex]
+        lookup: st4FanSensorName
     overrides:
       st4TempSensorValue:
         scale: 0.1

--- a/snmp.yml
+++ b/snmp.yml
@@ -54332,16 +54332,22 @@ modules:
     max_repetitions: 4
   servertech_sentry4:
     walk:
+    - 1.3.6.1.4.1.1718.4.1.14.2.1.2
+    - 1.3.6.1.4.1.1718.4.1.14.2.1.3
     - 1.3.6.1.4.1.1718.4.1.14.3
-    - 1.3.6.1.4.1.1718.4.1.2.2.1.3
+    - 1.3.6.1.4.1.1718.4.1.3.2.1.2
     - 1.3.6.1.4.1.1718.4.1.3.2.1.3
     - 1.3.6.1.4.1.1718.4.1.3.3
+    - 1.3.6.1.4.1.1718.4.1.4.2.1.2
     - 1.3.6.1.4.1.1718.4.1.4.2.1.4
     - 1.3.6.1.4.1.1718.4.1.4.3
+    - 1.3.6.1.4.1.1718.4.1.5.2.1.2
     - 1.3.6.1.4.1.1718.4.1.5.2.1.4
     - 1.3.6.1.4.1.1718.4.1.5.3
+    - 1.3.6.1.4.1.1718.4.1.7.2.1.2
     - 1.3.6.1.4.1.1718.4.1.7.2.1.4
     - 1.3.6.1.4.1.1718.4.1.7.3
+    - 1.3.6.1.4.1.1718.4.1.8.2.1.2
     - 1.3.6.1.4.1.1718.4.1.8.2.1.3
     - 1.3.6.1.4.1.1718.4.1.8.3
     - 1.3.6.1.4.1.1718.4.1.9.3
@@ -54358,8 +54364,15 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4FanSensorIndex
+        labelname: st4FanSensorID
+        oid: 1.3.6.1.4.1.1718.4.1.14.2.1.2
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4FanSensorIndex
+        labelname: st4FanSensorName
+        oid: 1.3.6.1.4.1.1718.4.1.14.2.1.3
         type: DisplayString
     - name: st4FanSensorStatus
       oid: 1.3.6.1.4.1.1718.4.1.14.3.1.2
@@ -54373,8 +54386,15 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4FanSensorIndex
+        labelname: st4FanSensorID
+        oid: 1.3.6.1.4.1.1718.4.1.14.2.1.2
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4FanSensorIndex
+        labelname: st4FanSensorName
+        oid: 1.3.6.1.4.1.1718.4.1.14.2.1.3
         type: DisplayString
       enum_values:
         0: normal
@@ -54411,8 +54431,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54440,8 +54461,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54488,8 +54510,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54513,8 +54536,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54561,8 +54585,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54586,8 +54611,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54634,8 +54660,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54659,8 +54686,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54684,8 +54712,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54733,8 +54762,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54758,8 +54788,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54784,8 +54815,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54810,8 +54842,9 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54860,14 +54893,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4LineIndex
+        labelname: st4LineID
+        oid: 1.3.6.1.4.1.1718.4.1.4.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54880,12 +54921,6 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
-      - labels: []
-        labelname: st4UnitIndex
-      - labels: []
-        labelname: st4InputCordIndex
-      - labels: []
-        labelname: st4LineIndex
       enum_values:
         0: unknown
         1: "on"
@@ -54904,14 +54939,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4LineIndex
+        labelname: st4LineID
+        oid: 1.3.6.1.4.1.1718.4.1.4.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54924,12 +54967,6 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
-      - labels: []
-        labelname: st4UnitIndex
-      - labels: []
-        labelname: st4InputCordIndex
-      - labels: []
-        labelname: st4LineIndex
       enum_values:
         0: normal
         1: disabled
@@ -54967,14 +55004,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4LineIndex
+        labelname: st4LineID
+        oid: 1.3.6.1.4.1.1718.4.1.4.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -54987,12 +55032,6 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
-      - labels: []
-        labelname: st4UnitIndex
-      - labels: []
-        labelname: st4InputCordIndex
-      - labels: []
-        labelname: st4LineIndex
     - name: st4LineCurrentStatus
       oid: 1.3.6.1.4.1.1718.4.1.4.3.1.4
       type: gauge
@@ -55007,14 +55046,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4LineIndex
+        labelname: st4LineID
+        oid: 1.3.6.1.4.1.1718.4.1.4.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55027,12 +55074,6 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
-      - labels: []
-        labelname: st4UnitIndex
-      - labels: []
-        labelname: st4InputCordIndex
-      - labels: []
-        labelname: st4LineIndex
       enum_values:
         0: normal
         1: disabled
@@ -55070,14 +55111,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4LineIndex
+        labelname: st4LineID
+        oid: 1.3.6.1.4.1.1718.4.1.4.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55090,12 +55139,6 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
-      - labels: []
-        labelname: st4UnitIndex
-      - labels: []
-        labelname: st4InputCordIndex
-      - labels: []
-        labelname: st4LineIndex
     - name: st4PhaseState
       oid: 1.3.6.1.4.1.1718.4.1.5.3.1.1
       type: gauge
@@ -55110,14 +55153,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55130,6 +55181,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55154,14 +55211,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55174,6 +55239,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55217,14 +55288,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55237,6 +55316,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55257,14 +55342,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55277,6 +55370,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55321,14 +55420,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55341,6 +55448,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55361,14 +55474,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55381,6 +55502,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55402,14 +55529,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55422,6 +55557,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55442,14 +55583,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55462,6 +55611,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55482,14 +55637,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55502,6 +55665,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55522,14 +55691,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55542,6 +55719,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55562,14 +55745,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55582,6 +55773,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55625,14 +55822,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55645,6 +55850,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55671,14 +55882,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4PhaseIndex
+        labelname: st4PhaseID
+        oid: 1.3.6.1.4.1.1718.4.1.5.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55691,6 +55910,12 @@ modules:
         labelname: st4UnitIndex
       - labels: []
         labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4UnitIndex
+      - labels: []
+        labelname: st4InputCordIndex
+      - labels: []
+        labelname: st4PhaseIndex
       - labels: []
         labelname: st4UnitIndex
       - labels: []
@@ -55711,14 +55936,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4BranchIndex
+        labelname: st4BranchID
+        oid: 1.3.6.1.4.1.1718.4.1.7.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55755,14 +55988,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4BranchIndex
+        labelname: st4BranchID
+        oid: 1.3.6.1.4.1.1718.4.1.7.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55818,14 +56059,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4BranchIndex
+        labelname: st4BranchID
+        oid: 1.3.6.1.4.1.1718.4.1.7.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55858,14 +56107,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4BranchIndex
+        labelname: st4BranchID
+        oid: 1.3.6.1.4.1.1718.4.1.7.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55921,14 +56178,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4BranchIndex
+        labelname: st4BranchID
+        oid: 1.3.6.1.4.1.1718.4.1.7.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -55961,14 +56226,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56005,14 +56278,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56068,14 +56349,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56108,14 +56397,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56171,14 +56468,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56211,14 +56516,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56251,14 +56564,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56291,14 +56612,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56354,14 +56683,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56394,14 +56731,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56434,14 +56779,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56497,14 +56850,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56537,14 +56898,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56583,14 +56952,22 @@ modules:
       lookups:
       - labels:
         - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
+        - st4InputCordIndex
+        labelname: st4InputCordID
+        oid: 1.3.6.1.4.1.1718.4.1.3.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
         - st4InputCordIndex
         labelname: st4InputCordName
         oid: 1.3.6.1.4.1.1718.4.1.3.2.1.3
+        type: DisplayString
+      - labels:
+        - st4UnitIndex
+        - st4InputCordIndex
+        - st4OutletIndex
+        labelname: st4OutletID
+        oid: 1.3.6.1.4.1.1718.4.1.8.2.1.2
         type: DisplayString
       - labels:
         - st4UnitIndex
@@ -56619,12 +56996,6 @@ modules:
         type: gauge
       - labelname: st4TempSensorIndex
         type: gauge
-      lookups:
-      - labels:
-        - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
-        type: DisplayString
       scale: 0.1
     - name: st4TempSensorStatus
       oid: 1.3.6.1.4.1.1718.4.1.9.3.1.2
@@ -56635,12 +57006,6 @@ modules:
         type: gauge
       - labelname: st4TempSensorIndex
         type: gauge
-      lookups:
-      - labels:
-        - st4UnitIndex
-        labelname: st4UnitName
-        oid: 1.3.6.1.4.1.1718.4.1.2.2.1.3
-        type: DisplayString
       enum_values:
         0: normal
         1: disabled


### PR DESCRIPTION
* Use fully-qualified walk syntax.
* Remove unused single index `st4UnitIndex` lookup.
* Add "ID" lookups for each of the tables to match Sentry3-MIB style.
* Fix lookups for `st4FanSensorMonitorTable`.