### PR TITLE
Split generator CI

### DIFF
--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -1,5 +1,5 @@
 ---
-name: CI
+name: Generator
 on:
   pull_request:
   push:
@@ -10,56 +10,36 @@ permissions:
   contents: read
 
 jobs:
-  test_go:
-    name: Go tests
+  generator:
+    name: Build generator
     runs-on: ubuntu-latest
     container:
       # Whenever the Go version is updated here, .promu.yml
       # should also be updated.
       image: quay.io/prometheus/golang-builder:1.26-base
+    defaults:
+      run:
+        working-directory: ./generator
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
       - uses: prometheus/promci-setup@5af30ba8c199a91d6c04ebdc3c48e630e355f62d # v0.1.0
-      - run: make
+      - run: apt-get update
+      - run: apt-get -y install build-essential diffutils libsnmp-dev p7zip-full
+      - run: make mibs
+      - run: make generator
+      - run: make parse_errors
+      - run: make generate
       - run: git diff --exit-code
 
-  mixins:
-    name: Test mixins
+  publish_generator_main:
+    name: Publish generator main branch artifacts
     runs-on: ubuntu-latest
-    container:
-      # Whenever the Go version is updated here, .promu.yml
-      # should also be updated.
-      image: quay.io/prometheus/golang-builder:1.26-base
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - run: go install github.com/monitoring-mixins/mixtool/cmd/mixtool@latest
-      - run: go install github.com/google/go-jsonnet/cmd/jsonnetfmt@latest
-      - run: make -C snmp-mixin lint build
-
-  build:
-    name: Build snmp_exporter
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        thread: [ 0, 1, 2, 3 ]
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: prometheus/promci/build@769ee18070cd21cfc2a24fa912349fd3e48dee58 # v0.6.0
-        with:
-          parallelism: 4
-          thread: ${{ matrix.thread }}
-
-  publish_main:
-    # https://github.com/prometheus/promci/blob/52c7012f5f0070d7281b8db4a119e21341d43c91/actions/publish_main/action.yml
-    name: Publish main branch artifacts
-    runs-on: ubuntu-latest
-    needs: [test_go, build]
+    needs: [generator]
+    defaults:
+      run:
+        working-directory: ./generator
     if: |
       (github.event_name == 'push' && github.event.ref == 'refs/heads/main')
     steps:
@@ -73,10 +53,13 @@ jobs:
           quay_io_login: ${{ secrets.quay_io_login }}
           quay_io_password: ${{ secrets.quay_io_password }}
 
-  publish_release:
-    name: Publish release artefacts
+  publish_generator_release:
+    name: Publish generator release artefacts
     runs-on: ubuntu-latest
-    needs: [test_go, build]
+    needs: [generator]
+    defaults:
+      run:
+        working-directory: ./generator
     if: |
       (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
     steps:


### PR DESCRIPTION
Split the generator CI into a separate CI flow to avoid mixing CI caches.