### PR TITLE
build(generator): fetch Eltex MIBs from prometheus-community/snmp

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -37,8 +37,7 @@ ARISTA_URL        := https://www.arista.com/assets/data/docs/MIBS
 CISCO_URL         := https://raw.githubusercontent.com/cisco/cisco-mibs/f55dc443daff58dfc86a764047ded2248bb94e12/v2
 DELL_OM_URL       := https://dl.dell.com/FOLDER11196144M/1/Dell-OM-MIBS-11010_A00.zip
 DLINK_URL         := https://ftp.dlink.de/des/des-3200-18/driver_software/DES-3200-18_mib_revC_4-04_all_en_20130603.zip
-ELTEX_MES_URL     := https://api.prod.eltex-co.ru/storage/upload_center/files/42/mibs_10.4.3.4.zip
-# hint: https://eltex-co.com/download/?product=337 if you need to update the ELTEX_MES_URL
+ELTEX_MIBS_URL    := https://raw.githubusercontent.com/prometheus-community/snmp/main/eltex
 DELL_NETWORK_URL  := https://supportkb.dell.com/attachment/ka02R000000I7TFQA0/Current_MIBs_pkb_en_US_1.zip
 HPE_URL           := https://downloads.hpe.com/pub/softlib2/software1/pubsw-linux/p1580676047/v229101/upd11.85mib.tar.gz
 IANA_CHARSET_URL  := https://www.iana.org/assignments/ianacharset-mib/ianacharset-mib
@@ -487,11 +486,12 @@ $(MIBDIR)/.cisco_imc:
 	@touch $(MIBDIR)/.cisco_imc
 
 $(MIBDIR)/.eltex-mes:
-	$(eval TMP := $(shell mktemp))
-	@echo ">> Downloading Eltex MES device mibs to $(TMP)"
-	@curl $(CURL_OPTS) $(CURL_USER_AGENT) -o $(TMP) $(ELTEX_MES_URL)
-	@unzip -j -d $(MIBDIR) $(TMP) fsiss.mib eltex/ELTEX-SMI-ACTUAL.mib eltex/ELTEX-MES-ISS-CPU-UTIL-MIB.mib eltex/ELTEX-MES-ISS-MIB.mib CISCO-QOS-PIB-MIB.mib
-	@rm -v $(TMP)
+	@echo ">> Downloading Eltex MES device mibs from prometheus-community/snmp"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/CISCO-QOS-PIB-MIB.mib "$(ELTEX_MIBS_URL)/CISCO-QOS-PIB-MIB.mib"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/ELTEX-MES-ISS-CPU-UTIL-MIB.mib "$(ELTEX_MIBS_URL)/ELTEX-MES-ISS-CPU-UTIL-MIB.mib"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/ELTEX-MES-ISS-MIB.mib "$(ELTEX_MIBS_URL)/ELTEX-MES-ISS-MIB.mib"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/ELTEX-SMI-ACTUAL.mib "$(ELTEX_MIBS_URL)/ELTEX-SMI-ACTUAL.mib"
+	@curl $(CURL_OPTS) -o $(MIBDIR)/fsiss.mib "$(ELTEX_MIBS_URL)/fsiss.mib"
 	@touch $(MIBDIR)/.eltex-mes
 
 $(MIBDIR)/.juniper:


### PR DESCRIPTION
Vendor API (eltex-co.ru) required downloading a zip and extracting specific files; the prometheus-community/snmp mirror exposes them directly, removing the unzip dependency and the fragile version-pinned URL.