### PR TITLE
fix(config): allow empty environment variable values during expansion

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -365,8 +365,8 @@ func (re *Regexp) UnmarshalYAML(unmarshal func(any) error) error {
 func substituteEnvVariables(value string) (string, error) {
 	missingEnv := ""
 	result := os.Expand(value, func(s string) string {
-		v := os.Getenv(s)
-		if v == "" && missingEnv == "" {
+		v, ok := os.LookupEnv(s)
+		if !ok && missingEnv == "" {
 			missingEnv = s
 		}
 		return v

--- a/config_test.go
+++ b/config_test.go
@@ -123,6 +123,25 @@ func TestEnvSecretsMissing(t *testing.T) {
 	}
 }
 
+// When environment variables are present but set to empty values.
+func TestEnvSecretsEmpty(t *testing.T) {
+	t.Setenv("ENV_USERNAME", "")
+	t.Setenv("ENV_PASSWORD", "")
+	t.Setenv("ENV_PRIV_PASSWORD", "")
+
+	sc := &SafeConfig{}
+	err := sc.ReloadConfig(nopLogger, []string{"testdata/snmp-auth-envvars.yml"}, true)
+	if err != nil {
+		t.Fatalf("Error loading config with empty env vars: %v", err)
+	}
+
+	for i := range sc.C.Auths {
+		if sc.C.Auths[i].Username != "snmp_" || sc.C.Auths[i].Password != "" || sc.C.Auths[i].PrivPassword != "" {
+			t.Fatal("failed to resolve empty env vars")
+		}
+	}
+}
+
 // When SNMPv2 was specified without credentials
 func TestEnvSecretsNotSpecified(t *testing.T) {
 	sc := &SafeConfig{}


### PR DESCRIPTION
Tiny follow-up to #1148.

Right now `${ENV_*}` fails if the env var exists but is empty. That is a real setup btw, shells and container envs allow it, so config load can blow up even though the var is set.

This switches the check to `os.LookupEnv`, so empty values are accepted and only truly missing vars error.

Repro:
1. Run `ENV_USERNAME='' ENV_PASSWORD='' ENV_PRIV_PASSWORD='' go test . -run TestEnvSecretsEmpty -count=1`
2. Before this patch it fails with `ENV_USERNAME environment variable not found`
3. With this patch it passes

Checks:
- `go test $(go list ./... | grep -v /generator$)`

@SuperQ
