### PR TITLE
Generator: Don't rewrite non-6-byte fixed-size 1x: types to PhysAddress48

### DIFF
--- a/generator/tree.go
+++ b/generator/tree.go
@@ -108,7 +108,7 @@ func prepareTree(nodes *Node, logger *slog.Logger) map[string]*Node {
 	walkNode(nodes, func(n *Node) {
 		// Set type on MAC addresses and strings.
 		// RFC 2579
-		if n.Hint == "1x:" {
+		if n.Hint == "1x:" && (n.FixedSize == 0 || n.FixedSize == 6) {
 			n.Type = "PhysAddress48"
 		}
 		if displayStringRe.MatchString(n.Hint) {

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -126,6 +126,16 @@ func TestTreePrepare(t *testing.T) {
 			in:  &Node{Oid: "1", Label: "mac", Hint: "1x:"},
 			out: &Node{Oid: "1", Label: "mac", Hint: "1x:", Type: "PhysAddress48"},
 		},
+		// MAC Address type set on six-byte fixed-size string.
+		{
+			in:  &Node{Oid: "1", Label: "mac6", Hint: "1x:", FixedSize: 6, Type: "OCTETSTR"},
+			out: &Node{Oid: "1", Label: "mac6", Hint: "1x:", FixedSize: 6, Type: "PhysAddress48"},
+		},
+		// Fixed-size string other than six bytes keeps its type.
+		{
+			in:  &Node{Oid: "1", Label: "serial8", Hint: "1x:", FixedSize: 8, Type: "OCTETSTR"},
+			out: &Node{Oid: "1", Label: "serial8", Hint: "1x:", FixedSize: 8, Type: "OCTETSTR"},
+		},
 		// Short ASCII string.
 		{
 			in:  &Node{Oid: "1", Label: "ascii", Hint: "32a"},
@@ -902,6 +912,18 @@ func TestGenerateConfigModule(t *testing.T) {
 							},
 						},
 					},
+					{
+						Oid: "1.10", Label: "sizedHex",
+						Children: []*Node{
+							{
+								Oid: "1.10.1", Label: "sizedHexEntry", Indexes: []string{"sizedHexIndex"},
+								Children: []*Node{
+									{Oid: "1.10.1.1", Access: "ACCESS_READONLY", Label: "sizedHexIndex", Type: "OCTETSTR", Hint: "1x:", FixedSize: 8},
+									{Oid: "1.10.1.2", Access: "ACCESS_READONLY", Label: "sizedHexFoo", Type: "INTEGER"},
+								},
+							},
+						},
+					},
 				},
 			},
 			cfg: &ModuleConfig{
@@ -1127,6 +1149,32 @@ func TestGenerateConfigModule(t *testing.T) {
 							{
 								Labelname: "ipv6Index",
 								Type:      "InetAddressIPv6",
+							},
+						},
+					},
+					{
+						Name: "sizedHexIndex",
+						Oid:  "1.10.1.1",
+						Help: " - 1.10.1.1",
+						Type: "OctetString",
+						Indexes: []*config.Index{
+							{
+								Labelname: "sizedHexIndex",
+								Type:      "OctetString",
+								FixedSize: 8,
+							},
+						},
+					},
+					{
+						Name: "sizedHexFoo",
+						Oid:  "1.10.1.2",
+						Help: " - 1.10.1.2",
+						Type: "gauge",
+						Indexes: []*config.Index{
+							{
+								Labelname: "sizedHexIndex",
+								Type:      "OctetString",
+								FixedSize: 8,
 							},
 						},
 					},


### PR DESCRIPTION
The generator rewrites any node with DISPLAY-HINT `1x:` to `PhysAddress48`, and the collector's `PhysAddress48` branch always consumes exactly 6 bytes. When the underlying textual convention is a fixed-size octet string of another length, the index is parsed at the wrong length and every index after it at the wrong offset. For example, `ELTEX-LTP8X::ONTSerial` (`OCTET STRING (SIZE (8))`, hint `1x:`) is used as a table index: only 6 of its 8 bytes are consumed, and the remaining 2 corrupt whatever index follows. Values are affected too, rendering only their first 6 bytes.

This change gates the rewrite on the parsed fixed size: nodes are rewritten only when the size is 6 or unknown. Keeping size-unknown nodes is deliberate - some MAC conventions have no single fixed size for net-snmp to report, e.g. `MacAddressNC` from RFC 2024 (`OCTET STRING (SIZE (0 | 6))`, same hint), and dropping those would change existing generated configs for actual MAC addresses.

Affected nodes now stay `OctetString`: indexes align correctly, and rendering becomes hex (`0x...`) instead of a mis-sized MAC-style string. 

Out of scope: `1x:` conventions whose size net-snmp doesn't report at the TC level (genuinely variable-size ones like `LldpV2ManAddress`, or sizes refined on the OBJECT-TYPE rather than the TC) still get rewritten and mis-parse when longer than 6 bytes. Those can't be told apart here from MAC conventions whose size simply isn't reported.

This is part of a series of PRs preparing for generator integration of `display_hint` on indexes (#1610, alongside #1646). Once the rewrite no longer captures non-6-byte conventions, those indexes stay `OctetString`, where the collector can apply the MIB's DISPLAY-HINT and render them as formatted strings rather than raw hex.
