### PR TITLE
feat: allow display_hint config for indexes

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -844,7 +844,7 @@ func pduValueAsString(pdu *gosnmp.SnmpPDU, typ, displayHint string, metrics Metr
 			// Prepend the length, as it is explicit in an index.
 			parts = append([]int{len(v)}, parts...)
 		}
-		str, _, _ := indexOidsAsString(parts, typ, 0, false, nil)
+		str, _, _ := indexOidsAsString(parts, typ, "", 0, false, nil)
 		return strings.ToValidUTF8(str, "�")
 	case nil:
 		return ""
@@ -858,7 +858,7 @@ func pduValueAsString(pdu *gosnmp.SnmpPDU, typ, displayHint string, metrics Metr
 // Convert oids to a string index value.
 //
 // Returns the string, the oids that were used and the oids left over.
-func indexOidsAsString(indexOids []int, typ string, fixedSize int, implied bool, enumValues map[int]string) (string, []int, []int) {
+func indexOidsAsString(indexOids []int, typ, displayHint string, fixedSize int, implied bool, enumValues map[int]string) (string, []int, []int) {
 	if typeMapping, ok := combinedTypeMapping[typ]; ok {
 		subOid, valueOids := splitOid(indexOids, 2)
 		if typ == "InetAddressMissingSize" {
@@ -868,15 +868,15 @@ func indexOidsAsString(indexOids []int, typ string, fixedSize int, implied bool,
 		var str string
 		var used, remaining []int
 		if t, ok := typeMapping[subOid[0]]; ok {
-			str, used, remaining = indexOidsAsString(valueOids, t, 0, false, enumValues)
+			str, used, remaining = indexOidsAsString(valueOids, t, displayHint, 0, false, enumValues)
 			return str, append(subOid, used...), remaining
 		}
 		if typ == "InetAddressMissingSize" {
 			// We don't know the size, so pass everything remaining.
-			return indexOidsAsString(indexOids, "OctetString", 0, true, enumValues)
+			return indexOidsAsString(indexOids, "OctetString", displayHint, 0, true, enumValues)
 		}
 		// The 2nd oid is the length.
-		return indexOidsAsString(indexOids, "OctetString", subOid[1]+2, false, enumValues)
+		return indexOidsAsString(indexOids, "OctetString", displayHint, subOid[1]+2, false, enumValues)
 	}
 
 	switch typ {
@@ -911,6 +911,9 @@ func indexOidsAsString(indexOids []int, typ string, fixedSize int, implied bool,
 		}
 		if len(parts) == 0 {
 			return "", subOid, indexOids
+		}
+		if v, ok := applyDisplayHint(displayHint, parts); ok {
+			return v, subOid, indexOids
 		}
 		return fmt.Sprintf("0x%X", string(parts)), subOid, indexOids
 	case "DisplayString":
@@ -970,7 +973,7 @@ func indexesToLabels(indexOids []int, metric *config.Metric, oidToPdu map[string
 
 	// Covert indexes to useful strings.
 	for _, index := range metric.Indexes {
-		str, subOid, remainingOids := indexOidsAsString(indexOids, index.Type, index.FixedSize, index.Implied, index.EnumValues)
+		str, subOid, remainingOids := indexOidsAsString(indexOids, index.Type, index.DisplayHint, index.FixedSize, index.Implied, index.EnumValues)
 		// The labelvalue is the text form of the index oids.
 		labels[index.Labelname] = str
 		// Save its oid in case we need it for lookups.

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -892,7 +892,7 @@ func pduValueAsString(pdu *gosnmp.SnmpPDU, typ, displayHint string, metrics Metr
 			// Prepend the length, as it is explicit in an index.
 			parts = append([]int{len(v)}, parts...)
 		}
-		str, _, _ := indexOidsAsString(parts, typ, 0, false, nil)
+		str, _, _ := indexOidsAsString(parts, typ, "", 0, false, nil)
 		return strings.ToValidUTF8(str, "�")
 	case nil:
 		return ""
@@ -906,7 +906,7 @@ func pduValueAsString(pdu *gosnmp.SnmpPDU, typ, displayHint string, metrics Metr
 // Convert oids to a string index value.
 //
 // Returns the string, the oids that were used and the oids left over.
-func indexOidsAsString(indexOids []int, typ string, fixedSize int, implied bool, enumValues map[int]string) (string, []int, []int) {
+func indexOidsAsString(indexOids []int, typ, displayHint string, fixedSize int, implied bool, enumValues map[int]string) (string, []int, []int) {
 	if typeMapping, ok := combinedTypeMapping[typ]; ok {
 		subOid, valueOids := splitOid(indexOids, 2)
 		if typ == "InetAddressMissingSize" {
@@ -916,15 +916,15 @@ func indexOidsAsString(indexOids []int, typ string, fixedSize int, implied bool,
 		var str string
 		var used, remaining []int
 		if t, ok := typeMapping[subOid[0]]; ok {
-			str, used, remaining = indexOidsAsString(valueOids, t, 0, false, enumValues)
+			str, used, remaining = indexOidsAsString(valueOids, t, displayHint, 0, false, enumValues)
 			return str, append(subOid, used...), remaining
 		}
 		if typ == "InetAddressMissingSize" {
 			// We don't know the size, so pass everything remaining.
-			return indexOidsAsString(indexOids, "OctetString", 0, true, enumValues)
+			return indexOidsAsString(indexOids, "OctetString", displayHint, 0, true, enumValues)
 		}
 		// The 2nd oid is the length.
-		return indexOidsAsString(indexOids, "OctetString", subOid[1]+2, false, enumValues)
+		return indexOidsAsString(indexOids, "OctetString", displayHint, subOid[1]+2, false, enumValues)
 	}
 
 	switch typ {
@@ -959,6 +959,9 @@ func indexOidsAsString(indexOids []int, typ string, fixedSize int, implied bool,
 		}
 		if len(parts) == 0 {
 			return "", subOid, indexOids
+		}
+		if v, ok := applyDisplayHint(displayHint, parts); ok {
+			return v, subOid, indexOids
 		}
 		return fmt.Sprintf("0x%X", string(parts)), subOid, indexOids
 	case "DisplayString":
@@ -1018,7 +1021,7 @@ func indexesToLabels(indexOids []int, metric *config.Metric, oidToPdu map[string
 
 	// Covert indexes to useful strings.
 	for _, index := range metric.Indexes {
-		str, subOid, remainingOids := indexOidsAsString(indexOids, index.Type, index.FixedSize, index.Implied, index.EnumValues)
+		str, subOid, remainingOids := indexOidsAsString(indexOids, index.Type, index.DisplayHint, index.FixedSize, index.Implied, index.EnumValues)
 		// The labelvalue is the text form of the index oids. Ensure it is valid UTF-8,
 		// as required for Prometheus label values.
 		labels[index.Labelname] = strings.ToValidUTF8(str, "�")

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1060,6 +1060,12 @@ func TestIndexesToLabels(t *testing.T) {
 			result:   map[string]string{"l": "0x4120FF"},
 		},
 		{
+			oid:      []int{4, 127, 0, 0, 1},
+			metric:   config.Metric{Indexes: []*config.Index{{Labelname: "l", Type: "OctetString", DisplayHint: "1d."}}},
+			oidToPdu: map[string]gosnmp.SnmpPDU{},
+			result:   map[string]string{"l": "127.0.0.1"},
+		},
+		{
 			oid:      []int{65, 32, 255},
 			metric:   config.Metric{Indexes: []*config.Index{{Labelname: "l", Type: "OctetString", FixedSize: 3}}},
 			oidToPdu: map[string]gosnmp.SnmpPDU{},

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1079,6 +1079,12 @@ func TestIndexesToLabels(t *testing.T) {
 			result:   map[string]string{"l": "0x4120FF"},
 		},
 		{
+			oid:      []int{4, 127, 0, 0, 1},
+			metric:   config.Metric{Indexes: []*config.Index{{Labelname: "l", Type: "OctetString", DisplayHint: "1d."}}},
+			oidToPdu: map[string]gosnmp.SnmpPDU{},
+			result:   map[string]string{"l": "127.0.0.1"},
+		},
+		{
 			oid:      []int{65, 32, 255},
 			metric:   config.Metric{Indexes: []*config.Index{{Labelname: "l", Type: "OctetString", FixedSize: 3}}},
 			oidToPdu: map[string]gosnmp.SnmpPDU{},

--- a/config/config.go
+++ b/config/config.go
@@ -247,11 +247,12 @@ type Metric struct {
 }
 
 type Index struct {
-	Labelname  string         `yaml:"labelname"`
-	Type       string         `yaml:"type"`
-	FixedSize  int            `yaml:"fixed_size,omitempty"`
-	Implied    bool           `yaml:"implied,omitempty"`
-	EnumValues map[int]string `yaml:"enum_values,omitempty"`
+	Labelname   string         `yaml:"labelname"`
+	Type        string         `yaml:"type"`
+	FixedSize   int            `yaml:"fixed_size,omitempty"`
+	Implied     bool           `yaml:"implied,omitempty"`
+	EnumValues  map[int]string `yaml:"enum_values,omitempty"`
+	DisplayHint string         `yaml:"display_hint,omitempty"`
 }
 
 type Lookup struct {

--- a/config/config.go
+++ b/config/config.go
@@ -251,11 +251,12 @@ type Metric struct {
 }
 
 type Index struct {
-	Labelname  string         `yaml:"labelname"`
-	Type       string         `yaml:"type"`
-	FixedSize  int            `yaml:"fixed_size,omitempty"`
-	Implied    bool           `yaml:"implied,omitempty"`
-	EnumValues map[int]string `yaml:"enum_values,omitempty"`
+	Labelname   string         `yaml:"labelname"`
+	Type        string         `yaml:"type"`
+	FixedSize   int            `yaml:"fixed_size,omitempty"`
+	Implied     bool           `yaml:"implied,omitempty"`
+	EnumValues  map[int]string `yaml:"enum_values,omitempty"`
+	DisplayHint string         `yaml:"display_hint,omitempty"`
 }
 
 type Lookup struct {

--- a/generator/FORMAT.md
+++ b/generator/FORMAT.md
@@ -43,6 +43,9 @@ modules:
           fixed_size: 8   # Only possible for OctetString/DisplayString types.
                           # If only one length is possible this is it. Otherwise
                           # this will be 0 or missing.
+          display_hint: 1d.   # Only possible for OctetString types.
+                              # RFC 2579 DISPLAY-HINT to format OctetString values as readable strings.
+                              # Useful when vendor-specific types display as hex instead of text.
         - labelname: someOtherString
           type: OctetString
           implied: true   # Only possible for OctetString/DisplayString types.

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -388,6 +388,7 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 					return
 				}
 				index.FixedSize = indexNode.FixedSize
+				index.DisplayHint = indexNode.Hint
 				if n.ImpliedIndex && count+1 == len(n.Indexes) {
 					index.Implied = true
 				}

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -1035,8 +1035,9 @@ func TestGenerateConfigModule(t *testing.T) {
 						Type: "PhysAddress48",
 						Indexes: []*config.Index{
 							{
-								Labelname: "physaddress48Index",
-								Type:      "PhysAddress48",
+								Labelname:   "physaddress48Index",
+								Type:        "PhysAddress48",
+								DisplayHint: "1x:",
 							},
 						},
 					},
@@ -1047,8 +1048,9 @@ func TestGenerateConfigModule(t *testing.T) {
 						Type: "gauge",
 						Indexes: []*config.Index{
 							{
-								Labelname: "physaddress48Index",
-								Type:      "PhysAddress48",
+								Labelname:   "physaddress48Index",
+								Type:        "PhysAddress48",
+								DisplayHint: "1x:",
 							},
 						},
 					},
@@ -1159,9 +1161,10 @@ func TestGenerateConfigModule(t *testing.T) {
 						Type: "OctetString",
 						Indexes: []*config.Index{
 							{
-								Labelname: "sizedHexIndex",
-								Type:      "OctetString",
-								FixedSize: 8,
+								Labelname:   "sizedHexIndex",
+								Type:        "OctetString",
+								FixedSize:   8,
+								DisplayHint: "1x:",
 							},
 						},
 					},
@@ -1172,9 +1175,10 @@ func TestGenerateConfigModule(t *testing.T) {
 						Type: "gauge",
 						Indexes: []*config.Index{
 							{
-								Labelname: "sizedHexIndex",
-								Type:      "OctetString",
-								FixedSize: 8,
+								Labelname:   "sizedHexIndex",
+								Type:        "OctetString",
+								FixedSize:   8,
+								DisplayHint: "1x:",
 							},
 						},
 					},


### PR DESCRIPTION
In https://github.com/prometheus/snmp_exporter/pull/1549, support for DISPLAY-HINT was added for metrics/lookups. However, this does not cover labels/strings coming from Index OIDs.

This PR extends the `Index` type and `indexOidsAsString` function to also handle display hints. This allows e.g. cases where IP addresses are used as index in OctetString format.

I was not sure how to best integrate this into the generator and its config, so I've left this part out of the PR for now. Happy to receive some pointers on how this could be integrated into the generator step, otherwise this could be merged as-is and require manual config adjustment for now, and generator functionality could come later?