### PR TITLE
docs: add practical SNMP config samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,10 @@ special installation.
 
 We also provide a sample [systemd unit file](examples/systemd/snmp_exporter.service).
 
+Practical SNMP setup samples (local workstation, network devices, SNMPv2c/v3
+auth, and notes on HTTP proxies such as Zscaler) are under
+[examples/sample-configs](examples/sample-configs).
+
 ## Running
 
 Start `snmp_exporter` as a daemon or from CLI:

--- a/examples/sample-configs/README.md
+++ b/examples/sample-configs/README.md
@@ -1,0 +1,179 @@
+# Sample SNMP configurations
+
+Practical configuration samples for common setups. They use modules already
+present in the default [`snmp.yml`](../../snmp.yml) (`if_mib`, `system`,
+`hrSystem`, `hrStorage`, and others).
+
+Authentication details for SNMPv1/v2c/v3 are also documented in the
+[generator file format](../../generator/README.md#file-format).
+
+## Architecture
+
+```
+Prometheus --HTTP--> snmp_exporter --SNMP (UDP/TCP 161)--> device
+```
+
+* Prometheus scrapes the exporter over HTTP(S).
+* The exporter scrapes the target device over SNMP.
+* **HTTP proxies (including Zscaler) do not carry SNMP.** Place
+  `snmp_exporter` on a host that has direct IP reachability to the devices
+  (management VRF/VLAN, DC network, VPN, or bastion with SNMP allowed).
+* If Prometheus must reach the exporter through a corporate HTTP proxy, use
+  Prometheus `proxy_url` on the scrape job. That only affects the
+  Prometheus → exporter path.
+
+## Scenario 1: Developer workstation (local SNMP agent)
+
+Use this to exercise the exporter against a machine you control.
+
+### Enable a local SNMP agent
+
+**Linux (snmpd):**
+
+```sh
+# Debian/Ubuntu
+sudo apt-get install snmpd snmp
+# Allow localhost (and optionally your LAN) in /etc/snmp/snmpd.conf, e.g.:
+#   rocommunity public 127.0.0.1
+#   agentAddress udp:127.0.0.1:161
+sudo systemctl enable --now snmpd
+snmpwalk -v2c -c public 127.0.0.1 system
+```
+
+**macOS:**
+
+Recent macOS releases no longer ship `snmpd`. Practical options:
+
+1. Install Net-SNMP via Homebrew and run `snmpd` with a local `snmpd.conf`, or
+2. Run a small SNMP agent in Docker for learning (example):
+
+```sh
+docker run --rm -p 1161:161/udp polinux/snmpd
+# Then scrape target tcp://127.0.0.1:1161 or udp on 1161 depending on image.
+```
+
+Confirm with `snmpwalk` before wiring Prometheus.
+
+### Scrape the workstation
+
+1. Start the exporter with the default config:
+
+   ```sh
+   ./snmp_exporter --config.file=snmp.yml
+   ```
+
+2. Manual check (defaults: `auth=public_v2`, `module=if_mib`):
+
+   ```sh
+   curl 'http://localhost:9116/snmp?target=127.0.0.1&auth=public_v2&module=if_mib'
+   # Host resources (when the agent implements HOST-RESOURCES-MIB):
+   curl 'http://localhost:9116/snmp?target=127.0.0.1&auth=public_v2&module=hrSystem'
+   curl 'http://localhost:9116/snmp?target=127.0.0.1&auth=public_v2&module=system'
+   ```
+
+3. Prometheus job: see [`prometheus-workstation.yml`](prometheus-workstation.yml).
+
+Useful default modules for hosts: `system`, `if_mib`, `hrSystem`, `hrStorage`,
+`hrDevice`. Prefer a read-only community or SNMPv3 on any shared network.
+
+## Scenario 2: Routers and switches (work / lab network)
+
+### Placement relative to proxies (Zscaler and similar)
+
+Corporate HTTP/HTTPS proxies (Zscaler Internet Access, Blue Coat, etc.) sit on
+web traffic. SNMP uses UDP (or TCP) to port 161 and is not tunneled through
+those proxies.
+
+Recommended pattern:
+
+1. Run `snmp_exporter` in a network segment that can reach device management
+   addresses (core/DC, OOB/management VRF, or jump host with SNMP permitted).
+2. Point Prometheus at that exporter (`__address__` replacement). Use
+   `proxy_url` only if *Prometheus* needs an HTTP proxy to reach the exporter.
+3. Do not expect Zscaler (or similar) to “proxy SNMP” to switches/routers.
+
+If devices are only reachable over a VPN, run the exporter on a host that is
+joined to that VPN or management network.
+
+### Auth and modules
+
+Most switches/routers work with the built-in `if_mib` module. Start with a
+read-only SNMPv2c community (`public_v2` in the default config), then move to
+SNMPv3 where policy requires it.
+
+Extra auth definitions (custom community + SNMPv3) live in
+[`snmp-auth-samples.yml`](snmp-auth-samples.yml). Load them **in addition** to
+the default modules file so you do not hand-edit `snmp.yml`:
+
+```sh
+./snmp_exporter \
+  --config.file=snmp.yml \
+  --config.file=examples/sample-configs/snmp-auth-samples.yml \
+  --config.expand-environment-variables
+```
+
+`--config.expand-environment-variables` is only required when using the
+`${ENV_…}` placeholders in the SNMPv3 sample.
+
+Prometheus jobs: see [`prometheus-network-devices.yml`](prometheus-network-devices.yml).
+
+Manual checks:
+
+```sh
+# SNMPv2c (default public_v2)
+curl 'http://localhost:9116/snmp?target=192.0.2.10&auth=public_v2&module=if_mib'
+
+# Custom community from snmp-auth-samples.yml
+curl 'http://localhost:9116/snmp?target=192.0.2.10&auth=readonly_v2c&module=if_mib'
+
+# SNMPv3 authPriv (set env vars first; see snmp-auth-samples.yml)
+curl 'http://localhost:9116/snmp?target=192.0.2.10&auth=network_v3_authpriv&module=if_mib'
+
+# TCP transport / non-default port
+curl 'http://localhost:9116/snmp?target=tcp%3A%2F%2F192.0.2.10%3A1161&auth=public_v2&module=if_mib'
+```
+
+Vendor-specific modules (Cisco, Juniper, Arista, …) are listed in
+[`snmp.yml`](../../snmp.yml). Use them only when the device supports the
+underlying MIBs.
+
+## Scenario 3: Generator auth snippets
+
+When generating your own `snmp.yml`, define auths in `generator.yml` as
+documented in [generator/README.md](../../generator/README.md#file-format).
+Minimal examples:
+
+```yaml
+auths:
+  public_v2:
+    version: 2
+    community: public
+
+  readonly_v2c:
+    version: 2
+    community: readonly-community
+
+  network_v3_authpriv:
+    version: 3
+    username: snmp-ro
+    security_level: authPriv
+    password: auth-secret
+    auth_protocol: SHA
+    priv_protocol: AES
+    priv_password: priv-secret
+```
+
+Regenerate with the generator, then point the exporter at the produced
+`snmp.yml`. Prefer environment-variable expansion for secrets in production
+(see the main [README](../../README.md#prometheus-configuration)).
+
+## Files in this directory
+
+| File | Purpose |
+|------|---------|
+| [`snmp-auth-samples.yml`](snmp-auth-samples.yml) | Extra exporter auths (SNMPv2c + SNMPv3) |
+| [`prometheus-workstation.yml`](prometheus-workstation.yml) | Prometheus scrape job for a local agent |
+| [`prometheus-network-devices.yml`](prometheus-network-devices.yml) | Prometheus scrape jobs for network gear |
+
+Replace example community strings, usernames, passwords, and addresses before
+use in any shared environment.

--- a/examples/sample-configs/prometheus-network-devices.yml
+++ b/examples/sample-configs/prometheus-network-devices.yml
@@ -1,0 +1,77 @@
+# Prometheus scrape configuration for routers/switches.
+#
+# Architecture notes:
+#   * snmp_exporter must have direct SNMP (UDP/TCP 161) reachability to devices.
+#   * HTTP proxies such as Zscaler do not proxy SNMP. Run the exporter on a host
+#     in the management network / DC / VPN that can open SNMP to the gear.
+#   * Use proxy_url on a job only when Prometheus needs an HTTP proxy to reach
+#     the exporter itself — never as a substitute for SNMP access.
+#
+# Load custom auths if needed:
+#   ./snmp_exporter --config.file=snmp.yml \
+#     --config.file=examples/sample-configs/snmp-auth-samples.yml \
+#     --config.expand-environment-variables
+#
+# Merge the scrape_configs entries into your prometheus.yml. Replace example
+# addresses and auth names.
+
+scrape_configs:
+  # SNMPv2c read-only community (built-in public_v2 in default snmp.yml).
+  - job_name: snmp_network_v2c
+    static_configs:
+      - targets:
+          - 192.0.2.10          # example switch
+          - 192.0.2.11          # example router
+          - switch.example.local
+    metrics_path: /snmp
+    params:
+      auth: [public_v2]
+      module: [if_mib]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: snmp-exporter.example.local:9116
+
+  # SNMPv3 authPriv (requires network_v3_authpriv from snmp-auth-samples.yml
+  # and SNMP_AUTH_PASSWORD / SNMP_PRIV_PASSWORD in the exporter environment).
+  - job_name: snmp_network_v3
+    static_configs:
+      - targets:
+          - 192.0.2.20
+    metrics_path: /snmp
+    params:
+      auth: [network_v3_authpriv]
+      module: [if_mib]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: snmp-exporter.example.local:9116
+
+  # Optional: Prometheus reaches the exporter via a corporate HTTP proxy.
+  # SNMP from the exporter to devices remains direct (no proxy).
+  - job_name: snmp_network_via_http_proxy
+    proxy_url: http://proxy.example.local:80
+    static_configs:
+      - targets:
+          - 192.0.2.30
+    metrics_path: /snmp
+    params:
+      auth: [public_v2]
+      module: [if_mib]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: snmp-exporter.example.local:9116
+
+  - job_name: snmp_exporter
+    static_configs:
+      - targets: ["snmp-exporter.example.local:9116"]

--- a/examples/sample-configs/prometheus-workstation.yml
+++ b/examples/sample-configs/prometheus-workstation.yml
@@ -1,0 +1,52 @@
+# Prometheus scrape configuration for a local SNMP agent (developer workstation).
+#
+# Prerequisites:
+#   * snmp_exporter running with the default snmp.yml (modules if_mib, system, hr*).
+#   * Local SNMP agent reachable at 127.0.0.1:161 with a read-only community
+#     that matches the chosen auth (default public_v2 uses community "public").
+#
+# Merge the scrape_configs entries into your prometheus.yml.
+
+scrape_configs:
+  # Interface counters and status from IF-MIB.
+  - job_name: snmp_workstation_if
+    static_configs:
+      - targets:
+          - 127.0.0.1
+    metrics_path: /snmp
+    params:
+      auth: [public_v2]
+      module: [if_mib]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: 127.0.0.1:9116  # snmp_exporter listen address
+
+  # System + host-resources modules in one scrape (module concurrency configurable
+  # on the exporter via --snmp.module-concurrency).
+  - job_name: snmp_workstation_host
+    static_configs:
+      - targets:
+          - 127.0.0.1
+    metrics_path: /snmp
+    params:
+      auth: [public_v2]
+      module:
+        - system
+        - hrSystem
+        - hrStorage
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: 127.0.0.1:9116
+
+  # Exporter process metrics.
+  - job_name: snmp_exporter
+    static_configs:
+      - targets: ["127.0.0.1:9116"]

--- a/examples/sample-configs/snmp-auth-samples.yml
+++ b/examples/sample-configs/snmp-auth-samples.yml
@@ -1,0 +1,43 @@
+# Sample authentication blocks for snmp_exporter.
+#
+# Load alongside the default modules file, for example:
+#   ./snmp_exporter \
+#     --config.file=snmp.yml \
+#     --config.file=examples/sample-configs/snmp-auth-samples.yml \
+#     --config.expand-environment-variables
+#
+# Do not redefine auth names that already exist in snmp.yml (for example
+# public_v1 / public_v2). Use distinct names as below.
+#
+# Replace placeholder secrets before use. Prefer environment variables for
+# SNMPv3 credentials in production (--config.expand-environment-variables).
+
+auths:
+  # SNMPv2c with a non-default read-only community string.
+  readonly_v2c:
+    community: readonly-community
+    version: 2
+
+  # SNMPv3 without authentication or privacy (rarely appropriate outside labs).
+  network_v3_noauth:
+    version: 3
+    username: snmp-ro
+    security_level: noAuthNoPriv
+
+  # SNMPv3 authentication only.
+  network_v3_authnopriv:
+    version: 3
+    username: snmp-ro
+    security_level: authNoPriv
+    password: ${SNMP_AUTH_PASSWORD}
+    auth_protocol: SHA
+
+  # SNMPv3 authentication + privacy (recommended for production).
+  network_v3_authpriv:
+    version: 3
+    username: snmp-ro
+    security_level: authPriv
+    password: ${SNMP_AUTH_PASSWORD}
+    auth_protocol: SHA
+    priv_protocol: AES
+    priv_password: ${SNMP_PRIV_PASSWORD}


### PR DESCRIPTION
## Summary

Adds practical sample configurations under `examples/sample-configs` so developers can try common SNMP setups without inventing unsupported features.

Addresses #401:

1. **Workstation scenario** – how to enable a local SNMP agent (Linux `snmpd`, macOS alternatives) and scrape it with the default `if_mib` / `system` / `hr*` modules.
2. **Network devices scenario** – SNMPv2c and SNMPv3 scrape jobs for routers/switches, plus placement guidance for corporate environments.
3. **HTTP proxies / Zscaler** – documents that SNMP is not HTTP: proxies such as Zscaler do not carry SNMP; place `snmp_exporter` where devices are reachable, and use Prometheus `proxy_url` only for the Prometheus → exporter path when needed.
4. **Auth samples** – extra SNMPv2c/v3 auth blocks loadable alongside the default `snmp.yml` (distinct names so they do not clash with built-in `public_v2`).

Also links the new directory from the main README.

## Files

| Path | Purpose |
|------|---------|
| `examples/sample-configs/README.md` | Scenario guide |
| `examples/sample-configs/snmp-auth-samples.yml` | Extra exporter auths (v2c + v3) |
| `examples/sample-configs/prometheus-workstation.yml` | Local agent scrape jobs |
| `examples/sample-configs/prometheus-network-devices.yml` | Network gear scrape jobs |
| `README.md` | Link to samples |

## Test plan

- [x] YAML files parse cleanly
- [x] Auth sample names do not collide with default `public_v1` / `public_v2`
- [x] Docs only describe supported exporter/Prometheus knobs (modules, auths, transports, `proxy_url`, env expansion)
- [x] Maintainer review of wording and placement under `examples/`

Fixes #401

Signed-off-by: Dean Chen <862469039@qq.com>