### PR TITLE
fix(generator): handle two InetAddress indexes sharing one InetAddressType

### DIFF
--- a/generator/tree.go
+++ b/generator/tree.go
@@ -408,10 +408,15 @@ func generateConfigModule(cfg *ModuleConfig, node *Node, nameToNode map[string]*
 
 				// Convert (InetAddressType,InetAddress) to (InetAddress)
 				if subtype, ok := combinedTypes[index.Type]; ok {
-					switch subtype {
-					case prevType:
+					switch {
+					case prevType == subtype:
 						metric.Indexes = metric.Indexes[:len(metric.Indexes)-1]
-					case prev2Type:
+					case prev2Type == subtype && combinedTypes[prevType] == subtype:
+						// The preceding index is itself a combined-type value (e.g. a second
+						// address sharing the same type field, as in (Type,Addr1,Addr2)). Its
+						// type field was already dropped when Addr1 was processed, so there is
+						// nothing left to remove for Addr2.
+					case prev2Type == subtype:
 						metric.Indexes = metric.Indexes[:len(metric.Indexes)-2]
 					default:
 						logger.Warn("Can't handle index type on node, missing preceding", "node", n.Label, "type", index.Type, "missing", subtype)

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -2094,6 +2094,86 @@ func TestGenerateConfigModule(t *testing.T) {
 				},
 			},
 		},
+		// Table with one InetAddressType shared by two InetAddress indexes.
+		// Both indexes become InetAddress, and the shared type is only dropped once.
+		{
+			node: &Node{
+				Oid: "1", Label: "root",
+				Children: []*Node{
+					{
+						Oid: "1.1", Label: "table",
+						Children: []*Node{
+							{
+								Oid: "1.1.1", Label: "tableEntry", Indexes: []string{"tableAddrType", "tableAddr1", "tableAddr2"},
+								Children: []*Node{
+									{Oid: "1.1.1.1", Access: "ACCESS_READONLY", Label: "tableAddrType", Type: "INTEGER", TextualConvention: "InetAddressType"},
+									{Oid: "1.1.1.2", Access: "ACCESS_READONLY", Label: "tableAddr1", Type: "OCTETSTR", TextualConvention: "InetAddress"},
+									{Oid: "1.1.1.3", Access: "ACCESS_READONLY", Label: "tableAddr2", Type: "OCTETSTR", TextualConvention: "InetAddress"},
+								},
+							},
+						},
+					},
+				},
+			},
+			cfg: &ModuleConfig{
+				Walk: []string{"1"},
+			},
+			out: &config.Module{
+				Walk: []string{"1"},
+				Metrics: []*config.Metric{
+					{
+						Name: "tableAddrType",
+						Oid:  "1.1.1.1",
+						Type: "gauge",
+						Help: " - 1.1.1.1",
+						Indexes: []*config.Index{
+							{
+								Labelname: "tableAddr1",
+								Type:      "InetAddress",
+							},
+							{
+								Labelname: "tableAddr2",
+								Type:      "InetAddress",
+							},
+						},
+					},
+					{
+						Name: "tableAddr1",
+						Oid:  "1.1.1.2",
+						Type: "InetAddress",
+						Help: " - 1.1.1.2",
+						Indexes: []*config.Index{
+							{
+								Labelname: "tableAddr1",
+								Type:      "InetAddress",
+							},
+							{
+								Labelname: "tableAddr2",
+								Type:      "InetAddress",
+							},
+						},
+					},
+					{
+						Name: "tableAddr2",
+						Oid:  "1.1.1.3",
+						// Not immediately preceded by an InetAddressType OID (that's
+						// tableAddr1's job), so its own value can't be decoded as InetAddress.
+						Type: "OctetString",
+						Help: " - 1.1.1.3",
+						Indexes: []*config.Index{
+							{
+								Labelname: "tableAddr1",
+								Type:      "InetAddress",
+							},
+							{
+								Labelname: "tableAddr2",
+								Type:      "InetAddress",
+							},
+						},
+					},
+				},
+			},
+		},
 		// Table with InetAddressType and InetAddress index in wrong order gets dropped.
 		{
 			node: &Node{


### PR DESCRIPTION
Motivation:
Some MIB tables use a single InetAddressType field to qualify two (or
more) subsequent InetAddress-typed index columns in the same row, e.g.
CISCO-IETF-IPMROUTE-MIB's cIpMRouteEntry:

    INDEX { cIpMRouteAddrType, cIpMRouteGroup, cIpMRouteSource, cIpMRouteSourceMask }

Generating a module that walks metrics from this table panics:

    panic: runtime error: slice bounds out of range [:-1]
        main.generateConfigModule.func2(...)
            generator/tree.go:415

Approach:
The index-collapsing logic in generateConfigModule combines a
(TypeField, AddressField) pair into a single index, and separately
(added in #782) collapses a 3-field (Afi, Safi, Address) pattern by
dropping the two preceding fields. When a second InetAddress field
immediately follows a first one that already consumed the shared
preceding InetAddressType, the code incorrectly fell into the
Afi/Safi/Address branch and tried to remove two elements from a slice
that only had one left.

The fix distinguishes "the preceding field is itself a sibling
combined-address value that already dropped the shared type" (nothing
left to remove) from the genuine Afi/Safi/Address case (drop two
fields), instead of always assuming the latter whenever the type is
found two positions back.

Validation:
Added a unit test in generator/tree_test.go covering a table with one
InetAddressType index followed by two InetAddress indexes, asserting
both become separate InetAddress-typed index labels without panicking.
Reproduced the original panic locally against the real
CISCO-IETF-IPMROUTE-MIB from the issue and confirmed the generator now
produces a snmp.yml with cIpMRouteGroup/cIpMRouteSource as separate
InetAddress indexes instead of crashing.

Ran:
  go test ./generator/... -run TestGenerateConfigModule -v   (PASS, 3/3 subtests)
  go build ./...                                              (OK)
  go test ./...                                               (all packages OK)

This only fixes the panic and the resulting metric loss for tables with
this index shape; it does not change behavior for tables the generator
already handled correctly.

Fixes #1218

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>