### PR TITLE
config: expand environment variables in the community field

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,13 @@ func LoadFile(logger *slog.Logger, paths []string, expandEnvVars bool) (*Config,
 	if expandEnvVars {
 		var err error
 		for i, auth := range cfg.Auths {
+			if auth.Community != "" {
+				community, err := substituteEnvVariables(string(auth.Community))
+				if err != nil {
+					return nil, err
+				}
+				cfg.Auths[i].Community.Set(community)
+			}
 			if auth.Username != "" {
 				cfg.Auths[i].Username, err = substituteEnvVariables(auth.Username)
 				if err != nil {

--- a/config_test.go
+++ b/config_test.go
@@ -80,6 +80,7 @@ func TestLoadMultipleConfigs(t *testing.T) {
 
 // When all environment variables are present
 func TestEnvSecrets(t *testing.T) {
+	t.Setenv("ENV_COMMUNITY", "mysecret")
 	t.Setenv("ENV_USERNAME", "username") // snmp_ prefix is set in config file
 	t.Setenv("ENV_PASSWORD", "snmp_password")
 	t.Setenv("ENV_PRIV_PASSWORD", "snmp_priv_password")
@@ -104,7 +105,7 @@ func TestEnvSecrets(t *testing.T) {
 
 	// we check whether vars we set are resolved correctly in config
 	for i := range sc.C.Auths {
-		if sc.C.Auths[i].Username != "snmp_username" || sc.C.Auths[i].Password != "snmp_password" || sc.C.Auths[i].PrivPassword != "snmp_priv_password" {
+		if sc.C.Auths[i].Community != "mysecret" || sc.C.Auths[i].Username != "snmp_username" || sc.C.Auths[i].Password != "snmp_password" || sc.C.Auths[i].PrivPassword != "snmp_priv_password" {
 			t.Fatal("failed to resolve secrets from env vars")
 		}
 	}
@@ -112,6 +113,7 @@ func TestEnvSecrets(t *testing.T) {
 
 // When environment variable(s) are absent
 func TestEnvSecretsMissing(t *testing.T) {
+	t.Setenv("ENV_COMMUNITY", "mysecret")
 	t.Setenv("ENV_PASSWORD", "snmp_password")
 	t.Setenv("ENV_PRIV_PASSWORD", "snmp_priv_password")
 
@@ -132,6 +134,7 @@ func TestEnvSecretsMissing(t *testing.T) {
 
 // When environment variables are present but set to empty values.
 func TestEnvSecretsEmpty(t *testing.T) {
+	t.Setenv("ENV_COMMUNITY", "")
 	t.Setenv("ENV_USERNAME", "")
 	t.Setenv("ENV_PASSWORD", "")
 	t.Setenv("ENV_PRIV_PASSWORD", "")
@@ -143,7 +146,7 @@ func TestEnvSecretsEmpty(t *testing.T) {
 	}
 
 	for i := range sc.C.Auths {
-		if sc.C.Auths[i].Username != "snmp_" || sc.C.Auths[i].Password != "" || sc.C.Auths[i].PrivPassword != "" {
+		if sc.C.Auths[i].Community != "" || sc.C.Auths[i].Username != "snmp_" || sc.C.Auths[i].Password != "" || sc.C.Auths[i].PrivPassword != "" {
 			t.Fatal("failed to resolve empty env vars")
 		}
 	}

--- a/testdata/snmp-auth-envvars.yml
+++ b/testdata/snmp-auth-envvars.yml
@@ -1,6 +1,6 @@
 auths:
   with_secret:
-    community: mysecret
+    community: ${ENV_COMMUNITY}
     security_level: SomethingReadOnly
     username: snmp_${ENV_USERNAME}
     password: ${ENV_PASSWORD}


### PR DESCRIPTION
## Problem

`--config.expand-environment-variables` substitutes environment variables in the auth `username`, `password`, and `priv_password` fields, but **not** in `community`. So a config like:

```yaml
auths:
  my_v2c:
    version: 2
    community: ${SNMP_COMMUNITY}
```

passes the literal string `${SNMP_COMMUNITY}` to the device as the community. The SNMPv2c agent silently drops the request and the scrape fails with:

```
error getting target <ip>: request timeout (after 3 retries)
```

This is easy to misdiagnose as a network/timeout problem, especially since the same flag correctly sources SNMPv3 secrets from the environment — so v3 targets work while v2c targets time out, using the identical mechanism.

## Fix

Expand `community` alongside the other secret-bearing auth fields in `config.LoadFile` (it is already a `config.Secret`, so this mirrors the existing `password` handling exactly).

## Testing

Extended the existing `TestEnvSecrets` / `TestEnvSecretsMissing` / `TestEnvSecretsEmpty` cases (and the `snmp-auth-envvars.yml` fixture) to source `community` from `${ENV_COMMUNITY}` and assert it resolves. The fixture's community value doubles as the secret-masking canary, so this also verifies `community` is still redacted by the `String()` method.

Verified against live hardware (two Juniper EX switches via SNMPv2c): before the patch, `${VAR}` communities time out after 3 retries; after, both switches scrape successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)