### PR TITLE
Sanitize index-derived label values to valid UTF-8

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -1019,8 +1019,9 @@ func indexesToLabels(indexOids []int, metric *config.Metric, oidToPdu map[string
 	// Covert indexes to useful strings.
 	for _, index := range metric.Indexes {
 		str, subOid, remainingOids := indexOidsAsString(indexOids, index.Type, index.FixedSize, index.Implied, index.EnumValues)
-		// The labelvalue is the text form of the index oids.
-		labels[index.Labelname] = str
+		// The labelvalue is the text form of the index oids. Ensure it is valid UTF-8,
+		// as required for Prometheus label values.
+		labels[index.Labelname] = strings.ToValidUTF8(str, "�")
 		// Save its oid in case we need it for lookups.
 		labelOids[index.Labelname] = subOid
 		// For the next iteration.

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -411,8 +411,8 @@ func TestPduToSample(t *testing.T) {
 				Help:    "Help string",
 				Indexes: []*config.Index{{Labelname: "foo", Type: "DisplayString"}},
 			},
-			oidToPdu:  make(map[string]gosnmp.SnmpPDU),
-			shouldErr: true, // Invalid ASCII/UTF-8 string.
+			oidToPdu:        make(map[string]gosnmp.SnmpPDU),
+			expectedMetrics: []string{`Desc{fqName: "test_metric", help: "Help string", constLabels: {}, variableLabels: {foo}} label:{name:"foo" value:"A�"} gauge:{value:3}`},
 		},
 		{
 			pdu: &gosnmp.SnmpPDU{
@@ -431,8 +431,8 @@ func TestPduToSample(t *testing.T) {
 					"": {{Value: "1", Regex: config.Regexp{regexp.MustCompile(".*")}}},
 				},
 			},
-			oidToPdu:  make(map[string]gosnmp.SnmpPDU),
-			shouldErr: true, // Invalid ASCII/UTF-8 string.
+			oidToPdu:        make(map[string]gosnmp.SnmpPDU),
+			expectedMetrics: []string{`Desc{fqName: "test_metric", help: "Help string", constLabels: {}, variableLabels: {foo}} label:{name:"foo" value:"A�"} gauge:{value:3}`},
 		},
 		{
 			pdu: &gosnmp.SnmpPDU{
@@ -1107,6 +1107,12 @@ func TestIndexesToLabels(t *testing.T) {
 			metric:   config.Metric{Indexes: []*config.Index{{Labelname: "l", Type: "DisplayString", Implied: true}}},
 			oidToPdu: map[string]gosnmp.SnmpPDU{},
 			result:   map[string]string{"l": "A "},
+		},
+		{
+			oid:      []int{2, 0xff, 65},
+			metric:   config.Metric{Indexes: []*config.Index{{Labelname: "l", Type: "DisplayString"}}},
+			oidToPdu: map[string]gosnmp.SnmpPDU{},
+			result:   map[string]string{"l": "�A"},
 		},
 		{
 			oid:      []int{0},


### PR DESCRIPTION
#968 replaced invalid UTF-8 in metric values with U+FFFD, but only on the `pduValueAsString` path. Labels built from table indexes go through `indexesToLabels` directly, so they never get sanitized. When a device returns non-UTF-8 bytes in a string-typed index (e.g. a `DisplayString` index containing Latin-1 or raw binary), `NewConstMetric` rejects the label value, the metric is replaced with an invalid metric, and the gather fails with an `snmp_error`, so the whole scrape errors out.

This applies the same `strings.ToValidUTF8(..., "�")` treatment to index label values, so those metrics survive with a replacement character instead of erroring out. Valid non-ASCII UTF-8 in index values passes through unchanged; only invalid byte sequences are replaced.

One known limitation: `ToValidUTF8` replaces each run of invalid bytes with a single replacement character, so two rows whose indexes differ only within an invalid run (say one-byte `DisplayString` indexes 0xFE and 0xFF) end up with identical label sets, and the gatherer rejects the duplicate series. That still fails the scrape, but it requires colliding garbage rather than any garbage, and it's the same trade-off #968 already accepted for values. Lookups are unaffected either way, since they key off the raw index OIDs rather than the sanitized string.

This does change behavior asserted by two existing tests, which expected the invalid-UTF-8 error. Those assertions date back to #303, which was about turning a panic into a graceful error rather than about erroring being the desired end state. #968 later settled on sanitizing for the value path, and this brings the index path in line with that. I've updated the two test cases accordingly. 

The practical motivation is to ensure safety for #1610, which adds `display_hint` formatting for index labels - the `a`/`t` hint formats write device bytes into labels and would hit that error path.
