### PR TITLE
Fix: update Synology MIB file download link in generator.yml

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -760,7 +760,7 @@ modules:
 #
 # Synology MIBs can be found here:
 #   http://www.synology.com/support/snmp_mib.php
-#   http://dedl.synology.com/download/Document/MIBGuide/Synology_MIB_File.zip
+#   http://global.download.synology.com/download/Document/Software/DeveloperGuide/Firmware/DSM/All/enu/Synology_MIB_File.zip
 #
 # Tested on RS2414rp+ NAS
 #


### PR DESCRIPTION
The previous link was dead. Updated it with a working one.