### PR TITLE
Keep the whole table index when caching dynamic filter matches

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -209,13 +209,29 @@ func filterAllowedIndices(logger *slog.Logger, filter config.DynamicFilter, pdus
 			}
 		}
 		if found {
-			pduArray := strings.Split(pdu.Name, ".")
-			index := pduArray[len(pduArray)-1]
+			index := indexFromOID(pdu.Name, filter.Oid)
+			if index == "" {
+				logger.Debug("Skipping PDU that is not under the filter OID", "oid", pdu.Name, "filter oid", filter.Oid)
+				continue
+			}
 			logger.Debug("Caching index", "index", index)
 			allowedList = append(allowedList, index)
 		}
 	}
 	return allowedList
+}
+
+// indexFromOID returns the table index carried by a PDU name, which is every
+// sub-identifier after the filter's own OID. Keeping only the last one drops
+// the rest of a composite index, so addAllowedIndices then builds a GET for an
+// OID that does not exist and the target metric goes missing.
+func indexFromOID(name, filterOID string) string {
+	name = strings.TrimPrefix(name, ".")
+	filterOID = strings.TrimPrefix(filterOID, ".")
+	if filterOID == "" || !strings.HasPrefix(name, filterOID+".") {
+		return ""
+	}
+	return name[len(filterOID)+1:]
 }
 
 func updateWalkConfig(walkConfig []string, filter config.DynamicFilter, logger *slog.Logger) []string {

--- a/collector/collector_test.go
+++ b/collector/collector_test.go
@@ -1409,6 +1409,75 @@ func TestFilterAllowedIndices(t *testing.T) {
 	}
 }
 
+func TestFilterAllowedIndicesCompositeIndex(t *testing.T) {
+	// jnxBgpM2PeerState, indexed by routing instance plus a local and a remote
+	// InetAddress, so the index is many sub-identifiers rather than one.
+	const stateOID = "1.3.6.1.4.1.2636.5.1.1.2.1.1.1.2"
+	pdus := []gosnmp.SnmpPDU{
+		{
+			Name:  stateOID + ".0.1.4.10.0.0.1.4.10.0.0.2",
+			Value: "3",
+		},
+		{
+			Name:  stateOID + ".0.1.4.10.0.0.1.4.10.0.0.3",
+			Value: "1",
+		},
+		{
+			// Leading dot, which gosnmp also emits.
+			Name:  "." + stateOID + ".0.2.4.10.0.1.1.4.10.0.1.2",
+			Value: "3",
+		},
+	}
+
+	filter := config.DynamicFilter{
+		Oid:     stateOID,
+		Targets: []string{"1.3.6.1.4.1.2636.5.1.1.2.1.1.1.11"},
+		Values:  []string{"3"},
+	}
+	want := []string{"0.1.4.10.0.0.1.4.10.0.0.2", "0.2.4.10.0.1.1.4.10.0.1.2"}
+
+	got := filterAllowedIndices(promslog.NewNopLogger(), filter, pdus, []string{}, Metrics{})
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("filterAllowedIndices(): got %v, want %v", got, want)
+	}
+
+	// The whole point of keeping the full index: the GET that gets built has to
+	// address the row the filter matched.
+	gets := addAllowedIndices(filter, got, promslog.NewNopLogger(), []string{})
+	wantGets := []string{
+		"1.3.6.1.4.1.2636.5.1.1.2.1.1.1.11.0.1.4.10.0.0.1.4.10.0.0.2",
+		"1.3.6.1.4.1.2636.5.1.1.2.1.1.1.11.0.2.4.10.0.1.1.4.10.0.1.2",
+	}
+	if !reflect.DeepEqual(gets, wantGets) {
+		t.Errorf("addAllowedIndices(): got %v, want %v", gets, wantGets)
+	}
+}
+
+func TestIndexFromOID(t *testing.T) {
+	cases := []struct {
+		name     string
+		filter   string
+		expected string
+	}{
+		{"1.3.6.1.2.1.2.2.1.8.2", "1.3.6.1.2.1.2.2.1.8", "2"},
+		{".1.3.6.1.2.1.2.2.1.8.2", "1.3.6.1.2.1.2.2.1.8", "2"},
+		{"1.3.6.1.2.1.2.2.1.8.2", ".1.3.6.1.2.1.2.2.1.8", "2"},
+		{"1.3.6.1.4.1.2636.5.1.1.2.1.1.1.2.0.1.4.10.0.0.1", "1.3.6.1.4.1.2636.5.1.1.2.1.1.1.2", "0.1.4.10.0.0.1"},
+		// Not under the filter OID at all.
+		{"1.3.6.1.2.1.2.2.1.9.2", "1.3.6.1.2.1.2.2.1.8", ""},
+		// The filter OID itself carries no index.
+		{"1.3.6.1.2.1.2.2.1.8", "1.3.6.1.2.1.2.2.1.8", ""},
+		// A longer OID that merely starts with the same digits.
+		{"1.3.6.1.2.1.2.2.1.80.2", "1.3.6.1.2.1.2.2.1.8", ""},
+		{"1.3.6.1.2.1.2.2.1.8.2", "", ""},
+	}
+	for _, c := range cases {
+		if got := indexFromOID(c.name, c.filter); got != c.expected {
+			t.Errorf("indexFromOID(%q, %q): got %q, want %q", c.name, c.filter, got, c.expected)
+		}
+	}
+}
+
 func TestUpdateWalkConfig(t *testing.T) {
 	cases := []struct {
 		filter config.DynamicFilter


### PR DESCRIPTION
`filterAllowedIndices` took the index of a matching row with

```go
pduArray := strings.Split(pdu.Name, ".")
index := pduArray[len(pduArray)-1]
```

which is only the last sub-identifier. That is right for a table indexed by a single integer, and wrong for anything else. `jnxBgpM2PeerTable` in #1687 is indexed by routing instance plus a local and a remote InetAddress, so every matching row cached the same trailing byte, and `addAllowedIndices` then built a GET for an OID that does not exist. The target metric simply goes missing, with nothing in the logs pointing at the index.

The index is everything after the filter's own OID, so `indexFromOID` now takes that, tolerating a leading dot on either side (gosnmp emits names both ways) and returning empty for a PDU outside the filter's subtree, which is then skipped rather than cached as a bad index.

Two tests. `TestFilterAllowedIndicesCompositeIndex` uses the issue's table and asserts both the cached indices and the GET OIDs that come out of `addAllowedIndices`, since that is where the damage actually shows. Against the current code it fails the way the report describes, with two distinct peers collapsing onto one index:

    got [2 2], want [0.1.4.10.0.0.1.4.10.0.0.2 0.2.4.10.0.1.1.4.10.0.1.2]
    got [1.3.6.1.4.1.2636.5.1.1.2.1.1.1.11.2 1.3.6.1.4.1.2636.5.1.1.2.1.1.1.11.2], want [...11.0.1.4.10.0.0.1.4.10.0.0.2 ...11.0.2.4.10.0.1.1.4.10.0.1.2]

`TestIndexFromOID` covers the parsing directly, including the case that would be easy to get wrong with a plain `TrimPrefix`: `1.3.6.1.2.1.2.2.1.80.2` is not under `1.3.6.1.2.1.2.2.1.8`.

The existing `TestFilterAllowedIndices` is untouched and still passes, which is the single-component case. `go test ./...` and `go vet ./...` are clean.

Verified against unit tests only; I do not have a Juniper device to reproduce the original walk on.

Fixes #1687