### PR TITLE
docs: fix hex casing in display_hint example comment

### DIFF
--- a/collector/display_hint.go
+++ b/collector/display_hint.go
@@ -54,7 +54,7 @@ func writeUint(w *strings.Builder, val uint64, base int) {
 //
 // Examples:
 //   - "1d.1d.1d.1d" on [192,168,1,1] → "192.168.1.1"
-//   - "1x:" on [0,26,43,60,77,94] → "00:1a:2b:3c:4d:5e"
+//   - "1x:" on [0,26,43,60,77,94] → "00:1A:2B:3C:4D:5E"
 //   - "255a" on [72,101,108,108,111] → "Hello"
 func applyDisplayHint(hint string, data []byte) (string, bool) {
 	if hint == "" || len(data) == 0 {


### PR DESCRIPTION
The '1x:' example in display_hint.go showed lowercase hex (00:1a:2b...), but writeHex emits uppercase (and the test asserts 00:1A:2B:3C:4D:5E). Corrected the comment to uppercase.
