### PR TITLE
generator: map String64 textual convention to DisplayString

### DIFF
--- a/generator/tree.go
+++ b/generator/tree.go
@@ -122,7 +122,7 @@ func prepareTree(nodes *Node, logger *slog.Logger) map[string]*Node {
 		}
 		// Vendor MIBs (e.g. Dell iDRAC) often define String64 as an OCTET STRING
 		// textual convention for printable text without a DisplayString DISPLAY-HINT.
-		if n.TextualConvention == "String64" {
+		if n.TextualConvention == "String64" || n.TextualConvention == "StringType" {
 			n.Type = "DisplayString"
 		}
 		if n.TextualConvention == "PhysAddress" {

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -120,6 +120,11 @@ func prepareTree(nodes *Node, logger *slog.Logger) map[string]*Node {
 		if n.TextualConvention == "DisplayString" {
 			n.Type = "DisplayString"
 		}
+		// Vendor MIBs (e.g. Dell iDRAC) often define String64 as an OCTET STRING
+		// textual convention for printable text without a DisplayString DISPLAY-HINT.
+		if n.TextualConvention == "String64" {
+			n.Type = "DisplayString"
+		}
 		if n.TextualConvention == "PhysAddress" {
 			n.Type = "PhysAddress48"
 		}

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -147,6 +147,11 @@ func TestTreePrepare(t *testing.T) {
 			in:  &Node{Oid: "1", Label: "ascii", TextualConvention: "DisplayString"},
 			out: &Node{Oid: "1", Label: "ascii", TextualConvention: "DisplayString", Type: "DisplayString"},
 		},
+		// Vendor String64 TC (e.g. Dell MIBs) → DisplayString for readable labels.
+		{
+			in:  &Node{Oid: "1", Label: "vendorStr", Type: "OCTETSTR", TextualConvention: "String64"},
+			out: &Node{Oid: "1", Label: "vendorStr", Type: "DisplayString", TextualConvention: "String64"},
+		},
 		// PhysAddress referencing RFC1213.
 		{
 			in:  &Node{Oid: "1", Label: "mac", TextualConvention: "PhysAddress"},

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -152,6 +152,11 @@ func TestTreePrepare(t *testing.T) {
 			in:  &Node{Oid: "1", Label: "vendorStr", Type: "OCTETSTR", TextualConvention: "String64"},
 			out: &Node{Oid: "1", Label: "vendorStr", Type: "DisplayString", TextualConvention: "String64"},
 		},
+		// Dell also uses StringType the same way.
+		{
+			in:  &Node{Oid: "1", Label: "vendorStr2", Type: "OCTETSTR", TextualConvention: "StringType"},
+			out: &Node{Oid: "1", Label: "vendorStr2", Type: "DisplayString", TextualConvention: "StringType"},
+		},
 		// PhysAddress referencing RFC1213.
 		{
 			in:  &Node{Oid: "1", Label: "mac", TextualConvention: "PhysAddress"},


### PR DESCRIPTION
Vendor MIBs (Dell iDRAC in #1387) use a `String64` textual convention on OCTET STRING without a DisplayString DISPLAY-HINT, so the generator left them as octet strings and the exporter printed hex.

Map `String64` to `DisplayString` the same way we already handle the DisplayString TC.

Fixes #1387