### PR TITLE
collector: fix multiple dynamic filters on the same OID overriding each other

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -93,6 +93,14 @@ func ScrapeTarget(snmp scraper.SNMPScraper, target string, auth *config.Auth, mo
 	// Evaluate rules.
 	newGet := module.Get
 	newWalk := module.Walk
+
+	// allowedIndicesByTarget accumulates, for each target OID, the
+	// intersection of the indices allowed by every filter targeting it.
+	// This makes multiple filters that target the same OID act as an AND,
+	// rather than the later filter discarding the earlier one's results.
+	allowedIndicesByTarget := map[string][]string{}
+	var filteredTargets []string
+
 	for _, filter := range module.Filters {
 		allowedList := []string{}
 		pdus, err := snmp.WalkAll(filter.Oid)
@@ -107,13 +115,23 @@ func ScrapeTarget(snmp scraper.SNMPScraper, target string, auth *config.Auth, mo
 		// Update config to get only index and not walk them.
 		newWalk = updateWalkConfig(newWalk, filter, logger)
 
-		// Only Keep indices not involved in filters.
-		newCfg := updateGetConfig(newGet, filter, logger)
+		for _, targetOid := range filter.Targets {
+			if existing, ok := allowedIndicesByTarget[targetOid]; ok {
+				allowedIndicesByTarget[targetOid] = intersectIndices(existing, allowedList)
+			} else {
+				filteredTargets = append(filteredTargets, targetOid)
+				allowedIndicesByTarget[targetOid] = allowedList
+			}
+		}
+	}
 
-		// We now add each index from filter to the get list.
-		newCfg = addAllowedIndices(filter, allowedList, logger, newCfg)
-
-		newGet = newCfg
+	// Apply the combined filters: remove each filtered target OID from the
+	// get config once, then add back only the indices allowed by every
+	// filter targeting that OID.
+	for _, targetOid := range filteredTargets {
+		singleTarget := config.DynamicFilter{Targets: []string{targetOid}}
+		newGet = updateGetConfig(newGet, singleTarget, logger)
+		newGet = addAllowedIndices(singleTarget, allowedIndicesByTarget[targetOid], logger, newGet)
 	}
 
 	version := auth.Version
@@ -159,6 +177,22 @@ func ScrapeTarget(snmp scraper.SNMPScraper, target string, auth *config.Auth, mo
 		results.pdus = append(results.pdus, pdus...)
 	}
 	return results, nil
+}
+
+// intersectIndices returns the indices present in both a and b, preserving
+// the order of a.
+func intersectIndices(a, b []string) []string {
+	bSet := make(map[string]bool, len(b))
+	for _, idx := range b {
+		bSet[idx] = true
+	}
+	result := make([]string, 0, len(a))
+	for _, idx := range a {
+		if bSet[idx] {
+			result = append(result, idx)
+		}
+	}
+	return result
 }
 
 func filterAllowedIndices(logger *slog.Logger, filter config.DynamicFilter, pdus []gosnmp.SnmpPDU, allowedList []string, metrics Metrics) []string {

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1451,6 +1451,53 @@ func TestScrapeTarget(t *testing.T) {
 			walkCall: []string{"1.3.6.1.2.1.2.2.1.2"},
 		},
 		{
+			// Two dynamic filters targeting the same OID should be ANDed
+			// together: only indices that satisfy both filters should be
+			// kept, instead of the second filter discarding the first's
+			// results.
+			name: "dynamic filter intersection",
+			module: &config.Module{
+				Get:  []string{},
+				Walk: []string{"1.3.6.1.2.1.31.1.1.1.18"},
+				Filters: []config.DynamicFilter{
+					{
+						Oid: "1.3.6.1.2.1.2.2.1.2",
+						Targets: []string{
+							"1.3.6.1.2.1.31.1.1.1.18",
+						},
+						Values: []string{"Intel Corporation 82540EM Gigabit Ethernet Controller"},
+					},
+					{
+						Oid: "1.3.6.1.2.1.2.2.1.7",
+						Targets: []string{
+							"1.3.6.1.2.1.31.1.1.1.18",
+						},
+						Values: []string{"1"},
+					},
+				},
+			},
+			getResponse: map[string]gosnmp.SnmpPDU{
+				"1.3.6.1.2.1.31.1.1.1.18.2": {Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.31.1.1.1.18.2", Value: "eth0"},
+			},
+			walkResponses: map[string][]gosnmp.SnmpPDU{
+				"1.3.6.1.2.1.2.2.1.2": {
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.2.2.1.2.1", Value: "lo"},
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.2.2.1.2.2", Value: "Intel Corporation 82540EM Gigabit Ethernet Controller"},
+					{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.2.2.1.2.3", Value: "Intel Corporation 82540EM Gigabit Ethernet Controller"},
+				},
+				"1.3.6.1.2.1.2.2.1.7": {
+					{Name: ".1.3.6.1.2.1.2.2.1.7.1", Value: 1},
+					{Name: ".1.3.6.1.2.1.2.2.1.7.2", Value: 1},
+					{Name: ".1.3.6.1.2.1.2.2.1.7.3", Value: 2},
+				},
+			},
+			expectPdus: []gosnmp.SnmpPDU{
+				{Type: gosnmp.OctetString, Name: ".1.3.6.1.2.1.31.1.1.1.18.2", Value: "eth0"},
+			},
+			getCall:  []string{"1.3.6.1.2.1.31.1.1.1.18.2"},
+			walkCall: []string{"1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.7"},
+		},
+		{
 			name: "filter NoSuchObject",
 			module: &config.Module{
 				Get: []string{"1.3.6.1.2.1.1.1.0", "1.3.6.1.2.1.1.2.0"},


### PR DESCRIPTION
Fixes #1621

When you define more than one `dynamic` filter and they target the same OID, only the last one actually has an effect. I dug into `ScrapeTarget` and the issue is that each filter's loop iteration calls `updateGetConfig` which strips out the indices that the previous filter just added, then `addAllowedIndices` adds back only its own matches. So if filter A adds indices [2,3] and filter B then runs on the same target, it removes [2,3] first and adds whatever it matched on its own, basically wiping out filter A's work.

This makes it impossible to do something like "interfaces where description isn't empty AND ifType is ethernet" since the two filters would target the same set of OIDs.

What I changed: instead of mutating the get config inside the filter loop, I first collect each filter's allowed indices per target OID, and if a target OID was already touched by a previous filter I intersect the two index lists (AND semantics). Once all filters have run, I apply the final intersected list to the get config, once per target OID.

Added a test case (`dynamic_filter_intersection`) with two filters on the same target OID to cover this. Ran `go test ./collector/...` and everything passes including the existing filter tests, also did `go build ./...`.

Happy to adjust the approach if there's a preferred direction for this.