### PR TITLE
generator: add missing Synology system metrics

### DIFF
--- a/generator/Makefile
+++ b/generator/Makefile
@@ -358,6 +358,9 @@ $(MIBDIR)/.synology:
 	@curl $(CURL_OPTS) -o $(TMP) $(SYNOLOGY_URL)
 	@unzip -j -d $(MIBDIR) $(TMP)
 	@patch mibs/SYNOLOGY-SMART-MIB.txt mib-patches/SYNOLOGY-SMART-MIB.0.patch
+	# Add cpuUtilization, memUtilization and thermalStatus, documented in the MIB
+	# Guide but missing from the published MIB download.
+	@patch mibs/SYNOLOGY-SYSTEM-MIB.txt mib-patches/SYNOLOGY-SYSTEM-MIB.0.patch
 	@rm -v $(TMP)
 	@touch $(MIBDIR)/.synology
 

--- a/generator/mib-patches/SYNOLOGY-SYSTEM-MIB.0.patch
+++ b/generator/mib-patches/SYNOLOGY-SYSTEM-MIB.0.patch
@@ -1,0 +1,40 @@
+--- SYNOLOGY-SYSTEM-MIB.txt.orig
++++ mibs/SYNOLOGY-SYSTEM-MIB.txt
+@@ -134,7 +134,36 @@
+     ::= { synoSystem 6 }
+ 
+ 
+-systemConformance OBJECT IDENTIFIER ::= { synoSystem 7 }
++cpuUtilization OBJECT-TYPE
++    SYNTAX      Integer32
++    MAX-ACCESS  read-only
++    STATUS      current
++    DESCRIPTION
++    "Synology CPU utilization.
++     Utilization (%) is the sum of user and system CPU usage."
++    ::= { synoSystem 7 1 }
++
++memUtilization OBJECT-TYPE
++    SYNTAX      Integer32
++    MAX-ACCESS  read-only
++    STATUS      current
++    DESCRIPTION
++    "Synology memory utilization.
++     Utilization (%) is the sum of memory usage."
++    ::= { synoSystem 7 2 }
++
++thermalStatus OBJECT-TYPE
++    SYNTAX      Integer32(1..2)
++    MAX-ACCESS  read-only
++    STATUS      current
++    DESCRIPTION
++    "Synology thermal status.
++     Normal(1): Thermal status functions normally.
++     Failed(2): Thermal status is abnormal."
++    ::= { synoSystem 8 }
++
++
++systemConformance OBJECT IDENTIFIER ::= { synoSystem 9 }
+ systemCompliances OBJECT IDENTIFIER ::= { systemConformance 1 }
+ systemGroups 			OBJECT IDENTIFIER ::= { systemConformance 2 }
+ 

--- a/snmp.yml
+++ b/snmp.yml
@@ -58625,6 +58625,18 @@ modules:
       oid: 1.3.6.1.4.1.6574.1.6
       type: gauge
       help: Synology system controller number Controller A(0) Controller B(1) - 1.3.6.1.4.1.6574.1.6
+    - name: cpuUtilization
+      oid: 1.3.6.1.4.1.6574.1.7.1
+      type: gauge
+      help: Synology CPU utilization - 1.3.6.1.4.1.6574.1.7.1
+    - name: memUtilization
+      oid: 1.3.6.1.4.1.6574.1.7.2
+      type: gauge
+      help: Synology memory utilization - 1.3.6.1.4.1.6574.1.7.2
+    - name: thermalStatus
+      oid: 1.3.6.1.4.1.6574.1.8
+      type: gauge
+      help: Synology thermal status - 1.3.6.1.4.1.6574.1.8
     - name: storageIOIndex
       oid: 1.3.6.1.4.1.6574.101.1.1.1
       type: gauge


### PR DESCRIPTION
## Summary

Adds `cpuUtilization`, `memUtilization` and `thermalStatus` to the `synology`
module by patching the stale Synology-supplied MIB.

## Background

The `synology` module already walks `SYNOLOGY-SYSTEM-MIB::synoSystem`
(`1.3.6.1.4.1.6574.1`), so these OIDs are requested from the device and the
device answers. They are dropped because the MIB the generator downloads does
not define them: `Synology_MIB_File.zip` ships a `SYNOLOGY-SYSTEM-MIB.txt` with
`LAST-UPDATED "201309110000Z"` that stops at `synoSystem 6` and puts
`systemConformance` at `.7`. With no definition, the generator emits no
`metrics` entry and the exporter discards the returned values.

The objects are documented in the official
[Synology DiskStation MIB Guide](https://global.download.synology.com/download/Document/Software/DeveloperGuide/Firmware/DSM/All/enu/Synology_DiskStation_MIB_Guide.pdf)
(updated 2025-03-25), Table 3-2:

| OID | Name | Type | Documented meaning |
|---|---|---|---|
| `.7.1` | `cpuUtilization` | Integer | Utilization (%), sum of user and system CPU usage |
| `.7.2` | `memUtilization` | Integer | Utilization (%), sum of memory usage |
| `.8` | `thermalStatus` | Integer | Normal(1) / Failed(2) |

## Why this layer

The fix belongs at the MIB source, not in `generator.yml`: `generator.yml` is
correct as-is, and an override cannot conjure objects the MIB never declares.
`SYNOLOGY_URL` still resolves and serves the current archive — Synology simply
does not ship these objects in it; they exist only in the MIB Guide. Every
public mirror I checked (LibreNMS and others) carries the same 2013 revision,
so switching sources does not help either.

## Prior art

This follows #1574, which patched `SYNOLOGY-SMART-MIB` in the same make target
for the same reason: the object is documented by Synology but absent from the
published MIB archive.

One difference worth calling out: #1574 was purely additive, while this patch
also moves `systemConformance` from `synoSystem 7` to `synoSystem 9`. That is
needed because `systemCompliances` (`{ systemConformance 1 }`) would otherwise
claim `1.3.6.1.4.1.6574.1.7.1` — the same OID as `cpuUtilization` — and because
`.7` is the utilization subtree in current firmware per the MIB Guide.

The move has no effect on the generated output: generating with and without it
produces a byte-identical `snmp.yml`, and neither variant raises a parse error.
Conformance nodes carry no data.

## Changes

- **`generator/mib-patches/SYNOLOGY-SYSTEM-MIB.0.patch`** (new): declares the
  three objects with the types and descriptions from the MIB Guide, and
  relocates `systemConformance` as described above.
- **`generator/Makefile`**: applies the patch in the `.synology` target, next to
  the existing SMART patch.
- **`snmp.yml`**: regenerated.

## Verification

Verified end-to-end against a live DSM 7.3 instance (SNMPv3):

```
$ snmpwalk -On <nas> 1.3.6.1.4.1.6574.1
.1.3.6.1.4.1.6574.1.7.1.0 = INTEGER: 9
.1.3.6.1.4.1.6574.1.7.2.0 = INTEGER: 20

$ curl 'localhost:9116/snmp?module=synology&target=<nas>'
cpuUtilization 13
memUtilization 20
```

Before this change, 2 of the 10 OIDs the device returns under
`1.3.6.1.4.1.6574.1` had no metric entry and were dropped; with it, all 10 are
covered.

The instance is VirtualDSM, which does not expose `thermalStatus` —
consistently with `temperature` (`.2`) and `controllerNumber` (`.6`), which it
also omits, as those are physical sensors. `thermalStatus` is taken from the MIB
Guide and would benefit from confirmation on physical hardware.

Also checked:

- `make mibs/.synology` from a clean state: fresh download, both patches apply
  cleanly.
- `make generate`: `module=synology metrics=213` (was 210), no Synology parse
  warnings; running it twice produces no further diff.
- `snmp_exporter --config.file=snmp.yml --dry-run`: parses successfully.
- `go test ./config/... ./scraper/... .`: all pass.

## Generated metrics

```yaml
- name: cpuUtilization
  oid: 1.3.6.1.4.1.6574.1.7.1
  type: gauge
  help: Synology CPU utilization - 1.3.6.1.4.1.6574.1.7.1
- name: memUtilization
  oid: 1.3.6.1.4.1.6574.1.7.2
  type: gauge
  help: Synology memory utilization - 1.3.6.1.4.1.6574.1.7.2
- name: thermalStatus
  oid: 1.3.6.1.4.1.6574.1.8
  type: gauge
  help: Synology thermal status - 1.3.6.1.4.1.6574.1.8
```

`thermalStatus` is generated as a plain `gauge`, consistent with every other
Synology status object (`systemStatus`, `powerStatus`, `systemFanStatus`,
`cpuFanStatus` are all `Integer32(1..2)` gauges). No override is added, since
the generated type already matches its siblings.

@SuperQ — flagging you as the author of #1574, since this extends the same
approach in the same make target.