### PR TITLE
Make the Synology diskIndex metric an info metric

### DIFF
--- a/generator/generator.yml
+++ b/generator/generator.yml
@@ -792,6 +792,8 @@ modules:
         lookup: raidName
         drop_source_indexes: true
     overrides:
+      SYNOLOGY-DISK-MIB::diskIndex:
+        type: DisplayString
       SYNOLOGY-DISK-MIB::diskModel:
         type: DisplayString
       SYNOLOGY-DISK-MIB::diskType:


### PR DESCRIPTION
The contributers docs say to at a contributor, so here: @SuperQ

When using the default configuration extracted by the config generator for a Synology NAS I get something like the following metrics (among many others):

```
# HELP diskIndex The index of disk table - 1.3.6.1.4.1.6574.2.1.1.1
# TYPE diskIndex gauge
diskIndex{diskID="0x1234567890AB1"} 0
diskIndex{diskID="0x1234567890AB2"} 2
diskIndex{diskID="0x1234567890AB3"} 5
diskIndex{diskID="0x1234567890AB4"} 7
diskIndex{diskID="0x1234567890AB5"} 1
diskIndex{diskID="0x1234567890AB6"} 3
diskIndex{diskID="0x1234567890AB7"} 4
diskIndex{diskID="0x1234567890AB8"} 6
```

I hope the index corresponds to the physical slot of the NAS the disk is in. This would be essential in determining which disk is failing should a `diskHealthStatus` / `diskStatus` metric report the `diskID` as being non-nominal. However, this metric having this index as a metric value instead as a label, makes it really hard to do a proper join. Ideally, this index should be a label with the value being `1` allowing an easy join (especially with the new (still experimental) `info` function in Prometheus.

As far as I can tell, there is no way at query time to rewrite a metric value to a label, so the only way I've been able to join is something like:

```
diskHealth + on(diskID) (diskIndex == 3 * 0)
```

Which would get the 4th slot's disk Health. But this requires a query per slot which is less than ideal.

This change makes the metrics look like:

```
# HELP diskIndex The index of disk table - 1.3.6.1.4.1.6574.2.1.1.1
# TYPE diskIndex gauge
diskIndex{diskID="0x1234567890AB1",diskIndex="0"} 1
diskIndex{diskID="0x1234567890AB2",diskIndex="2"} 1
diskIndex{diskID="0x1234567890AB3",diskIndex="5"} 1
diskIndex{diskID="0x1234567890AB4",diskIndex="7"} 1
diskIndex{diskID="0x1234567890AB5",diskIndex="1"} 1
diskIndex{diskID="0x1234567890AB6",diskIndex="3"} 1
diskIndex{diskID="0x1234567890AB7",diskIndex="4"} 1
diskIndex{diskID="0x1234567890AB8",diskIndex="6"} 1
```

This will make joining much easier.

N.B. The verbosity of this post is not due to AI but because this started as a discussion post, but as I was writing it I realized it could be turned into a PR.