### PR TITLE
Make generator retry to download MIB-s on all errors (4XX included)

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -15,7 +15,7 @@ MIBDIR   := mibs
 MIB_PATH := 'mibs'
 SNMP_YML ?= '../snmp.yml'
 
-CURL_OPTS ?= -L -sS --retry 3 --retry-delay 3 --fail
+CURL_OPTS ?= -L -sS --retry 3 --retry-delay 3 --fail --retry-all-errors
 CURL_USER_AGENT ?= -H "user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36 snmp_exporter/generator"
 
 REPO_TAG ?= $(shell git rev-parse --abbrev-ref HEAD)


### PR DESCRIPTION
When using the generator, some URL-s have defences on them and return 403 or whatever else errors. For example the PICO/NEC url-s. Therefore us `retry-all-errors` on curl to use the retry mechhanism on 4XX errors aswell. Default is only for 5XX.

