### PR TITLE
Add type override ParseFloatString

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -595,6 +595,15 @@ func parseDateAndTimeWithPattern(metric *config.Metric, pdu *gosnmp.SnmpPDU, met
 	return float64(t.Unix()), nil
 }
 
+func parseFloatString(pdu *gosnmp.SnmpPDU, metrics Metrics) (float64, error) {
+	pduValue := pduValueAsString(pdu, "DisplayString", "", metrics)
+	f, err := strconv.ParseFloat(strings.TrimSpace(pduValue), 64)
+	if err != nil {
+		return 0, fmt.Errorf("error parsing string to float: %w", err)
+	}
+	return f, nil
+}
+
 func parseNtpTimestamp(pdu *gosnmp.SnmpPDU) (float64, error) {
 	data, ok := pdu.Value.([]byte)
 	if !ok {
@@ -649,6 +658,13 @@ func pduToSamples(indexOids []int, pdu *gosnmp.SnmpPDU, metric *config.Metric, o
 		value, err = parseDateAndTimeWithPattern(metric, pdu, metrics)
 		if err != nil {
 			logger.Debug("Error parsing ParseDateAndTime", "err", err)
+			return []prometheus.Metric{}
+		}
+	case "ParseFloatString":
+		t = prometheus.GaugeValue
+		value, err = parseFloatString(pdu, metrics)
+		if err != nil {
+			logger.Debug("Error parsing ParseFloatString", "err", err)
 			return []prometheus.Metric{}
 		}
 	case "NTPTimeStamp":

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -978,6 +978,43 @@ func TestParseDateAndTimeWithPattern(t *testing.T) {
 	}
 }
 
+func TestParseFloatString(t *testing.T) {
+	cases := []struct {
+		pdu       *gosnmp.SnmpPDU
+		metric    config.Metric
+		result    float64
+		shouldErr bool
+	}{
+		{
+			pdu:       &gosnmp.SnmpPDU{Value: "3.14159"},
+			result:    3.14159,
+			shouldErr: false,
+		},
+		{
+			pdu:       &gosnmp.SnmpPDU{Value: " 3.14159 "},
+			result:    3.14159,
+			shouldErr: false,
+		},
+		{
+			pdu:       &gosnmp.SnmpPDU{Value: "ABC"},
+			result:    0,
+			shouldErr: true,
+		},
+	}
+	for _, c := range cases {
+		got, err := parseFloatString(c.pdu, Metrics{})
+		if c.shouldErr && err == nil {
+			t.Fatalf("Was expecting error, but none returned.")
+		}
+		if !c.shouldErr && err != nil {
+			t.Fatalf("Was expecting no error, but one returned.")
+		}
+		if !reflect.DeepEqual(got, c.result) {
+			t.Errorf("parseFloatString(%v) result: got %v, want %v", c.pdu, got, c.result)
+		}
+	}
+}
+
 // Every type listed as renderable must be handled by indexOidsAsString
 // rather than hitting its unknown-type panic.
 func TestRenderableIndexTypes(t *testing.T) {

--- a/generator/README.md
+++ b/generator/README.md
@@ -181,6 +181,7 @@ modules:
                              #   OctetString: A bit string, rendered as 0xff34.
                              #   DateAndTime: An RFC 2579 DateAndTime byte sequence. If the device has no time zone data, UTC is used.
                              #   ParseDateAndTime: Parse a DisplayString and return the timestamp. See datetime_pattern config option
+                             #   ParseFloatString: Parse the value as a DisplayString and return the float64 value.
                              #   NTPTimeStamp: Parse the NTP timestamp (RFC-1305, March 1992, Section 3.1) and return Unix timestamp as float.
                              #   DisplayString: An ASCII or UTF-8 string.
                              #   PhysAddress48: A 48 bit MAC address, rendered as 00:01:02:03:04:ff.

--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -152,103 +152,39 @@ modules:
       - DELL-RAC-MIB::drsCMCPSUTable
     overrides:
       drsKWhCumulativeTime:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsMaxPowerSpecification:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsPotentialPower:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsPowerSurplus:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsIdlePower:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsAmpsReading:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsKWhCumulative:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsPSULocation:
         type: DisplayString
       drsPSUAmpsReading:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsPSUWattsReading:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsPSUVoltsReading:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsWattsMinTime:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsWattsMinUsage:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsWattsPeakTime:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsWattsReading:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsWattsPeakUsage:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
       drsWattsResetTime:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '(.*)'
-              value: '$1'
+        type: ParseFloatString
 
 # Dell network (Force10)
   dell_network:
@@ -1212,15 +1148,9 @@ modules:
       pduLocation:
         ignore: true # Lookup metric
       pduMainLoadAmp:
-        regex_extracts:
-          '':
-            - regex: '(.*)(.)'
-              value: '$1.$2'
+        type: ParseFloatString
       pduMainLoadVoltage:
-        regex_extracts:
-          '':
-            - regex: '(.*)(.)'
-              value: '$1.$2'
+        type: ParseFloatString
       pduMainActivePower:
         regex_extracts:
           '':
@@ -1452,11 +1382,7 @@ modules:
         lookup: "IF-MIB::ifName"
     overrides:
       ddmStatusBiasCurrent:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '^(\d+\.\d+).*'
-              value: '$1'
+        type: ParseFloatString
       ddmStatusLossSignal:
         type: DisplayString
         regex_extracts:
@@ -1466,17 +1392,9 @@ modules:
             - regex: 'True'
               value: '1'
       ddmStatusRxPow:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '^(\d+\.\d+).*'
-              value: '$1'
+        type: ParseFloatString
       ddmStatusTemperature:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '^(\d+\.\d+).*'
-              value: '$1'
+        type: ParseFloatString
       ddmStatusTxFault:
         type: DisplayString
         regex_extracts:
@@ -1486,17 +1404,9 @@ modules:
             - regex: 'True'
               value: '1'
       ddmStatusTxPow:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '^(\d+\.\d+).*'
-              value: '$1'
+        type: ParseFloatString
       ddmStatusVoltage:
-        type: DisplayString
-        regex_extracts:
-          '':
-            - regex: '^(\d+\.\d+).*'
-              value: '$1'
+        type: ParseFloatString
   cisco_imc:
     walk:
       - 1.3.6.1.4.1.9.9.719.1.45.1.1.6  #cucsStorageControllerOperState

--- a/generator/tree.go
+++ b/generator/tree.go
@@ -139,6 +139,9 @@ func prepareTree(nodes *Node, logger *slog.Logger) map[string]*Node {
 		if n.TextualConvention == "NTPTimeStamp" {
 			n.Type = "NTPTimeStamp"
 		}
+		if n.TextualConvention == "ParseFloatString" {
+			n.Type = "ParseFloatString"
+		}
 		// Convert RFC 4001 InetAddress types textual convention to type.
 		if n.TextualConvention == "InetAddressIPv4" || n.TextualConvention == "InetAddressIPv6" || n.TextualConvention == "InetAddress" {
 			n.Type = n.TextualConvention
@@ -172,6 +175,8 @@ func metricType(t string) (string, bool) {
 	case "DateAndTime":
 		return t, true
 	case "ParseDateAndTime":
+		return t, true
+	case "ParseFloatString":
 		return t, true
 	case "NTPTimeStamp":
 		return t, true

--- a/generator/tree_test.go
+++ b/generator/tree_test.go
@@ -181,6 +181,11 @@ func TestTreePrepare(t *testing.T) {
 			in:  &Node{Oid: "1", Type: "DisplayString", TextualConvention: "ParseDateAndTime"},
 			out: &Node{Oid: "1", Type: "ParseDateAndTime", TextualConvention: "ParseDateAndTime"},
 		},
+		// ParseFloatString
+		{
+			in:  &Node{Oid: "1", Type: "DisplayString", TextualConvention: "ParseFloatString"},
+			out: &Node{Oid: "1", Type: "ParseFloatString", TextualConvention: "ParseFloatString"},
+		},
 		// RFC 4100 InetAddress conventions.
 		{
 			in:  &Node{Oid: "1", Type: "OctectString", TextualConvention: "InetAddressIPv4"},
@@ -403,6 +408,7 @@ func TestGenerateConfigModule(t *testing.T) {
 					{Oid: "1.204", Access: "ACCESS_READONLY", Label: "InetAddressIPv6", Type: "OCTETSTR", TextualConvention: "InetAddressIPv6"},
 					{Oid: "1.205", Access: "ACCESS_READONLY", Label: "ParseDateAndTime", Type: "DisplayString", TextualConvention: "ParseDateAndTime"},
 					{Oid: "1.206", Access: "ACCESS_READONLY", Label: "NTPTimeStamp", Type: "NTPTimeStamp", TextualConvention: "NTPTimeStamp"},
+					{Oid: "1.207", Access: "ACCESS_READONLY", Label: "ParseFloatString", Type: "ParseFloatString", TextualConvention: "ParseFloatString"},
 				},
 			},
 			cfg: &ModuleConfig{
@@ -536,6 +542,12 @@ func TestGenerateConfigModule(t *testing.T) {
 						Oid:  "1.206",
 						Type: "NTPTimeStamp",
 						Help: " - 1.206",
+					},
+					{
+						Name: "ParseFloatString",
+						Oid:  "1.207",
+						Type: "ParseFloatString",
+						Help: " - 1.207",
 					},
 				},
 			},

--- a/snmp.yml
+++ b/snmp.yml
@@ -14457,7 +14457,7 @@ modules:
         fixed_size: 1
     - name: drsPotentialPower
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.2
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0002 This attribute defines the power (in Watts) required
         by the chassis infrastructure, plus the sum of the maximum power requirements
         for all currently powered-on servers. - 1.3.6.1.4.1.674.10892.2.4.1.1.2
@@ -14465,13 +14465,9 @@ modules:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsIdlePower
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.3
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0003 This attribute defines the power (in Watts) required
         by the chassis infrastructure, plus the sum of the minimum power requirements
         for all currently powered-on servers. - 1.3.6.1.4.1.674.10892.2.4.1.1.3
@@ -14479,153 +14475,105 @@ modules:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsMaxPowerSpecification
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.4
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0004 This attribute defines the power limit (in Watts)
         at which server throttling will take place. - 1.3.6.1.4.1.674.10892.2.4.1.1.4
       indexes:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsPowerSurplus
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.5
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0005 This attribute defines the power surplus (in Watts)
         remaining above the drsPotentialPower reading. - 1.3.6.1.4.1.674.10892.2.4.1.1.5
       indexes:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsKWhCumulative
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.6
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0006 This attribute defines the cumulative chassis power
         usage (in KWh) since last reset. - 1.3.6.1.4.1.674.10892.2.4.1.1.6
       indexes:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsKWhCumulativeTime
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.7
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0007 This attribute defines the timestamp of the most recent
         chassis power accumulator reset. - 1.3.6.1.4.1.674.10892.2.4.1.1.7
       indexes:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsWattsPeakUsage
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.8
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0008 This attribute defines the chassis peak power usage
         (in Watts) since last reset. - 1.3.6.1.4.1.674.10892.2.4.1.1.8
       indexes:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsWattsPeakTime
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.9
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0009 This attribute defines the timestamp of the most recent
         chassis peak power usage. - 1.3.6.1.4.1.674.10892.2.4.1.1.9
       indexes:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsWattsMinUsage
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.10
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0010 This attribute defines the chassis mimimum power usage
         (in Watts) since last reset. - 1.3.6.1.4.1.674.10892.2.4.1.1.10
       indexes:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsWattsMinTime
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.11
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0011 This attribute defines the timestamp of the most recent
         chassis minimum power usage. - 1.3.6.1.4.1.674.10892.2.4.1.1.11
       indexes:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsWattsResetTime
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.12
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0012 This attribute defines the timestamp of the most recent
         reset of the chassis min/peak Watts readings. - 1.3.6.1.4.1.674.10892.2.4.1.1.12
       indexes:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsWattsReading
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.13
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0013 This attribute defines the instantaneous chassis power
         usage (in Watts). - 1.3.6.1.4.1.674.10892.2.4.1.1.13
       indexes:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsAmpsReading
       oid: 1.3.6.1.4.1.674.10892.2.4.1.1.14
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0001.0001.0014 This attribute defines the instantaneous chassis current
         usage (in Watts). - 1.3.6.1.4.1.674.10892.2.4.1.1.14
       indexes:
       - labelname: drsChassisIndex
         type: gauge
         fixed_size: 1
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsPSUChassisIndex
       oid: 1.3.6.1.4.1.674.10892.2.4.2.1.1
       type: gauge
@@ -14676,7 +14624,7 @@ modules:
         3: basic
     - name: drsPSUVoltsReading
       oid: 1.3.6.1.4.1.674.10892.2.4.2.1.5
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0002.0001.0005 This attribute defines the instantaneous PSU Voltage
         reading. - 1.3.6.1.4.1.674.10892.2.4.2.1.5
       indexes:
@@ -14685,13 +14633,9 @@ modules:
         fixed_size: 1
       - labelname: drsPSUIndex
         type: gauge
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsPSUAmpsReading
       oid: 1.3.6.1.4.1.674.10892.2.4.2.1.6
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0002.0001.0006 This attribute defines the instantaneous PSU Current
         reading. - 1.3.6.1.4.1.674.10892.2.4.2.1.6
       indexes:
@@ -14700,13 +14644,9 @@ modules:
         fixed_size: 1
       - labelname: drsPSUIndex
         type: gauge
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
     - name: drsPSUWattsReading
       oid: 1.3.6.1.4.1.674.10892.2.4.2.1.7
-      type: DisplayString
+      type: ParseFloatString
       help: 0004.0002.0001.0007 This attribute defines the instantaneous PSU Wattage
         reading. - 1.3.6.1.4.1.674.10892.2.4.2.1.7
       indexes:
@@ -14715,10 +14655,6 @@ modules:
         fixed_size: 1
       - labelname: drsPSUIndex
         type: gauge
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:(.*))$
   dlink:
     walk:
     - 1.3.6.1.4.1.171.12.1.1.6
@@ -24345,7 +24281,7 @@ modules:
     metrics:
     - name: pduMainLoadVoltage
       oid: 1.3.6.1.4.1.34550.20.2.1.1.1.13
-      type: DisplayString
+      type: ParseFloatString
       help: The voltage measured on this PDU in tenth of Volts - 1.3.6.1.4.1.34550.20.2.1.1.1.13
       indexes:
       - labelname: pduIndex
@@ -24361,13 +24297,9 @@ modules:
         labelname: pduLocation
         oid: 1.3.6.1.4.1.34550.20.2.1.1.1.7
         type: DisplayString
-      regex_extracts:
-        "":
-        - value: $1.$2
-          regex: ^(?:(.*)(.))$
     - name: pduMainLoadAmp
       oid: 1.3.6.1.4.1.34550.20.2.1.1.1.14
-      type: DisplayString
+      type: ParseFloatString
       help: The current load measured on this PDU in tenth of Amps - 1.3.6.1.4.1.34550.20.2.1.1.1.14
       indexes:
       - labelname: pduIndex
@@ -24383,10 +24315,6 @@ modules:
         labelname: pduLocation
         oid: 1.3.6.1.4.1.34550.20.2.1.1.1.7
         type: DisplayString
-      regex_extracts:
-        "":
-        - value: $1.$2
-          regex: ^(?:(.*)(.))$
     - name: pduMainActivePower
       oid: 1.3.6.1.4.1.34550.20.2.1.1.1.17
       type: DisplayString
@@ -60163,7 +60091,7 @@ modules:
     metrics:
     - name: ddmStatusTemperature
       oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.2
-      type: DisplayString
+      type: ParseFloatString
       help: This object indicates the temperature of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.2
       indexes:
       - labelname: ifIndex
@@ -60179,13 +60107,9 @@ modules:
         labelname: ifName
         oid: 1.3.6.1.2.1.31.1.1.1.1
         type: DisplayString
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:^(\d+\.\d+).*)$
     - name: ddmStatusVoltage
       oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.3
-      type: DisplayString
+      type: ParseFloatString
       help: This object indicates the voltage of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.3
       indexes:
       - labelname: ifIndex
@@ -60201,13 +60125,9 @@ modules:
         labelname: ifName
         oid: 1.3.6.1.2.1.31.1.1.1.1
         type: DisplayString
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:^(\d+\.\d+).*)$
     - name: ddmStatusBiasCurrent
       oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.4
-      type: DisplayString
+      type: ParseFloatString
       help: This object indicates the bias current of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.4
       indexes:
       - labelname: ifIndex
@@ -60223,13 +60143,9 @@ modules:
         labelname: ifName
         oid: 1.3.6.1.2.1.31.1.1.1.1
         type: DisplayString
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:^(\d+\.\d+).*)$
     - name: ddmStatusTxPow
       oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.5
-      type: DisplayString
+      type: ParseFloatString
       help: This object indicates the tx power of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.5
       indexes:
       - labelname: ifIndex
@@ -60245,13 +60161,9 @@ modules:
         labelname: ifName
         oid: 1.3.6.1.2.1.31.1.1.1.1
         type: DisplayString
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:^(\d+\.\d+).*)$
     - name: ddmStatusRxPow
       oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.6
-      type: DisplayString
+      type: ParseFloatString
       help: This object indicates the rx power of the port. - 1.3.6.1.4.1.11863.6.96.1.7.1.1.6
       indexes:
       - labelname: ifIndex
@@ -60267,10 +60179,6 @@ modules:
         labelname: ifName
         oid: 1.3.6.1.2.1.31.1.1.1.1
         type: DisplayString
-      regex_extracts:
-        "":
-        - value: $1
-          regex: ^(?:^(\d+\.\d+).*)$
     - name: ddmStatusLossSignal
       oid: 1.3.6.1.4.1.11863.6.96.1.7.1.1.8
       type: DisplayString


### PR DESCRIPTION
Add a new custom type override, `ParseFloatString` that allows simplifying the trivial "OCTET STRING is a number in ascci text" cases that typically reqiure a more complicated `regex_extracts` expression.
* Apply `ParseFloatString` to a number of generator.yml examples.